### PR TITLE
Add Sykli.Mesh for distributed task execution

### DIFF
--- a/core/test/sykli/mesh_test.exs
+++ b/core/test/sykli/mesh_test.exs
@@ -89,7 +89,7 @@ defmodule Sykli.MeshTest do
     end
   end
 
-  describe "select_node/2" do
+  describe "select_node/3" do
     test "returns :local when no nodes connected" do
       task = make_task("any-task")
 
@@ -102,10 +102,10 @@ defmodule Sykli.MeshTest do
       assert {:ok, :local} = Mesh.select_node(task, [:local])
     end
 
-    test "returns error when no candidates provided and no nodes available" do
+    test "falls back to :local when candidates list is empty" do
       task = make_task("any-task")
 
-      # With empty candidates and strategy :any, should return local
+      # With empty candidates and strategy :any, should fall back to local
       assert {:ok, :local} = Mesh.select_node(task, [], strategy: :any)
     end
 
@@ -116,7 +116,7 @@ defmodule Sykli.MeshTest do
     end
   end
 
-  describe "dispatch_to_any/3" do
+  describe "dispatch_to_any/2" do
     test "runs task on first available node" do
       task = make_task("any-node-task", command: "echo dispatched")
 
@@ -147,7 +147,7 @@ defmodule Sykli.MeshTest do
     end
   end
 
-  describe "broadcast_task/3" do
+  describe "broadcast_task/2" do
     test "runs task on all available nodes" do
       task = make_task("broadcast-task", command: "echo broadcast")
 


### PR DESCRIPTION
## Summary

- Adds `Sykli.Mesh` module for running tasks on remote BEAM nodes
- `dispatch_task/3` sends task to specific node (local or remote)
- `dispatch_to_any/2` runs on first available node
- `broadcast_task/2` runs on all nodes in parallel
- `select_node/3` chooses node based on strategy (`:any`, `:local`, `:remote`)
- `node_info/1` returns node capabilities (docker, platform, cpus, memory)

Uses `:rpc.call` for remote execution via `Executor.Local`. Falls back to local when no remote nodes connected.

## Test plan

- [x] 23 unit tests for mesh dispatch
- [x] Tests for local dispatch
- [x] Tests for node selection strategies
- [x] Tests for error handling (node down, timeout, task failure)
- [x] `mix test test/sykli/mesh_test.exs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)