### PR TITLE
feat: add `sykli plan` dry-run execution planning

### DIFF
--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -3,6 +3,7 @@ defmodule Sykli.CLI do
   CLI entry point for escript.
   """
 
+  alias Sykli.Delta
   alias Sykli.Error
   alias Sykli.Error.Formatter
 
@@ -49,6 +50,9 @@ defmodule Sykli.CLI do
       ["verify" | verify_args] ->
         handle_verify(verify_args)
 
+      ["plan" | plan_args] ->
+        handle_plan(plan_args)
+
       ["explain" | explain_args] ->
         handle_explain(explain_args)
 
@@ -91,6 +95,7 @@ defmodule Sykli.CLI do
       sykli validate   Check sykli file for errors without running
       sykli explain    Show last run occurrence (AI-readable report)
       sykli explain --pipeline  Show pipeline structure (for AI)
+      sykli plan       Dry-run: show what would run based on git changes
       sykli context    Generate AI context file (.sykli/context.json)
       sykli verify     Cross-platform verification via mesh nodes
       sykli delta      Run only tasks affected by git changes
@@ -1040,6 +1045,248 @@ defmodule Sykli.CLI do
   defp format_verify_reason(:retry_on_different_platform), do: "retry on different platform"
   defp format_verify_reason(:explicit_verify), do: "explicit verify: always"
   defp format_verify_reason(reason), do: to_string(reason)
+
+  # ----- PLAN SUBCOMMAND -----
+
+  defp handle_plan(["--help"]) do
+    IO.puts("""
+    Usage: sykli plan [options] [path]
+
+    Dry-run: show what tasks would execute based on git changes.
+
+    Analyzes git diff to determine affected tasks, predicts cache hits,
+    and shows the execution plan without running anything.
+
+    Options:
+      --from=<ref>    Compare against branch/commit (default: auto-detect)
+      --json          Output as JSON (for AI assistants)
+      --verbose, -v   Show file-level details
+      --help          Show this help
+
+    Examples:
+      sykli plan                  What would run? (auto-detects base branch)
+      sykli plan --json           Structured JSON output (for AI)
+      sykli plan --from=main      Compare against specific branch
+      sykli plan --verbose        Show file-level details
+    """)
+
+    halt(0)
+  end
+
+  defp handle_plan(args) do
+    {opts, path} = parse_plan_args(args)
+    path = path || "."
+    json_output = Keyword.get(opts, :json, false)
+    verbose = Keyword.get(opts, :verbose, false)
+
+    case get_task_graph_parsed(path) do
+      {:ok, graph} ->
+        # Load run history for duration estimates
+        run_history =
+          case Sykli.RunHistory.load_latest(path: path) do
+            {:ok, run} -> run
+            {:error, _} -> nil
+          end
+
+        plan_opts = [path: path, run_history: run_history]
+
+        plan_opts =
+          if opts[:from] do
+            [{:from, opts[:from]} | plan_opts]
+          else
+            plan_opts
+          end
+
+        case Sykli.Plan.generate(graph, plan_opts) do
+          {:ok, plan} ->
+            if json_output do
+              output_plan_json(plan)
+            else
+              output_plan_text(plan, verbose)
+            end
+
+            halt(0)
+
+          {:error, reason} ->
+            if json_output do
+              IO.puts(Jason.encode!(%{error: Delta.format_error(reason)}))
+            else
+              IO.puts("#{IO.ANSI.red()}#{Delta.format_error(reason)}#{IO.ANSI.reset()}")
+            end
+
+            halt(1)
+        end
+
+      {:error, reason} ->
+        if json_output do
+          error = Error.wrap(reason)
+          IO.puts(Jason.encode!(%{error: error.message, code: error.code}))
+        else
+          display_error(reason)
+        end
+
+        halt(1)
+    end
+  end
+
+  defp parse_plan_args(args) do
+    {opts, rest} =
+      Enum.reduce(args, {[], []}, fn arg, {opts, rest} ->
+        cond do
+          String.starts_with?(arg, "--from=") ->
+            from = String.replace_prefix(arg, "--from=", "")
+            {[{:from, from} | opts], rest}
+
+          arg == "--json" ->
+            {[{:json, true} | opts], rest}
+
+          arg == "--verbose" or arg == "-v" ->
+            {[{:verbose, true} | opts], rest}
+
+          String.starts_with?(arg, "--") ->
+            {opts, rest}
+
+          true ->
+            {opts, rest ++ [arg]}
+        end
+      end)
+
+    {opts, List.first(rest)}
+  end
+
+  defp output_plan_json(plan) do
+    IO.puts(Jason.encode!(plan, pretty: true))
+  end
+
+  defp output_plan_text(plan, verbose) do
+    changed_count = length(plan.changed_files)
+    from = plan.from
+    plan_data = plan.plan
+    tasks = plan_data.tasks
+    skipped = plan.skipped
+    total = length(tasks) + length(skipped)
+
+    IO.puts("")
+
+    IO.puts(
+      "#{IO.ANSI.cyan()}Based on changes since #{from}#{IO.ANSI.reset()} #{IO.ANSI.faint()}(#{changed_count} file#{if changed_count != 1, do: "s"})#{IO.ANSI.reset()}"
+    )
+
+    IO.puts("")
+
+    if tasks == [] do
+      IO.puts("#{IO.ANSI.green()}No tasks would run#{IO.ANSI.reset()}")
+    else
+      IO.puts("Would run #{length(tasks)} of #{total} tasks:")
+      IO.puts("")
+
+      # Group by level
+      Enum.each(plan_data.execution_levels, fn level_info ->
+        IO.puts("  #{IO.ANSI.cyan()}Level #{level_info.level}#{IO.ANSI.reset()}")
+
+        Enum.each(level_info.tasks, fn task_name ->
+          task = Enum.find(tasks, &(&1.name == task_name))
+
+          if task do
+            output_plan_task(task, verbose)
+          end
+        end)
+      end)
+    end
+
+    # Skipped
+    if skipped != [] do
+      IO.puts("")
+      IO.puts("  #{IO.ANSI.faint()}Skipped:#{IO.ANSI.reset()}")
+
+      Enum.each(skipped, fn s ->
+        IO.puts(
+          "    #{IO.ANSI.faint()}○ #{s.name}#{IO.ANSI.reset()} #{IO.ANSI.faint()}#{s.reason}#{IO.ANSI.reset()}"
+        )
+      end)
+    end
+
+    # Summary
+    IO.puts("")
+
+    if plan_data.critical_path != [] do
+      IO.puts(
+        "#{IO.ANSI.cyan()}Critical path:#{IO.ANSI.reset()} #{Enum.join(plan_data.critical_path, " → ")}"
+      )
+    end
+
+    if plan_data.estimated_duration_ms do
+      IO.puts(
+        "#{IO.ANSI.faint()}Estimated: #{format_duration(plan_data.estimated_duration_ms)}, #{plan_data.parallelism} max parallel#{IO.ANSI.reset()}"
+      )
+    end
+
+    IO.puts("")
+  end
+
+  defp output_plan_task(task, verbose) do
+    icon =
+      if task.cached do
+        "#{IO.ANSI.yellow()}⊙#{IO.ANSI.reset()}"
+      else
+        "#{IO.ANSI.green()}•#{IO.ANSI.reset()}"
+      end
+
+    cached_label = if task.cached, do: " (cached)", else: ""
+    reason_str = format_plan_reason(task)
+
+    IO.puts(
+      "    #{icon} #{task.name}#{cached_label}  #{IO.ANSI.faint()}#{reason_str}#{IO.ANSI.reset()}"
+    )
+
+    if verbose and task.triggered_by != [] do
+      files_str = Enum.take(task.triggered_by, 3) |> Enum.join(", ")
+
+      suffix =
+        if length(task.triggered_by) > 3,
+          do: " +#{length(task.triggered_by) - 3} more",
+          else: ""
+
+      IO.puts("      #{IO.ANSI.faint()}↳ #{files_str}#{suffix}#{IO.ANSI.reset()}")
+    end
+  end
+
+  defp format_plan_reason(task) do
+    case task.reason do
+      "direct" ->
+        count = length(task.triggered_by)
+
+        if count > 0 do
+          first = List.first(task.triggered_by)
+
+          if count > 1 do
+            "#{first} (+#{count - 1} more)"
+          else
+            first
+          end
+        else
+          "inputs changed"
+        end
+
+      "dependent" ->
+        dep = Map.get(task, :depends_on_affected, "upstream")
+        "depends on #{dep}"
+
+      other ->
+        other
+    end
+  end
+
+  # Get task graph as parsed Graph (map of name => Task struct)
+  defp get_task_graph_parsed(path) do
+    alias Sykli.{Detector, Graph}
+
+    with {:ok, sdk_file} <- Detector.find(path),
+         {:ok, json} <- Detector.emit(sdk_file),
+         {:ok, graph} <- Graph.parse(json) do
+      {:ok, Graph.expand_matrix(graph)}
+    end
+  end
 
   # ----- EXPLAIN SUBCOMMAND -----
 

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -1215,7 +1215,7 @@ defmodule Sykli.CLI do
       )
     end
 
-    if plan_data.estimated_duration_ms do
+    if plan_data.estimated_duration_ms != nil do
       IO.puts(
         "#{IO.ANSI.faint()}Estimated: #{format_duration(plan_data.estimated_duration_ms)}, #{plan_data.parallelism} max parallel#{IO.ANSI.reset()}"
       )

--- a/core/lib/sykli/plan.ex
+++ b/core/lib/sykli/plan.ex
@@ -1,0 +1,225 @@
+defmodule Sykli.Plan do
+  @moduledoc """
+  Dry-run execution planning for AI assistants.
+
+  Given the current git diff and task graph, produces a structured plan
+  showing what tasks would run, in what order, with cache predictions
+  and reasoning — all without executing anything.
+
+  Composes existing modules:
+  - `Delta` for change detection
+  - `Cache` for cache predictions
+  - `Explain` for execution levels and critical path
+
+  ## Usage
+
+      {:ok, graph} = Sykli.Graph.parse(json)
+      graph = Sykli.Graph.expand_matrix(graph)
+      {:ok, plan} = Sykli.Plan.generate(graph, from: "origin/main", path: ".")
+  """
+
+  alias Sykli.{Delta, Cache, Explain}
+  alias Sykli.Graph.Task
+
+  @schema_version "1.0"
+
+  @doc """
+  Generates a dry-run execution plan.
+
+  Options:
+    - `:from` - git ref to compare against (default: auto-detected)
+    - `:path` - project path (default: ".")
+    - `:run_history` - a `Sykli.RunHistory.Run` struct for duration estimates
+  """
+  @spec generate(map(), keyword()) :: {:ok, map()} | {:error, term()}
+  def generate(graph, opts \\ []) do
+    from = Keyword.get(opts, :from) || detect_base_branch(Keyword.get(opts, :path, "."))
+    path = Keyword.get(opts, :path, ".")
+    run_history = Keyword.get(opts, :run_history)
+
+    tasks_list = Map.values(graph)
+
+    case Delta.affected_tasks_detailed(tasks_list, from: from, path: path) do
+      {:ok, affected} ->
+        plan = build_plan(graph, affected, from, path, run_history)
+        {:ok, plan}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Predicts cache status for each task in the graph.
+
+  Returns a map of `%{task_name => %{cached: boolean, reason: atom | nil}}`.
+  """
+  @spec predict_cache(map(), String.t()) :: %{
+          String.t() => %{cached: boolean(), reason: atom() | nil}
+        }
+  def predict_cache(graph, workdir) do
+    Map.new(graph, fn {name, task} ->
+      if Task.cacheable?(task) do
+        case Cache.check_detailed(task, workdir) do
+          {:hit, _key} ->
+            {name, %{cached: true, reason: nil}}
+
+          {:miss, _key, reason} ->
+            {name, %{cached: false, reason: reason}}
+        end
+      else
+        {name, %{cached: false, reason: :not_cacheable}}
+      end
+    end)
+  end
+
+  @doc """
+  Detects the base branch to compare against.
+
+  Tries origin/main, then origin/master, falls back to HEAD.
+  """
+  @spec detect_base_branch(String.t()) :: String.t()
+  def detect_base_branch(path \\ ".") do
+    cond do
+      ref_exists?("origin/main", path) -> "origin/main"
+      ref_exists?("origin/master", path) -> "origin/master"
+      true -> "HEAD"
+    end
+  end
+
+  # --- Private ---
+
+  defp ref_exists?(ref, path) do
+    case Sykli.Git.run(["rev-parse", "--verify", ref], cd: path) do
+      {:ok, _} -> true
+      _ -> false
+    end
+  end
+
+  defp build_plan(graph, affected, from, path, run_history) do
+    affected_names = MapSet.new(Enum.map(affected, & &1.name))
+
+    # Build affected subgraph for level computation.
+    # Strip dependencies to non-affected tasks so compute_levels doesn't stall.
+    affected_graph =
+      graph
+      |> Enum.filter(fn {name, _} -> MapSet.member?(affected_names, name) end)
+      |> Map.new(fn {name, task} ->
+        trimmed_deps = Enum.filter(task.depends_on || [], &MapSet.member?(affected_names, &1))
+        {name, %{task | depends_on: trimmed_deps}}
+      end)
+
+    # Cache predictions for affected tasks
+    cache_predictions = predict_cache(affected_graph, path)
+
+    # Execution levels for affected tasks only
+    levels = Explain.compute_levels(affected_graph)
+    blocks = Explain.compute_blocks(affected_graph)
+    duration_map = build_duration_map(run_history)
+    critical_path = Explain.compute_critical_path(affected_graph, duration_map)
+
+    # Build affected task details
+    affected_lookup = Map.new(affected, fn a -> {a.name, a} end)
+
+    plan_tasks =
+      affected_graph
+      |> Enum.map(fn {name, task} ->
+        affected_info = Map.get(affected_lookup, name, %{reason: :always, files: []})
+        cache_info = Map.get(cache_predictions, name, %{cached: false, reason: nil})
+        task_blocks = Map.get(blocks, name, []) |> Enum.sort()
+
+        level =
+          levels
+          |> Enum.find_value(fn {lvl, names} ->
+            if name in names, do: lvl
+          end) || 0
+
+        reason_str = format_reason(affected_info.reason)
+        triggered_by = Map.get(affected_info, :files, [])
+
+        base = %{
+          name: name,
+          command: task.command,
+          reason: reason_str,
+          triggered_by: triggered_by,
+          cached: cache_info.cached,
+          cache_reason: if(cache_info.reason, do: Atom.to_string(cache_info.reason)),
+          level: level,
+          depends_on: Task.depends_on(task),
+          blocks: task_blocks
+        }
+
+        # Add depends_on_affected for dependent tasks
+        if affected_info.reason == :dependent do
+          Map.put(base, :depends_on_affected, affected_info.depends_on)
+        else
+          base
+        end
+      end)
+      |> Enum.sort_by(& &1.level)
+
+    # Compute skipped tasks
+    skipped =
+      graph
+      |> Enum.reject(fn {name, _} -> MapSet.member?(affected_names, name) end)
+      |> Enum.map(fn {name, _} -> %{name: name, reason: "no inputs changed"} end)
+      |> Enum.sort_by(& &1.name)
+
+    # Changed files
+    changed_files =
+      case Delta.get_changed_files(from, path) do
+        {:ok, files} -> files
+        _ -> []
+      end
+
+    # Execution levels formatted
+    execution_levels =
+      levels
+      |> Enum.sort_by(fn {level, _} -> level end)
+      |> Enum.map(fn {level, names} -> %{level: level, tasks: Enum.sort(names)} end)
+
+    estimated_duration_ms = estimate_duration(levels, duration_map)
+
+    max_parallelism =
+      levels
+      |> Enum.map(fn {_level, names} -> length(names) end)
+      |> Enum.max(fn -> 0 end)
+
+    %{
+      version: @schema_version,
+      from: from,
+      changed_files: changed_files,
+      plan: %{
+        task_count: length(plan_tasks),
+        tasks: plan_tasks,
+        execution_levels: execution_levels,
+        critical_path: critical_path,
+        estimated_duration_ms: estimated_duration_ms,
+        parallelism: max_parallelism
+      },
+      skipped: skipped
+    }
+  end
+
+  defp format_reason(:direct), do: "direct"
+  defp format_reason(:dependent), do: "dependent"
+  defp format_reason(other), do: to_string(other)
+
+  defp build_duration_map(nil), do: %{}
+
+  defp build_duration_map(%{tasks: tasks}) do
+    Map.new(tasks, fn t -> {t.name, t.duration_ms || 1000} end)
+  end
+
+  defp build_duration_map(_), do: %{}
+
+  defp estimate_duration(levels, duration_map) do
+    levels
+    |> Enum.map(fn {_level, names} ->
+      names
+      |> Enum.map(&Map.get(duration_map, &1, 1000))
+      |> Enum.max(fn -> 0 end)
+    end)
+    |> Enum.sum()
+  end
+end

--- a/core/test/sykli/plan_test.exs
+++ b/core/test/sykli/plan_test.exs
@@ -111,10 +111,9 @@ defmodule Sykli.PlanTest do
           plan_data = plan.plan
           assert is_list(plan_data.execution_levels)
           assert is_list(plan_data.critical_path)
-          assert is_integer(plan_data.parallelism) or plan_data.parallelism == 0
+          assert is_integer(plan_data.parallelism)
 
-          assert is_integer(plan_data.estimated_duration_ms) or
-                   plan_data.estimated_duration_ms == 0
+          assert is_integer(plan_data.estimated_duration_ms)
 
         {:error, _reason} ->
           :ok

--- a/core/test/sykli/plan_test.exs
+++ b/core/test/sykli/plan_test.exs
@@ -1,0 +1,165 @@
+defmodule Sykli.PlanTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.{Plan, Graph}
+
+  describe "predict_cache/2" do
+    test "non-cacheable tasks report not_cacheable" do
+      {:ok, graph} =
+        parse_graph([
+          %{"name" => "lint", "command" => "mix credo"}
+        ])
+
+      result = Plan.predict_cache(graph, ".")
+      assert result["lint"].cached == false
+      assert result["lint"].reason == :not_cacheable
+    end
+
+    test "cacheable tasks without cache report a miss reason" do
+      {:ok, graph} =
+        parse_graph([
+          %{"name" => "test", "command" => "mix test", "inputs" => ["**/*.ex"]}
+        ])
+
+      result = Plan.predict_cache(graph, ".")
+      assert result["test"].cached == false
+      # The specific reason depends on cache state — just verify it's an atom
+      assert is_atom(result["test"].reason)
+      refute result["test"].reason == :not_cacheable
+    end
+
+    test "returns map keyed by task name" do
+      {:ok, graph} =
+        parse_graph([
+          %{"name" => "lint", "command" => "mix credo"},
+          %{"name" => "test", "command" => "mix test", "inputs" => ["**/*.ex"]}
+        ])
+
+      result = Plan.predict_cache(graph, ".")
+      assert Map.has_key?(result, "lint")
+      assert Map.has_key?(result, "test")
+    end
+  end
+
+  describe "detect_base_branch/1" do
+    test "returns a string" do
+      result = Plan.detect_base_branch(".")
+      assert is_binary(result)
+    end
+
+    test "returns one of origin/main, origin/master, or HEAD" do
+      result = Plan.detect_base_branch(".")
+      assert result in ["origin/main", "origin/master", "HEAD"]
+    end
+  end
+
+  describe "generate/2 structure" do
+    test "returns plan with expected top-level keys" do
+      {:ok, graph} =
+        parse_graph([
+          %{"name" => "lint", "command" => "mix credo"},
+          %{"name" => "test", "command" => "mix test", "depends_on" => ["lint"]}
+        ])
+
+      # Use HEAD to get no changes, producing a plan with all skipped
+      case Plan.generate(graph, from: "HEAD", path: ".") do
+        {:ok, plan} ->
+          assert Map.has_key?(plan, :version)
+          assert Map.has_key?(plan, :from)
+          assert Map.has_key?(plan, :changed_files)
+          assert Map.has_key?(plan, :plan)
+          assert Map.has_key?(plan, :skipped)
+
+          assert plan.version == "1.0"
+          assert plan.from == "HEAD"
+
+        {:error, _reason} ->
+          # May fail if not in a git repo context - that's OK for unit tests
+          :ok
+      end
+    end
+
+    test "plan with no changes produces empty task list and all skipped" do
+      {:ok, graph} =
+        parse_graph([
+          %{"name" => "lint", "command" => "mix credo"},
+          %{"name" => "test", "command" => "mix test", "depends_on" => ["lint"]}
+        ])
+
+      case Plan.generate(graph, from: "HEAD", path: ".") do
+        {:ok, plan} ->
+          assert plan.plan.task_count == 0
+          assert plan.plan.tasks == []
+          assert length(plan.skipped) == 2
+
+          skipped_names = Enum.map(plan.skipped, & &1.name) |> Enum.sort()
+          assert skipped_names == ["lint", "test"]
+
+        {:error, _reason} ->
+          :ok
+      end
+    end
+
+    test "plan data includes execution_levels, critical_path, parallelism" do
+      {:ok, graph} =
+        parse_graph([
+          %{"name" => "lint", "command" => "mix credo"}
+        ])
+
+      case Plan.generate(graph, from: "HEAD", path: ".") do
+        {:ok, plan} ->
+          plan_data = plan.plan
+          assert is_list(plan_data.execution_levels)
+          assert is_list(plan_data.critical_path)
+          assert is_integer(plan_data.parallelism) or plan_data.parallelism == 0
+
+          assert is_integer(plan_data.estimated_duration_ms) or
+                   plan_data.estimated_duration_ms == 0
+
+        {:error, _reason} ->
+          :ok
+      end
+    end
+
+    test "skipped tasks include name and reason" do
+      {:ok, graph} =
+        parse_graph([
+          %{"name" => "deploy", "command" => "deploy.sh"}
+        ])
+
+      case Plan.generate(graph, from: "HEAD", path: ".") do
+        {:ok, plan} ->
+          Enum.each(plan.skipped, fn s ->
+            assert Map.has_key?(s, :name)
+            assert Map.has_key?(s, :reason)
+          end)
+
+        {:error, _} ->
+          :ok
+      end
+    end
+
+    test "plan is JSON-encodable" do
+      {:ok, graph} =
+        parse_graph([
+          %{"name" => "lint", "command" => "mix credo"},
+          %{"name" => "test", "command" => "mix test", "depends_on" => ["lint"]}
+        ])
+
+      case Plan.generate(graph, from: "HEAD", path: ".") do
+        {:ok, plan} ->
+          assert {:ok, _json} = Jason.encode(plan)
+
+        {:error, _} ->
+          :ok
+      end
+    end
+  end
+
+  # Helpers
+
+  defp parse_graph(tasks) do
+    json = Jason.encode!(%{"tasks" => tasks})
+    Graph.parse(json)
+  end
+end

--- a/core/test/sykli/plan_test.exs
+++ b/core/test/sykli/plan_test.exs
@@ -112,7 +112,6 @@ defmodule Sykli.PlanTest do
           assert is_list(plan_data.execution_levels)
           assert is_list(plan_data.critical_path)
           assert is_integer(plan_data.parallelism)
-
           assert is_integer(plan_data.estimated_duration_ms)
 
         {:error, _reason} ->

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -158,6 +158,24 @@
     },
 
     {
+      "id": "POS-022",
+      "name": "Plan help text exits 0 with usage",
+      "fixture": "single_task",
+      "command": "sykli plan --help",
+      "expect_exit": 0,
+      "expect_stdout_contains": ["Usage:", "--from=", "--json"]
+    },
+    {
+      "id": "POS-023",
+      "name": "Plan JSON output is valid JSON",
+      "fixture": "dependency_chain",
+      "command": "git init -q && git add . && git commit -q -m init && sykli plan --json --from=HEAD",
+      "shell": true,
+      "expect_exit": 0,
+      "expect_json_contains": {"version": "1.0"}
+    },
+
+    {
       "id": "NEG-001",
       "name": "Cycle detection rejects circular deps",
       "fixture": "cycle_ab",
@@ -353,6 +371,16 @@
       "command": "sykli",
       "expect_exit": 0,
       "expect_stdout": "1 passed"
+    },
+
+    {
+      "id": "SYS-011",
+      "name": "Plan with no changes shows empty plan",
+      "fixture": "dependency_chain",
+      "command": "git init -q && git add . && git commit -q -m init && sykli plan --from=HEAD --json",
+      "shell": true,
+      "expect_exit": 0,
+      "expect_json_contains": {"version": "1.0"}
     },
 
     {


### PR DESCRIPTION
## Summary
- Adds `sykli plan` command — zero-cost dry-run showing what tasks would execute based on git changes
- Composes existing Delta, Cache, and Explain modules to produce structured plans with cache predictions, execution levels, and critical path
- Supports `--json` (for AI), `--from=<ref>`, `--verbose` flags
- Auto-detects base branch (origin/main → origin/master → HEAD)

## Test plan
- [x] 10 unit tests in `plan_test.exs` (predict_cache, detect_base_branch, plan structure, JSON encodability)
- [x] 3 new blackbox tests (POS-022: help, POS-023: JSON output, SYS-011: no changes)
- [x] All 23 existing POS blackbox tests pass
- [x] `mix format` clean
- [x] Escript builds and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)