### PR TITLE
Fix JSON parse error from Go download messages

### DIFF
--- a/core/lib/sykli/detector.ex
+++ b/core/lib/sykli/detector.ex
@@ -29,7 +29,7 @@ defmodule Sykli.Detector do
     dir = Path.dirname(path)
     file = Path.basename(path)
 
-    case System.cmd("go", ["run", file, "--emit"], cd: dir, stderr_to_stdout: true) do
+    case System.cmd("go", ["run", file, "--emit"], cd: dir) do
       {output, 0} -> {:ok, output}
       {error, _} -> {:error, {:go_failed, error}}
     end

--- a/core/mix.exs
+++ b/core/mix.exs
@@ -5,7 +5,7 @@ defmodule Sykli.MixProject do
     [
       app: :sykli,
       version: "0.1.0",
-      elixir: "~> 1.15",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       escript: [main_module: Sykli.CLI],
       deps: deps()


### PR DESCRIPTION
## Summary
- Remove `stderr_to_stdout: true` from Go SDK runner so download messages don't pollute JSON output
- Relax Elixir version constraint to `~> 1.14`

## Test plan
- [x] Run `./sykli ../examples/go-project` - all tasks complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)