### PR TITLE
Fix K8s job lifecycle namespace handling

### DIFF
--- a/core/lib/sykli/target/k8s.ex
+++ b/core/lib/sykli/target/k8s.ex
@@ -429,6 +429,8 @@ defmodule Sykli.Target.K8s do
   def run_task(task, state, opts) do
     progress = Keyword.get(opts, :progress)
     prefix = progress_prefix(progress)
+    job_module = Keyword.get(opts, :job_module, Job)
+    namespace = task_namespace(task, state)
 
     # Get timestamp
     {_, {h, m, s}} = :calendar.local_time()
@@ -445,10 +447,10 @@ defmodule Sykli.Target.K8s do
     # Build and apply Job
     manifest = build_job_manifest(task, job_name, state, opts)
 
-    case apply_job(manifest, state) do
+    case apply_job(manifest, state, job_module) do
       :ok ->
         # Wait for completion
-        case wait_for_job(job_name, state, task.timeout || 300) do
+        case wait_for_job(job_name, namespace, state, task.timeout || 300, job_module) do
           {:ok, :succeeded} ->
             duration_ms = System.monotonic_time(:millisecond) - start_time
 
@@ -456,19 +458,19 @@ defmodule Sykli.Target.K8s do
               "#{IO.ANSI.green()}✓ #{task.name}#{IO.ANSI.reset()} #{IO.ANSI.faint()}#{format_duration(duration_ms)}#{IO.ANSI.reset()}"
             )
 
-            cleanup_job(job_name, state)
+            cleanup_job(job_name, namespace, state, job_module)
             :ok
 
           {:ok, :failed} ->
             duration_ms = System.monotonic_time(:millisecond) - start_time
-            logs = get_job_logs(job_name, state)
+            logs = get_job_logs(job_name, namespace, state, job_module)
 
             IO.puts(
               "#{IO.ANSI.red()}✗ #{task.name}#{IO.ANSI.reset()} #{IO.ANSI.faint()}#{format_duration(duration_ms)}#{IO.ANSI.reset()}"
             )
 
             IO.puts("#{IO.ANSI.faint()}#{logs}#{IO.ANSI.reset()}")
-            cleanup_job(job_name, state)
+            cleanup_job(job_name, namespace, state, job_module)
             {:error, :job_failed}
 
           {:error, :timeout} ->
@@ -476,7 +478,7 @@ defmodule Sykli.Target.K8s do
               "#{IO.ANSI.red()}✗ #{task.name}#{IO.ANSI.reset()} #{IO.ANSI.faint()}(timeout)#{IO.ANSI.reset()}"
             )
 
-            cleanup_job(job_name, state)
+            cleanup_job(job_name, namespace, state, job_module)
             {:error, :timeout}
 
           {:error, reason} ->
@@ -484,7 +486,7 @@ defmodule Sykli.Target.K8s do
               "#{IO.ANSI.red()}✗ #{task.name}#{IO.ANSI.reset()} #{IO.ANSI.faint()}(#{inspect(reason)})#{IO.ANSI.reset()}"
             )
 
-            cleanup_job(job_name, state)
+            cleanup_job(job_name, namespace, state, job_module)
             {:error, reason}
         end
 
@@ -873,8 +875,8 @@ defmodule Sykli.Target.K8s do
   # K8S API OPERATIONS
   # ─────────────────────────────────────────────────────────────────────────────
 
-  defp apply_job(manifest, state) do
-    case Job.create(manifest, state.auth_config) do
+  defp apply_job(manifest, state, job_module) do
+    case job_module.create(manifest, state.auth_config) do
       {:ok, _job} -> :ok
       # Job already exists, that's fine
       {:error, %Error{type: :conflict}} -> :ok
@@ -882,10 +884,10 @@ defmodule Sykli.Target.K8s do
     end
   end
 
-  defp wait_for_job(job_name, state, timeout_seconds) do
+  defp wait_for_job(job_name, namespace, state, timeout_seconds, job_module) do
     timeout_ms = timeout_seconds * 1000
 
-    case Job.wait_complete(job_name, state.namespace, state.auth_config, timeout: timeout_ms) do
+    case job_module.wait_complete(job_name, namespace, state.auth_config, timeout: timeout_ms) do
       {:ok, :succeeded} -> {:ok, :succeeded}
       {:ok, :failed} -> {:ok, :failed}
       {:error, %Error{type: :timeout}} -> {:error, :timeout}
@@ -893,18 +895,22 @@ defmodule Sykli.Target.K8s do
     end
   end
 
-  defp get_job_logs(job_name, state) do
-    case Job.logs(job_name, state.namespace, state.auth_config) do
+  defp get_job_logs(job_name, namespace, state, job_module) do
+    case job_module.logs(job_name, namespace, state.auth_config) do
       {:ok, logs} -> logs
       {:error, :no_pods} -> "(no pods found for job)"
       {:error, error} -> "Failed to get logs: #{format_error(error)}"
     end
   end
 
-  defp cleanup_job(job_name, state) do
+  defp cleanup_job(job_name, namespace, state, job_module) do
     # Best effort cleanup - ignore errors
-    Job.delete(job_name, state.namespace, state.auth_config)
+    job_module.delete(job_name, namespace, state.auth_config)
     :ok
+  end
+
+  defp task_namespace(task, state) do
+    (task.k8s && task.k8s.namespace) || state.namespace
   end
 
   defp ensure_namespace(state) do

--- a/core/lib/sykli/target/k8s.ex
+++ b/core/lib/sykli/target/k8s.ex
@@ -430,7 +430,6 @@ defmodule Sykli.Target.K8s do
     progress = Keyword.get(opts, :progress)
     prefix = progress_prefix(progress)
     job_module = Keyword.get(opts, :job_module, Job)
-    namespace = task_namespace(task, state)
 
     # Get timestamp
     {_, {h, m, s}} = :calendar.local_time()
@@ -446,6 +445,7 @@ defmodule Sykli.Target.K8s do
 
     # Build and apply Job
     manifest = build_job_manifest(task, job_name, state, opts)
+    namespace = get_in(manifest, ["metadata", "namespace"]) || state.namespace
 
     case apply_job(manifest, state, job_module) do
       :ok ->
@@ -907,10 +907,6 @@ defmodule Sykli.Target.K8s do
     # Best effort cleanup - ignore errors
     job_module.delete(job_name, namespace, state.auth_config)
     :ok
-  end
-
-  defp task_namespace(task, state) do
-    (task.k8s && task.k8s.namespace) || state.namespace
   end
 
   defp ensure_namespace(state) do

--- a/core/test/sykli/target/k8s_test.exs
+++ b/core/test/sykli/target/k8s_test.exs
@@ -4,6 +4,28 @@ defmodule Sykli.Target.K8sTest do
   alias Sykli.Target.K8s
   alias Sykli.Target.K8sOptions
 
+  defmodule FakeJob do
+    def create(manifest, _auth_config) do
+      send(self(), {:job_create, get_in(manifest, ["metadata", "namespace"])})
+      {:ok, manifest}
+    end
+
+    def wait_complete(job_name, namespace, _auth_config, _opts) do
+      send(self(), {:job_wait_complete, job_name, namespace})
+      {:ok, :succeeded}
+    end
+
+    def logs(job_name, namespace, _auth_config) do
+      send(self(), {:job_logs, job_name, namespace})
+      {:ok, "logs"}
+    end
+
+    def delete(job_name, namespace, _auth_config) do
+      send(self(), {:job_delete, job_name, namespace})
+      {:ok, %{"status" => "Success"}}
+    end
+  end
+
   # ─────────────────────────────────────────────────────────────────────────────
   # JOB MANIFEST BUILDING - GIT CLONE INIT CONTAINER
   # ─────────────────────────────────────────────────────────────────────────────
@@ -104,6 +126,32 @@ defmodule Sykli.Target.K8sTest do
 
       # Should have no init containers
       assert init_containers == nil or init_containers == []
+    end
+  end
+
+  describe "run_task/3 namespace handling" do
+    test "uses task k8s namespace consistently for wait and delete lifecycle calls" do
+      task = %Sykli.Graph.Task{
+        name: "build",
+        command: "echo hi",
+        container: "alpine:latest",
+        k8s: %K8sOptions{namespace: "task-ns"}
+      }
+
+      state = %K8s{
+        namespace: "state-ns",
+        auth_config: %{},
+        artifact_pvc: "sykli-artifacts",
+        in_cluster: false
+      }
+
+      assert :ok = K8s.run_task(task, state, job_module: FakeJob)
+
+      assert_receive {:job_create, "task-ns"}
+      assert_receive {:job_wait_complete, job_name, "task-ns"}
+      assert_receive {:job_delete, ^job_name, "task-ns"}
+      refute_received {:job_wait_complete, _, "state-ns"}
+      refute_received {:job_delete, _, "state-ns"}
     end
   end
 


### PR DESCRIPTION
## Summary
- use the task's effective K8s namespace consistently across job wait/log/delete lifecycle calls
- add a small job-module test hook so lifecycle namespace behavior can be tested without real K8s I/O
- add a regression test covering task-level namespace overrides in 

## Testing
- cd core && mix test test/sykli/k8s/resources/job_test.exs test/sykli/target/k8s_test.exs