### PR TITLE
Add daemon mode for mesh networking with role-based nodes

### DIFF
--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -735,7 +735,19 @@ defmodule Sykli.CLI do
 
   defp handle_daemon(["start" | args]) do
     foreground = "--foreground" in args or "-f" in args
-    role = parse_role_arg(args)
+
+    role =
+      case parse_role_arg(args) do
+        {:ok, r} ->
+          r
+
+        {:error, invalid_role} ->
+          IO.puts(:stderr, "Invalid daemon role: #{invalid_role}")
+          IO.puts(:stderr, "Valid roles are: full, worker, coordinator")
+          IO.puts(:stderr, "")
+          print_daemon_help()
+          halt(1)
+      end
 
     role_label =
       case role do
@@ -831,14 +843,11 @@ defmodule Sykli.CLI do
         end
 
     case role_arg do
-      nil -> :full
-      "worker" -> :worker
-      "coordinator" -> :coordinator
-      "full" -> :full
-      invalid ->
-        IO.puts(:stderr, "#{IO.ANSI.red()}Invalid role: #{invalid}#{IO.ANSI.reset()}")
-        IO.puts(:stderr, "Valid roles: full, worker, coordinator")
-        halt(1)
+      nil -> {:ok, :full}
+      "worker" -> {:ok, :worker}
+      "coordinator" -> {:ok, :coordinator}
+      "full" -> {:ok, :full}
+      invalid -> {:error, invalid}
     end
   end
 

--- a/core/test/sykli/mesh_test.exs
+++ b/core/test/sykli/mesh_test.exs
@@ -68,11 +68,21 @@ defmodule Sykli.MeshTest do
       assert is_list(nodes)
     end
 
-    test "includes :local when node can execute" do
-      # Default node role is :full, which can execute
+    test "includes :local when current node can execute tasks" do
+      # Test nodes (nonode@nohost) are treated as :full nodes, which can execute
+      # This test verifies the happy path where the node can execute
       nodes = Mesh.available_nodes()
 
       assert :local in nodes
+    end
+
+    test "excludes :local for coordinator-only nodes" do
+      # Coordinators cannot execute tasks, so :local should not be included
+      # when running on a coordinator node. We verify this by checking the
+      # underlying role detection logic.
+      assert Sykli.Daemon.can_execute?(:coordinator_abc123@host) == false
+      assert Sykli.Daemon.can_execute?(:worker_abc123@host) == true
+      assert Sykli.Daemon.can_execute?(:sykli_abc123@host) == true
     end
   end
 


### PR DESCRIPTION
## Summary

- **Daemon mode**: Long-running BEAM node that joins the mesh for distributed CI
- **Role-based nodes**: Support for `full`, `worker`, and `coordinator` roles
  - `full`: Can execute tasks AND coordinate (default)
  - `worker`: Execute only - forwards events to coordinators
  - `coordinator`: Coordinate only - runs dashboard, aggregates events
- **CLI commands**: `sykli daemon start/stop/status` with `--role` flag
- **Validation**: Invalid role values now show clear error messages

## Test plan

- [x] All 388 tests pass
- [x] `mix format` passes
- [x] `mix escript.build` succeeds
- [x] Role validation rejects invalid values with helpful error message
- [x] Mesh filtering correctly excludes coordinators from task execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)