### PR TITLE
Fix Burrito env var leaking to child processes

### DIFF
--- a/core/lib/sykli/application.ex
+++ b/core/lib/sykli/application.ex
@@ -35,7 +35,10 @@ defmodule Sykli.Application do
     result = Supervisor.start_link(children, opts)
 
     # If running as Burrito binary, invoke CLI
+    # Clear the env var immediately to prevent subprocess inheritance
+    # (otherwise mix test would trigger CLI.main too!)
     if burrito?() do
+      System.delete_env("__BURRITO_BIN_PATH")
       args = Burrito.Util.Args.argv()
       Sykli.CLI.main(args)
     end


### PR DESCRIPTION
## Summary
- Clear `__BURRITO_BIN_PATH` immediately after detecting Burrito mode
- Prevents subprocesses (like `mix test`) from triggering `CLI.main()`

## Problem
When running `sykli` on itself (dogfooding), the `core:test` task failed because:
1. Sykli runs as Burrito binary, setting `__BURRITO_BIN_PATH`
2. Task runs `cd core && mix test`
3. `mix test` starts Elixir app which inherits the env var
4. App detects "Burrito mode" and calls `CLI.main()`
5. CLI looks for sykli.go in `core/` → fails

## Test plan
- [x] All unit tests pass (531 Elixir, 95 Rust, Go, Elixir SDK)
- [x] Dogfood passes: `./sykli` runs all 9 tasks successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)