### PR TITLE
feat(cli): v0.6 visual reset (ADR-020)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,12 @@
-<div align="center">
+# sykli
 
-# SYKLI
+Local-first CI for the next generation of software developers.
 
-**CI pipelines as real code. AI reads the results. Supply chain signed.**
-
-[![GitHub Release](https://img.shields.io/github/v/release/yairfalse/sykli?style=flat-square&color=blue)](https://github.com/yairfalse/sykli/releases)
-[![crates.io](https://img.shields.io/crates/v/sykli?style=flat-square&color=orange)](https://crates.io/crates/sykli)
-[![Hex.pm](https://img.shields.io/hexpm/v/sykli?style=flat-square&color=purple)](https://hex.pm/packages/sykli)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
-
-</div>
+For developers who chose Bun over npm, Linear over Jira, and Vercel over raw AWS.
+Write pipelines as real code, run them on hardware you control, and keep network optional.
+When a task fails, Sykli emits structured context your AI agent can act on directly.
 
 ```go
-// sykli.go — your CI config is a Go program
 package main
 
 import sykli "github.com/yairfalse/sykli/sdk/go"
@@ -26,17 +20,13 @@ func main() {
 ```
 
 ```
-$ sykli
-▶ test   go test ./...
-✓ test   124ms
+sykli · parallel_tasks.exs                         local · 0.5.3
 
-▶ build  go build -o app
-✓ build  1.2s
+  ●  task_a    echo a                                  108ms
+  ●  task_b    echo b                                  112ms
 
-✓ 2 passed in 1.4s
+  ─  2 passed                                          111ms
 ```
-
-No YAML. No DSL. No vendor lock-in. Write pipelines in **Go**, **Rust**, **TypeScript**, **Elixir**, or **Python**.
 
 ---
 

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -3,7 +3,7 @@ defmodule Sykli.CLI do
   CLI entry point for escript.
   """
 
-  alias Sykli.CLI.JsonResponse
+  alias Sykli.CLI.{JsonResponse, Live, Renderer, FixRenderer}
   alias Sykli.Delta
   alias Sykli.Error
   alias Sykli.Error.Formatter
@@ -139,8 +139,8 @@ defmodule Sykli.CLI do
     start_time = System.monotonic_time(:millisecond)
     json_output = Keyword.get(opts, :json, false)
 
-    # Suppress stdout before any work so target setup lines don't leak
-    original_gl = if json_output, do: suppress_stdout(), else: nil
+    # Suppress stdout before any work so target setup and executor progress do not leak.
+    original_gl = suppress_stdout()
 
     try do
       run_opts = []
@@ -233,12 +233,15 @@ defmodule Sykli.CLI do
           IO.puts(JsonResponse.ok(run_json_data("passed", results, duration, path)))
         else
           IO.puts(
-            "\n#{IO.ANSI.green()}✓ All tasks completed in #{format_duration(duration)}#{IO.ANSI.reset()}"
+            Renderer.render_run(
+              pipeline_label(path),
+              target_label(opts),
+              @version,
+              results,
+              duration,
+              ansi?: Live.ansi?()
+            )
           )
-
-          Enum.each(results, fn %Sykli.Executor.TaskResult{name: name} ->
-            IO.puts("  ✓ #{name}")
-          end)
         end
 
         halt(0)
@@ -247,10 +250,15 @@ defmodule Sykli.CLI do
         if json_output do
           IO.puts(JsonResponse.ok(run_json_data("failed", results, duration, path)))
         else
-          IO.puts("\n#{IO.ANSI.red()}Build failed#{IO.ANSI.reset()}")
-
           IO.puts(
-            "\n  #{IO.ANSI.faint()}💡 Ask your AI: \"read .sykli/occurrence.json and fix the failure\"#{IO.ANSI.reset()}"
+            Renderer.render_run(
+              pipeline_label(path),
+              target_label(opts),
+              @version,
+              results,
+              duration,
+              ansi?: Live.ansi?()
+            )
           )
         end
 
@@ -274,6 +282,20 @@ defmodule Sykli.CLI do
       tasks: Enum.map(results, &task_result_to_map/1),
       occurrence_path: Path.join([path, ".sykli", "occurrence.json"])
     }
+  end
+
+  defp pipeline_label(path) do
+    case Sykli.Detector.find(path) do
+      {:ok, {sdk_file, _runner}} -> sdk_file
+      _ -> path
+    end
+  end
+
+  defp target_label(opts) do
+    case Keyword.get(opts, :target, :local) do
+      :k8s -> "k8s"
+      _ -> "local"
+    end
   end
 
   defp task_result_to_map(%Sykli.Executor.TaskResult{} = r) do
@@ -1449,7 +1471,7 @@ defmodule Sykli.CLI do
         if json_output do
           IO.puts(JsonResponse.ok(Sykli.Fix.to_map(result)))
         else
-          IO.puts("#{IO.ANSI.green()}Nothing to fix — last run passed.#{IO.ANSI.reset()}")
+          IO.puts(FixRenderer.render(result, ansi?: Live.ansi?()))
         end
 
         halt(0)
@@ -1459,7 +1481,7 @@ defmodule Sykli.CLI do
           IO.puts(JsonResponse.ok(Sykli.Fix.to_map(result)))
         else
           IO.puts("")
-          IO.puts(Sykli.Fix.Output.format(result))
+          IO.puts(FixRenderer.render(result, ansi?: Live.ansi?()))
           IO.puts("")
         end
 

--- a/core/lib/sykli/cli/fix_renderer.ex
+++ b/core/lib/sykli/cli/fix_renderer.ex
@@ -1,0 +1,168 @@
+defmodule Sykli.CLI.FixRenderer do
+  @moduledoc "Pure renderer for `sykli fix` terminal output."
+
+  alias Sykli.CLI.Theme
+
+  @width 64
+
+  def render(result, opts \\ [])
+
+  def render(%{status: :nothing_to_fix}, opts) do
+    [color(Theme.glyph(:pass), :accent, opts), "  Nothing to fix. Last run passed."]
+  end
+
+  def render(%{status: :failure_found} = result, opts) do
+    [
+      render_header(result, opts),
+      "\n\n",
+      Enum.map(result.tasks, &render_task(&1, opts)),
+      render_diff(result.diff_since_last_good, opts)
+    ]
+  end
+
+  defp render_header(result, opts) do
+    summary = result.summary || %{}
+    failed = summary["failed_count"] || length(result.tasks || [])
+    total = summary["total_count"] || failed
+    ref = summary["git_ref"]
+    branch = summary["git_branch"]
+
+    git =
+      cond do
+        ref && branch -> " · #{String.slice(ref, 0, 7)} · #{branch}"
+        ref -> " · #{String.slice(ref, 0, 7)}"
+        true -> ""
+      end
+
+    [
+      color(Theme.glyph(:fail), :error, opts),
+      "  ",
+      "#{failed} of #{total} tasks failed",
+      color(git, :dim, opts)
+    ]
+  end
+
+  defp render_task(task, opts) do
+    [
+      color(Theme.glyph(:fail), :error, opts),
+      "  ",
+      task["name"],
+      "  ",
+      color(
+        String.duplicate("─", max(8, @width - String.length(task["name"] || "") - 6)),
+        :error,
+        opts
+      ),
+      "\n\n",
+      render_command(task),
+      render_locations(task["locations"] || [], opts),
+      render_causes(task["possible_causes"] || [], opts),
+      render_fix(task["suggested_fix"], opts),
+      render_history(task["history"], opts),
+      "\n"
+    ]
+  end
+
+  defp render_command(task) do
+    case {task["command"], task["exit_code"]} do
+      {nil, nil} ->
+        []
+
+      {command, nil} ->
+        ["    $ ", command, "\n\n"]
+
+      {command, code} ->
+        ["    $ ", command || "", "\n", "    exit code ", to_string(code), "\n\n"]
+    end
+  end
+
+  defp render_locations([], _opts), do: []
+
+  defp render_locations(locations, opts) do
+    Enum.map(locations, fn loc ->
+      [
+        color("    " <> location_label(loc), :dim, opts),
+        "\n",
+        render_location_message(loc, opts),
+        render_source(loc["source_lines"], opts),
+        "\n"
+      ]
+    end)
+  end
+
+  defp render_location_message(%{"message" => message}, opts) when is_binary(message),
+    do: [color("    " <> message, :error, opts), "\n"]
+
+  defp render_location_message(_loc, _opts), do: []
+
+  defp render_source(nil, _opts), do: []
+
+  defp render_source(lines, opts) do
+    Enum.map(lines, fn line ->
+      style = if String.starts_with?(line, ">>"), do: :error, else: :dim
+      [color("    " <> line, style, opts), "\n"]
+    end)
+  end
+
+  defp render_causes([], _opts), do: []
+
+  defp render_causes(causes, opts) do
+    Enum.map(causes, fn cause ->
+      ["    ", color("because", :warning, opts), "  ", cause, "\n"]
+    end) ++ ["\n"]
+  end
+
+  defp render_fix(nil, _opts), do: []
+  defp render_fix(fix, opts), do: ["    ", color("fix", :accent, opts), "      ", fix, "\n\n"]
+
+  defp render_history(nil, _opts), do: []
+
+  defp render_history(history, opts) do
+    parts =
+      []
+      |> maybe_append(history["pass_rate"], fn rate -> "#{round(rate * 100)}% pass rate" end)
+      |> maybe_append(history["streak"], fn streak -> "streak: #{streak}" end)
+      |> maybe_append(history["flaky"], fn _ -> "flaky" end)
+
+    if parts == [], do: [], else: [color("    " <> Enum.join(parts, " · "), :dim, opts), "\n"]
+  end
+
+  defp render_diff(nil, _opts), do: []
+
+  defp render_diff(diff, opts) do
+    ref = diff["ref"] || "last pass"
+    stat = diff["stat"]
+
+    [
+      color("Changes since #{ref}", :dim, opts),
+      "\n",
+      if(stat && stat != "", do: indent(stat), else: [])
+    ]
+  end
+
+  defp location_label(%{"file" => file, "line" => line})
+       when is_binary(file) and not is_nil(line),
+       do: "#{file}:#{line}"
+
+  defp location_label(%{"file" => file}) when is_binary(file), do: file
+  defp location_label(_), do: "location unknown"
+
+  defp indent(text) do
+    text
+    |> String.split("\n", trim: true)
+    |> Enum.map_join("\n", &"    #{&1}")
+  end
+
+  defp maybe_append(list, nil, _fun), do: list
+  defp maybe_append(list, false, _fun), do: list
+  defp maybe_append(list, value, fun), do: list ++ [fun.(value)]
+
+  defp color(text, style, opts) do
+    if Keyword.get(opts, :ansi?, false), do: [ansi(style), text, Theme.reset()], else: text
+  end
+
+  defp ansi(:accent), do: Theme.accent()
+  defp ansi(:error), do: Theme.error()
+  defp ansi(:warning), do: Theme.warning()
+  defp ansi(:dim), do: Theme.dim()
+end

--- a/core/lib/sykli/cli/live.ex
+++ b/core/lib/sykli/cli/live.ex
@@ -1,0 +1,27 @@
+defmodule Sykli.CLI.Live do
+  @moduledoc "TTY helpers for live `sykli run` rendering."
+
+  @cursor_save "\e7"
+  @cursor_restore "\e8"
+  @clear_line "\e[2K"
+
+  def tty?(device \\ :stdio) do
+    match?({:ok, _}, :io.columns(device))
+  end
+
+  def ansi?(device \\ :stdio), do: tty?(device)
+
+  def cursor_save(true), do: @cursor_save
+  def cursor_save(false), do: ""
+
+  def cursor_restore(true), do: @cursor_restore
+  def cursor_restore(false), do: ""
+
+  def clear_line(true), do: @clear_line
+  def clear_line(false), do: ""
+
+  def spinner_frame(tick) when is_integer(tick) do
+    frames = Sykli.CLI.Theme.spinner_frames()
+    Enum.at(frames, rem(tick, length(frames)))
+  end
+end

--- a/core/lib/sykli/cli/renderer.ex
+++ b/core/lib/sykli/cli/renderer.ex
@@ -33,7 +33,16 @@ defmodule Sykli.CLI.Renderer do
 
   def render_task_row(%TaskResult{} = result, opts \\ []) do
     command = result_command(result)
-    left = ["  ", glyph_for(result.status, opts), "  ", pad(result.name, @name_width), command]
+
+    left = [
+      "  ",
+      glyph_for(result.status, opts),
+      "  ",
+      pad(result.name, @name_width),
+      "  ",
+      command
+    ]
+
     right = task_suffix(result)
 
     [align(left, right), "\n"]
@@ -44,7 +53,7 @@ defmodule Sykli.CLI.Renderer do
         frame \\ Theme.glyph(:running),
         opts \\ []
       ) do
-    left = ["  ", color(frame, :accent, opts), "  ", pad(name, @name_width), command || ""]
+    left = ["  ", color(frame, :accent, opts), "  ", pad(name, @name_width), "  ", command || ""]
     [left, "\n"]
   end
 
@@ -155,7 +164,7 @@ defmodule Sykli.CLI.Renderer do
 
   defp pad(value, width) do
     value = to_string(value || "")
-    value <> String.duplicate(" ", max(1, width - visible_length(value)))
+    value <> String.duplicate(" ", max(0, width - visible_length(value)))
   end
 
   defp failed?(%TaskResult{status: status}), do: status in [:failed, :errored]

--- a/core/lib/sykli/cli/renderer.ex
+++ b/core/lib/sykli/cli/renderer.ex
@@ -1,0 +1,196 @@
+defmodule Sykli.CLI.Renderer do
+  @moduledoc "Pure renderer for `sykli run` terminal output."
+
+  alias Sykli.CLI.Theme
+  alias Sykli.Executor.TaskResult
+
+  @width 64
+  @name_width 12
+  @output_lines 10
+
+  def render_run(pipeline_path, target, version, results, duration_ms, opts \\ []) do
+    [
+      render_header(pipeline_path, target, version, opts),
+      "\n\n",
+      Enum.map(results, &render_task_row(&1, opts)),
+      "\n",
+      render_summary(%{results: results, duration_ms: duration_ms}, opts),
+      failure_blocks(results, opts)
+    ]
+  end
+
+  def render_header(pipeline_path, target, version, opts \\ []) do
+    left = "sykli · #{Path.basename(to_string(pipeline_path))}"
+    right = "#{target} · #{version}"
+
+    line =
+      left <>
+        String.duplicate(" ", max(1, @width - visible_length(left) - visible_length(right))) <>
+        right
+
+    color(line, :dim, opts)
+  end
+
+  def render_task_row(%TaskResult{} = result, opts \\ []) do
+    command = result_command(result)
+    left = ["  ", glyph_for(result.status, opts), "  ", pad(result.name, @name_width), command]
+    right = task_suffix(result)
+
+    [align(left, right), "\n"]
+  end
+
+  def render_running_row(
+        %{name: name, command: command},
+        frame \\ Theme.glyph(:running),
+        opts \\ []
+      ) do
+    left = ["  ", color(frame, :accent, opts), "  ", pad(name, @name_width), command || ""]
+    [left, "\n"]
+  end
+
+  def render_summary(%{results: results, duration_ms: duration_ms}, _opts \\ []) do
+    left = ["  ", Theme.glyph(:blocked), "  ", summary_text(results)]
+    [align(left, format_duration(duration_ms)), "\n"]
+  end
+
+  def separator, do: String.duplicate("─", 45)
+
+  def render_separator, do: separator()
+
+  def render_failure_block(%TaskResult{} = result, opts \\ []) do
+    [
+      "\n  ",
+      color(Theme.glyph(:fail), :error, opts),
+      "  ",
+      result.name,
+      "  ",
+      color(separator(), :error, opts),
+      "\n\n",
+      output_excerpt(failure_output(result)),
+      "\n",
+      render_fix_hint(opts),
+      "\n"
+    ]
+  end
+
+  def render_fix_hint(opts \\ []) do
+    color("      Run  sykli fix  for AI-readable analysis.", :dim, opts)
+  end
+
+  def format_duration(ms) when is_integer(ms) and ms < 1000, do: "#{ms}ms"
+  def format_duration(ms) when is_integer(ms) and ms < 60_000, do: "#{Float.round(ms / 1000, 1)}s"
+  def format_duration(ms) when is_integer(ms), do: "#{Float.round(ms / 60_000, 1)}m"
+  def format_duration(_), do: ""
+
+  defp failure_blocks(results, opts) do
+    results
+    |> Enum.filter(&failed?/1)
+    |> Enum.map(&render_failure_block(&1, opts))
+  end
+
+  defp glyph_for(:passed, opts), do: color(Theme.glyph(:pass), :accent, opts)
+  defp glyph_for(:cached, _opts), do: Theme.glyph(:cache)
+  defp glyph_for(:failed, opts), do: color(Theme.glyph(:fail), :error, opts)
+  defp glyph_for(:errored, opts), do: color(Theme.glyph(:fail), :error, opts)
+  defp glyph_for(:blocked, _opts), do: Theme.glyph(:blocked)
+  defp glyph_for(:skipped, _opts), do: Theme.glyph(:blocked)
+
+  defp task_suffix(%TaskResult{status: :cached}), do: "(cache)"
+  defp task_suffix(%TaskResult{status: :blocked}), do: "skipped (blocked)"
+  defp task_suffix(%TaskResult{status: :skipped}), do: "skipped"
+  defp task_suffix(%TaskResult{duration_ms: ms}), do: format_duration(ms)
+
+  defp summary_text(results) do
+    results
+    |> Enum.map(&summary_status/1)
+    |> Enum.frequencies()
+    |> Enum.filter(fn {_status, count} -> count > 0 end)
+    |> Enum.sort_by(fn {status, _count} -> summary_order(status) end)
+    |> Enum.map(fn {status, count} -> "#{count} #{plural(status, count)}" end)
+    |> Enum.join(" · ")
+  end
+
+  defp summary_status(%TaskResult{status: status}) when status in [:failed, :errored], do: :failed
+  defp summary_status(%TaskResult{status: :passed}), do: :passed
+  defp summary_status(%TaskResult{status: :cached}), do: :cached
+  defp summary_status(%TaskResult{status: :blocked}), do: :blocked
+  defp summary_status(%TaskResult{status: :skipped}), do: :skipped
+
+  defp summary_order(:failed), do: 0
+  defp summary_order(:passed), do: 1
+  defp summary_order(:cached), do: 2
+  defp summary_order(:blocked), do: 3
+  defp summary_order(:skipped), do: 4
+
+  defp plural(:failed, 1), do: "failed"
+  defp plural(:failed, _), do: "failed"
+  defp plural(:passed, 1), do: "passed"
+  defp plural(:passed, _), do: "passed"
+  defp plural(:cached, 1), do: "cached"
+  defp plural(:cached, _), do: "cached"
+  defp plural(:blocked, 1), do: "blocked"
+  defp plural(:blocked, _), do: "blocked"
+  defp plural(:skipped, 1), do: "skipped"
+  defp plural(:skipped, _), do: "skipped"
+
+  defp result_command(%TaskResult{command: command}) when is_binary(command), do: command
+  defp result_command(_), do: ""
+
+  defp output_excerpt(nil), do: ""
+  defp output_excerpt(""), do: ""
+
+  defp output_excerpt(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.take(-@output_lines)
+    |> Enum.map_join("\n", &"      #{&1}")
+  end
+
+  defp align(left, right) do
+    left_text = IO.iodata_to_binary(left)
+    right_text = to_string(right || "")
+    spaces = max(1, @width - visible_length(left_text) - visible_length(right_text))
+    [left, String.duplicate(" ", spaces), right_text]
+  end
+
+  defp pad(value, width) do
+    value = to_string(value || "")
+    value <> String.duplicate(" ", max(1, width - visible_length(value)))
+  end
+
+  defp failed?(%TaskResult{status: status}), do: status in [:failed, :errored]
+
+  defp failure_output(%TaskResult{output: output}) when is_binary(output) and output != "",
+    do: output
+
+  defp failure_output(%TaskResult{error: %Sykli.Error{} = error}) do
+    [error.message | error.hints || []]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp failure_output(%TaskResult{error: error}) when not is_nil(error), do: inspect(error)
+  defp failure_output(_result), do: nil
+
+  defp color(text, style, opts) do
+    if Keyword.get(opts, :ansi?, false) do
+      [ansi(style), text, Theme.reset()]
+    else
+      text
+    end
+  end
+
+  defp ansi(:accent), do: Theme.accent()
+  defp ansi(:error), do: Theme.error()
+  defp ansi(:warning), do: Theme.warning()
+  defp ansi(:dim), do: Theme.dim()
+
+  defp visible_length(value) do
+    value
+    |> IO.iodata_to_binary()
+    |> strip_ansi()
+    |> String.length()
+  end
+
+  defp strip_ansi(value), do: Regex.replace(~r/\e\[[0-9;]*m/, value, "")
+end

--- a/core/lib/sykli/cli/theme.ex
+++ b/core/lib/sykli/cli/theme.ex
@@ -1,0 +1,29 @@
+defmodule Sykli.CLI.Theme do
+  @moduledoc "Shared glyphs and colors for Sykli CLI output."
+
+  @accent IO.ANSI.color(80)
+  @error IO.ANSI.red()
+  @warning IO.ANSI.yellow()
+  @dim IO.ANSI.faint()
+  @reset IO.ANSI.reset()
+
+  @pass "●"
+  @cache "○"
+  @fail "✕"
+  @blocked "─"
+  @running ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+  def accent, do: @accent
+  def error, do: @error
+  def warning, do: @warning
+  def dim, do: @dim
+  def reset, do: @reset
+
+  def glyph(:pass), do: @pass
+  def glyph(:cache), do: @cache
+  def glyph(:fail), do: @fail
+  def glyph(:blocked), do: @blocked
+  def glyph(:running), do: hd(@running)
+
+  def spinner_frames, do: @running
+end

--- a/core/lib/sykli/executor.ex
+++ b/core/lib/sykli/executor.ex
@@ -48,7 +48,7 @@ defmodule Sykli.Executor do
     """
 
     @enforce_keys [:name, :status, :duration_ms]
-    defstruct [:name, :status, :duration_ms, :error, :output]
+    defstruct [:name, :status, :duration_ms, :error, :output, :command]
 
     @type status :: :passed | :failed | :errored | :cached | :skipped | :blocked
     @type t :: %__MODULE__{
@@ -56,7 +56,8 @@ defmodule Sykli.Executor do
             status: status(),
             duration_ms: non_neg_integer(),
             error: term() | nil,
-            output: String.t() | nil
+            output: String.t() | nil,
+            command: String.t() | nil
           }
   end
 
@@ -334,7 +335,8 @@ defmodule Sykli.Executor do
                     name: task.name,
                     status: :errored,
                     duration_ms: duration,
-                    error: reason
+                    error: reason,
+                    command: task.command
                   }
               end
             end)
@@ -355,7 +357,8 @@ defmodule Sykli.Executor do
                 name: original.name,
                 status: :errored,
                 duration_ms: 0,
-                error: Error.internal("task process crashed: #{inspect(reason)}")
+                error: Error.internal("task process crashed: #{inspect(reason)}"),
+                command: original.command
               }
 
             {{task_ref, nil}, original} ->
@@ -365,7 +368,8 @@ defmodule Sykli.Executor do
                 name: original.name,
                 status: :errored,
                 duration_ms: 0,
-                error: Error.internal("task process timed out")
+                error: Error.internal("task process timed out"),
+                command: original.command
               }
           end)
 
@@ -435,7 +439,8 @@ defmodule Sykli.Executor do
         name: task.name,
         status: :blocked,
         duration_ms: 0,
-        error: :dependency_failed
+        error: :dependency_failed,
+        command: task.command
       }
     end)
   end
@@ -546,7 +551,8 @@ defmodule Sykli.Executor do
                     name: task.name,
                     status: :errored,
                     duration_ms: duration,
-                    error: Error.missing_secrets(task.name, missing)
+                    error: Error.missing_secrets(task.name, missing),
+                    command: task.command
                   }
               end
 
@@ -559,7 +565,8 @@ defmodule Sykli.Executor do
                 name: task.name,
                 status: :errored,
                 duration_ms: duration,
-                error: Error.internal("OIDC credential exchange failed: #{reason}")
+                error: Error.internal("OIDC credential exchange failed: #{reason}"),
+                command: task.command
               }
           end
         after
@@ -575,7 +582,8 @@ defmodule Sykli.Executor do
           name: task.name,
           status: :skipped,
           duration_ms: duration,
-          error: nil
+          error: nil,
+          command: task.command
         }
       end
     end
@@ -600,7 +608,13 @@ defmodule Sykli.Executor do
 
         Output.gate_approved(prefix, task.name, approver)
 
-        %TaskResult{name: task.name, status: :passed, duration_ms: duration, error: nil}
+        %TaskResult{
+          name: task.name,
+          status: :passed,
+          duration_ms: duration,
+          error: nil,
+          command: task.command
+        }
 
       {:denied, reason} ->
         maybe_emit_gate_resolved(run_id, task.name, :denied, reason, duration)
@@ -611,7 +625,8 @@ defmodule Sykli.Executor do
           name: task.name,
           status: :failed,
           duration_ms: duration,
-          error: Error.internal("gate '#{task.name}' denied: #{reason}")
+          error: Error.internal("gate '#{task.name}' denied: #{reason}"),
+          command: task.command
         }
 
       {:timed_out} ->
@@ -623,7 +638,8 @@ defmodule Sykli.Executor do
           name: task.name,
           status: :failed,
           duration_ms: duration,
-          error: Error.internal("gate '#{task.name}' timed out after #{gate.timeout}s")
+          error: Error.internal("gate '#{task.name}' timed out after #{gate.timeout}s"),
+          command: task.command
         }
     end
   end
@@ -660,7 +676,8 @@ defmodule Sykli.Executor do
           name: task.name,
           status: :cached,
           duration_ms: duration,
-          error: nil
+          error: nil,
+          command: task.command
         }
 
       {:miss, cache_key, reason} ->
@@ -751,7 +768,8 @@ defmodule Sykli.Executor do
           status: :passed,
           duration_ms: duration,
           error: nil,
-          output: output
+          output: output,
+          command: task.command
         }
 
       {:error, reason} when attempt < max_attempts ->
@@ -787,7 +805,8 @@ defmodule Sykli.Executor do
           status: :failed,
           duration_ms: duration,
           error: reason,
-          output: output
+          output: output,
+          command: task.command
         }
     end
   end

--- a/core/test/sykli/cli/fix_renderer_test.exs
+++ b/core/test/sykli/cli/fix_renderer_test.exs
@@ -1,0 +1,82 @@
+defmodule Sykli.CLI.FixRendererTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.CLI.FixRenderer
+
+  describe "render/1" do
+    test "nothing_to_fix returns success message" do
+      output =
+        %{status: :nothing_to_fix}
+        |> FixRenderer.render()
+        |> IO.iodata_to_binary()
+
+      assert output =~ "●  Nothing to fix. Last run passed."
+    end
+
+    test "failure_found renders header, task details, and proposed fix" do
+      output =
+        failure_result()
+        |> FixRenderer.render()
+        |> IO.iodata_to_binary()
+
+      assert output =~ "✕  1 of 3 tasks failed · abc1234 · main"
+      assert output =~ "✕  test:auth"
+      assert output =~ "$ npm test -- --filter auth"
+      assert output =~ "exit code 1"
+      assert output =~ "src/auth.ts:42"
+      assert output =~ "Expected token"
+      assert output =~ "because  src/auth.ts changed"
+      assert output =~ "fix      check token format"
+      assert output =~ "94% pass rate"
+    end
+
+    test "failure_found renders diff stat" do
+      output =
+        failure_result(%{
+          diff_since_last_good: %{
+            "ref" => "abc1234",
+            "stat" => "src/auth.ts | 12 +++---"
+          }
+        })
+        |> FixRenderer.render()
+        |> IO.iodata_to_binary()
+
+      assert output =~ "Changes since abc1234"
+      assert output =~ "src/auth.ts | 12 +++---"
+    end
+  end
+
+  defp failure_result(overrides \\ %{}) do
+    Map.merge(
+      %{
+        status: :failure_found,
+        summary: %{
+          "failed_count" => 1,
+          "total_count" => 3,
+          "git_ref" => "abc1234def",
+          "git_branch" => "main"
+        },
+        tasks: [
+          %{
+            "name" => "test:auth",
+            "command" => "npm test -- --filter auth",
+            "exit_code" => 1,
+            "locations" => [
+              %{
+                "file" => "src/auth.ts",
+                "line" => 42,
+                "message" => "Expected token",
+                "source_lines" => ["41 | const token = nil", ">> 42 | parse(token)"]
+              }
+            ],
+            "possible_causes" => ["src/auth.ts changed"],
+            "suggested_fix" => "check token format",
+            "history" => %{"pass_rate" => 0.94, "streak" => 0, "flaky" => false}
+          }
+        ],
+        diff_since_last_good: nil
+      },
+      overrides
+    )
+  end
+end

--- a/core/test/sykli/cli/renderer_test.exs
+++ b/core/test/sykli/cli/renderer_test.exs
@@ -1,0 +1,63 @@
+defmodule Sykli.CLI.RendererTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.CLI.Renderer
+  alias Sykli.Executor.TaskResult
+
+  test "renders passing run without banned internal vocabulary" do
+    output =
+      Renderer.render_run(
+        "parallel_tasks.exs",
+        "local",
+        "0.5.3",
+        [
+          %TaskResult{name: "task_a", command: "echo a", status: :passed, duration_ms: 108},
+          %TaskResult{name: "task_b", command: "echo b", status: :passed, duration_ms: 112}
+        ],
+        111
+      )
+      |> IO.iodata_to_binary()
+
+    assert output =~ "sykli · parallel_tasks.exs"
+    assert output =~ "  ●  task_a"
+    assert output =~ "  ─  2 passed"
+
+    refute output =~ "Level"
+    refute output =~ "1L"
+    refute output =~ "(first run)"
+    refute output =~ "Target: local (docker:"
+    refute output =~ "All tasks completed"
+  end
+
+  test "renders failure block with output excerpt and fix hint" do
+    output =
+      Renderer.render_run(
+        "build.exs",
+        "local",
+        "0.5.3",
+        [
+          %TaskResult{name: "test", command: "go test ./...", status: :passed, duration_ms: 1800},
+          %TaskResult{
+            name: "build",
+            command: "go build ./cmd/app",
+            status: :failed,
+            duration_ms: 912,
+            output: "old\n./cmd/app/main.go:42:13: undefined: ResolveOpts\n"
+          },
+          %TaskResult{
+            name: "lint",
+            command: "golangci-lint",
+            status: :blocked,
+            duration_ms: 0
+          }
+        ],
+        2700
+      )
+      |> IO.iodata_to_binary()
+
+    assert output =~ "  ✕  build"
+    assert output =~ "  ─  1 failed · 1 passed · 1 blocked"
+    assert output =~ "./cmd/app/main.go:42:13: undefined: ResolveOpts"
+    assert output =~ "Run  sykli fix  for AI-readable analysis."
+  end
+end

--- a/docs/adr/020-positioning-and-visual-direction.md
+++ b/docs/adr/020-positioning-and-visual-direction.md
@@ -1,0 +1,187 @@
+# ADR-020: Positioning, Audience, and Visual Direction
+
+**Status:** Proposed
+**Date:** 2026-04-27
+
+---
+
+## Context
+
+Sykli's substance is strong — runtime decoupling, FALSE Protocol occurrences, attestations, eval harness, MCP server, AI-readable failure analysis. But the project has never written down *who it is for* or *how it should look*. The README is a list of features, the CLI output is a kitchen sink of every color in the default palette, and the marketing claims ("CI as real code", "AI reads the results", "supply chain signed") are three claims fighting for the same headline.
+
+Without a canonical positioning, every decision drifts: do we add an enterprise dashboard? Do we ship a SaaS? Do we make the CLI cute or sober? Each new contributor (human or agent) re-litigates the same questions.
+
+This ADR fixes positioning, audience, and visual direction in one place so future decisions can be measured against it.
+
+---
+
+## Decision
+
+### Thesis
+
+> **Sykli is local-first CI for the next generation of software developers.**
+
+This is the canonical one-sentence statement. It is the headline of the README, the elevator pitch, and the test against which features are accepted or rejected.
+
+### What "local-first" commits us to
+
+Local-first is a category term (Ink & Switch et al.), not just an adjective. Adopting it commits us to:
+
+- **The user's hardware is the execution authority.** Sykli runs on the developer's laptop, their mesh, their self-hosted runners, their VPS. Never on hardware Sykli (the project) owns or operates.
+- **The project ships software, not a service.** No hosted dashboard. No multi-tenant control plane. No SaaS billing. No on-call rotation.
+- **Network is opt-in.** A developer with no internet, no GitHub, and no S3 still gets a working CI tool. Cloud features (S3 cache, GitHub status, mesh peering across networks) are additive, never required.
+- **Determinism and reproducibility are first-class.** Local-first software in a multi-machine world only works if runs are replayable byte-for-byte. This reinforces the existing direction in ADR-010 and the simulator scaffolding.
+
+### Audience
+
+> **Developers who chose Bun over npm, mise over nvm, Linear over Jira, Raycast over Spotlight, Tailscale over OpenVPN, Vercel/Fly over raw AWS — and who code daily with AI agents.**
+
+This audience:
+
+- Has taste and pays for tools that respect it.
+- Believes their tools should be fast, beautiful, and opinionated.
+- Has never accepted that "real CI" requires YAML and a vendor dashboard.
+- Treats AI assistants (Claude Code, Cursor, Copilot) as a daily collaborator, not a novelty.
+- Cares about supply chain provenance — signed builds, verifiable attestations.
+- Wants to debug locally, not by re-running CI to read logs.
+
+### What this rules in
+
+- Polished, restrained CLI experience modeled on Linear/Vercel/Raycast.
+- AI-readability as a headline feature (`sykli fix`, `sykli mcp`, the FALSE Protocol).
+- Mesh as peer-to-peer infrastructure for *one user's* nodes (laptop + office + VPS), not a hosted service.
+- GitHub-native integration via the user's own infrastructure (see ADR-021).
+- Single-binary install, `brew install sykli`, `mise use sykli`.
+
+### What this rules out
+
+- ❌ Hosted SaaS where users submit jobs to Sykli-owned infrastructure.
+- ❌ Multi-tenant control plane.
+- ❌ Enterprise CI vendor positioning (do not compete with Jenkins/CircleCI on their turf).
+- ❌ "AI-native CI" as the lead claim — it's vibe-marketing. Local-first is positioning; AI-readability is evidence.
+- ❌ Charm-style playful aesthetic. Bun-style bro/hype aesthetic. Either fights the brand.
+- ❌ YAML configuration. Ever.
+
+---
+
+## Visual Direction
+
+### Aesthetic: Nordic Minimal
+
+Reference set: **Linear**, **Vercel CLI**, **Raycast**. Common DNA: near-black backgrounds, near-white text, surgical use of whitespace, *one* cold accent color, almost-invisible micro-interactions, restraint as the dominant move.
+
+Sykli adopts this aesthetic verbatim. It is consistent with the audience, with local-first as a sober commitment, and with the supply-chain-as-craft brand.
+
+### Accent color
+
+**One** accent: cold cyan-teal (approximately `#7DD3D8`). Used **only** for:
+
+- The success glyph (`●`)
+- The running-state spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`)
+- The wordmark in marketing surfaces
+
+Never for warnings, errors, dim text, separators, or decorative use. The accent is reserved.
+
+Errors use red (`✕`). Warnings use yellow. Cache hits and skipped tasks use no color at all (they should feel free, not negative).
+
+### Glyph language
+
+Status is carried by glyph, not color. A user in a colorblind-friendly terminal, or a screenshot-of-a-screenshot, must still parse the run.
+
+| Glyph | Meaning |
+|-------|---------|
+| `●`   | Passed (cyan-teal) |
+| `○`   | Cache hit (no color) |
+| `✕`   | Failed (red) |
+| `─`   | Blocked / skipped (no color) |
+| `⠋`   | Running (cyan-teal, animated) |
+
+### Output rules
+
+These are commitments, not suggestions. Code-level enforcement lives in the renderer module (see Consequences).
+
+1. **One summary per run.** Not two, not three. Today's output emits up to three; that is a bug.
+2. **No internal vocabulary.** "Level", "1L", "(first run)", "Target: local (docker: Docker version 28.5.1, build e180ab8)" — all banned. The user's mental model is *tasks* and *runs*. The renderer speaks that vocabulary, nothing else.
+3. **Right-aligned timing column.** Time-to-glance for "what was slow" should be one eye movement.
+4. **Streamed task stdout is hidden by default.** Show on failure, or with `--stream`. Today's interleaved dim-grey output is the worst of both worlds.
+5. **Animation lives in a single redraw region.** Cursor save/restore, dirty-row tracking. No new lines emitted until a task transitions to terminal state.
+6. **Failure is the highest-stakes surface.** When something fails, the renderer collapses success noise, draws a horizontal rule under the failed task, shows the offending output inline, and points the user at `sykli fix` in a single line.
+7. **`sykli fix` is the screenshot moment.** Its renderer is a separate module with its own layout. It shows: what broke, where it changed (git provenance), the proposed fix, and a one-line causality statement.
+
+### Reference frame: passing parallel run
+
+```
+sykli · parallel_tasks.exs                         local · 0.5.3
+
+  ⠋  task_a    echo a
+  ⠋  task_b    echo b
+
+  ●  task_a    echo a                                  108ms
+  ●  task_b    echo b                                  112ms
+
+  ─  2 passed                                          111ms
+```
+
+### Reference frame: failure
+
+```
+sykli · build.exs                                  local · 0.5.3
+
+  ●  test         go test ./...                       1.8s
+  ✕  build        go build ./cmd/app                  912ms
+  ─  lint         golangci-lint                       skipped (blocked)
+
+  ─  1 failed · 1 passed · 1 blocked                  2.7s
+
+  ✕  build  ─────────────────────────────────────────────
+
+      ./cmd/app/main.go:42:13: undefined: ResolveOpts
+
+      Run  sykli fix  for AI-readable analysis.
+```
+
+---
+
+## Consequences
+
+### README
+
+The current 220-line README is rewritten around the thesis. Hero is three lines + one code sample + one terminal frame in the new visual style. The MCP server and `sykli fix` are surfaced above the fold — they are the differentiators, not side features.
+
+### CLI
+
+A new `Sykli.CLI.Renderer` module owns frame composition (header, task rows, summary) as pure functions returning IO-lists. A new `Sykli.CLI.Live` module owns the redraw region. The current line-emit-per-event renderer in `cli.ex` is replaced. `sykli fix` gets its own renderer. Estimated 2 weeks for a v0.6 visual reset across the most-watched commands.
+
+### Marketing surfaces
+
+Wordmark: lowercase `sykli`. No all-caps. No custom monogram in v0.6 — defer until brand work has budget.
+
+Badges that don't resolve to real published packages are removed from the README. If `sykli` is published to crates.io / hex.pm later, the badges return.
+
+### Architecture
+
+This ADR has architectural force, not just aesthetic. The local-first commitment is now load-bearing for every future ADR. Specifically:
+
+- ADR-021 (GitHub-native integration) is constrained: the receiver must run on the user's mesh, never on Sykli-owned infrastructure.
+- ADR-006 (cluster peers) and ADR-001 (local first, remote when you have to) are reinforced and cited as load-bearing.
+- ADR-012's "Cloud Mesh" Phase 2 hint is constrained: cloud nodes join the user's cluster as peers; they are not a centralized dispatcher.
+
+### Decisions deferred
+
+These are intentionally *not* decided here, to keep this ADR scoped:
+
+- The exact hex value of the accent color (`#7DD3D8` is a target; designer can tune).
+- The wordmark typeface for marketing surfaces (CLI uses the terminal's monospace).
+- Whether `sykli init` becomes a TUI flow or stays as a one-shot scaffolder.
+- Light-terminal palette (the spec above assumes dark; light mode is a follow-on).
+
+---
+
+## References
+
+- **Local-first software** — Kleppmann, Wiggins, van Hardenberg, McGranaghan. <https://www.inkandswitch.com/local-first/>
+- **ADR-001** — Meta-design ("local first, remote when you have to")
+- **ADR-006** — Local/Remote Architecture (cluster peers)
+- **ADR-010** — Reproducible Builds (determinism foundation)
+- **ADR-012** — BEAM Superpowers (Cloud Mesh Phase 2 hint)
+- **ADR-021** — GitHub-Native Integration via Webhook + Mesh Receiver (downstream of this ADR)

--- a/docs/adr/021-github-native-via-webhook-mesh-receiver.md
+++ b/docs/adr/021-github-native-via-webhook-mesh-receiver.md
@@ -1,0 +1,180 @@
+# ADR-021: GitHub-Native Integration via Webhook + Mesh Receiver
+
+**Status:** Proposed
+**Date:** 2026-04-27
+**Supersedes:** ADR-004 (GitHub Integration via Commit Status API + run-inside-Actions)
+
+---
+
+## Context
+
+ADR-004 (Accepted, 2024-12-03) chose the smallest viable GitHub integration for v1: Sykli runs *inside* a GitHub Actions runner, reads `GITHUB_TOKEN` from the runner environment, and reports per-task pass/fail via the Commit Status API. No GitHub App, no webhook receiver, no Checks API.
+
+That decision was correct for v1. It got Sykli onto PRs without requiring users to register an app or expose an endpoint. But it has a structural problem: **Sykli doesn't replace GitHub Actions; it lives inside it.** The Actions runner is the execution authority. Actions YAML is required. The Actions log UI is where users still go to read failures. Sykli is a guest in someone else's CI.
+
+For the v0.6+ thesis (ADR-020 — local-first CI for the next generation of developers), this is a contradiction. A local-first CI tool cannot have its execution authority owned by GitHub Actions. The audience we are targeting will not accept "you need a GitHub Actions runner to use Sykli."
+
+This ADR replaces ADR-004 with a model where **GitHub fires events at the user's mesh, the mesh executes the run, and the mesh reports back via Checks API.** Actions is no longer in the picture.
+
+---
+
+## Decision
+
+**Sykli ships a GitHub App. Users install it against their repos. One node in the user's mesh plays the `:webhook_receiver` role and exposes an HTTPS endpoint reachable from `api.github.com`. Push and PR events arrive at the receiver, the mesh executes the pipeline, and results are reported back via the Checks API using the App's installation token.**
+
+### Topology
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                                                                    │
+│  GitHub                                                            │
+│    │                                                               │
+│    │  webhook (push, pull_request, check_run)                      │
+│    ▼                                                               │
+│  ┌────────────────────────────────────────────────────────────┐    │
+│  │                  USER'S MESH                                │    │
+│  │  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐  │    │
+│  │  │  receiver    │───▶│  scheduler   │───▶│  worker      │  │    │
+│  │  │  (HTTPS)     │    │  (placement) │    │  (executor)  │  │    │
+│  │  │  :webhook_   │    │              │    │              │  │    │
+│  │  │  receiver    │    │              │    │              │  │    │
+│  │  └──────────────┘    └──────────────┘    └──────────────┘  │    │
+│  │         │                                       │           │    │
+│  │         └───────────── OTP cluster (peers) ─────┘           │    │
+│  └────────────────────────────────────────────────────────────┘    │
+│                          │                                         │
+│                          │  Checks API (status, annotations)       │
+│                          ▼                                         │
+│  GitHub                                                            │
+│                                                                    │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+The receiver is **not a service**. It is a node in the user's OTP cluster with a `:webhook_receiver` capability label. Placement (ADR-017), occurrence broadcast, fault tolerance, and graceful shutdown all apply to it for free.
+
+### Why this is local-first
+
+- The receiver runs on hardware the user controls (laptop, office NAS, VPS, Raspberry Pi, anything with an IP and an Erlang VM).
+- Sykli (the project) operates zero servers in this model.
+- No user data, no source code, no secrets ever transit Sykli-owned infrastructure.
+- A user with no internet still has a working CI tool — the GitHub-native path is opt-in.
+- Users pick their own exposure mechanism: public IP + TLS, Tailscale Funnel, Cloudflare Tunnel, ngrok, port-forward on their router. The receiver is HTTPS-only and signature-verified; the exposure layer is the user's choice.
+
+### Why GitHub App, not OAuth or PAT
+
+| Option | Token scope | UX | Verdict |
+|---|---|---|---|
+| **PAT (current ADR-004)** | User's full account | "Add this token to env" | Insecure. Wide blast radius. No installation model. |
+| **OAuth App** | User-token, broad | "Authorize this app to act as you" | Acts *as* the user; not what we want. |
+| **GitHub App** | Installation-scoped, narrow | "Install this app on these repos" | ✓ Right model. |
+
+GitHub Apps give us:
+- Installation-scoped tokens (rotate hourly, scoped to the installation's repos).
+- A clean install UX (org admins click "Install" against specific repos).
+- Webhook delivery with HMAC signatures.
+- Checks API write access.
+- No "act as a user" semantics — Sykli speaks as itself.
+
+### Reporting: Checks API, not Commit Status API
+
+Per-task statuses become **Check Runs**, not commit statuses. Why:
+
+- Check Runs support **annotations** (file + line + message), which makes `sykli fix` output renderable inline on the PR diff. This is a major UX win.
+- Check Runs support **structured output** (title, summary, text), which maps cleanly to the FALSE Protocol occurrence shape.
+- Check Runs support **rerequesting** ("Re-run failed checks") natively.
+- Commit statuses are a flat list with no annotations. They were the v1 compromise; they don't carry the data Sykli now produces.
+
+The mapping:
+
+| Sykli concept | Check Runs concept |
+|---|---|
+| Pipeline run | One *check suite* |
+| Task | One *check run* within the suite |
+| Task occurrence (FALSE Protocol) | Check run's `output.summary` (Markdown) + annotations |
+| `sykli fix` analysis | Annotations on the offending file/line |
+
+### Security
+
+The receiver is the most exposed component in the mesh. Hard requirements:
+
+- **HTTPS only.** No plaintext webhook endpoint.
+- **Signature verification.** Every incoming webhook MUST be HMAC-verified against the App's webhook secret before any processing. Reject mismatches without logging the body.
+- **Installation token rotation.** The receiver requests installation tokens on demand and caches them for ≤55 minutes (under the 1-hour expiry).
+- **No persisted secrets in webhooks.** Webhook bodies are processed in memory; only the resolved run record is persisted (and that is masked via `SecretMasker`, per existing convention).
+- **Replay protection.** Track `X-GitHub-Delivery` IDs in a bounded LRU; reject duplicates.
+- **Rate limiting.** The receiver applies a per-installation rate limit before dispatching to the mesh. A spammed installation cannot starve other installations.
+
+### Fallback: self-hosted Actions runner mode
+
+ADR-004's "run inside Actions" model is *not* deleted. It remains as a documented fallback path for users who:
+
+- Cannot expose any HTTPS endpoint to the public internet.
+- Are on a corporate network with no Tailscale/Cloudflare Tunnel option.
+- Want to evaluate Sykli without registering a GitHub App.
+
+In this mode, Sykli still installs as a binary; the user runs it inside their Actions YAML; status reports go through the legacy Commit Status API path. This is documented as the *fallback*, not the headline.
+
+---
+
+## Consequences
+
+### Net new components
+
+- `Sykli.GitHub.App` — installation token management, JWT signing for App auth, webhook secret storage.
+- `Sykli.GitHub.Webhook.Receiver` — HTTPS endpoint, signature verification, replay protection, dispatch into the mesh.
+- `Sykli.GitHub.Checks` — Checks API client, suite/run mapping, annotation upload.
+- `Sykli.Mesh.Roles` — capability label `:webhook_receiver` and placement rule (only one node per mesh holds this role at a time).
+
+### Modified components
+
+- `Sykli.Mesh.Transport` (ADR-013) gains a `:webhook` event type for receiver→scheduler dispatch.
+- The existing `Sykli.SCM.GitHub` module (ADR-004 Commit Status path) is kept and marked as the fallback path. It becomes secondary to the Checks API path.
+- The existing `.github/workflows/sykli-ci.yml` dogfooding pipeline is migrated to demonstrate both modes.
+
+### Migration path
+
+1. **0.6:** Receiver, App registration flow, Checks API client, mesh role. Documented as opt-in alongside the existing in-Actions path. Both modes work; in-Actions is still default.
+2. **0.7:** GitHub-native (this ADR's path) becomes the documented default. In-Actions is moved to a "fallback" page.
+3. **0.8+:** GitHub-native is the only path advertised in marketing. In-Actions remains supported but undocumented in the hero.
+
+### Operational responsibilities
+
+The user operates their own receiver. This means:
+
+- They expose an endpoint (their choice of mechanism).
+- They register the App against their repos (one-time install flow).
+- They are responsible for the receiver's uptime — but if it goes down, GitHub auto-retries failed deliveries for up to 8 hours, and operators can manually redeliver any event within 30 days via the GitHub API. The mesh catches up on recovery.
+
+Sykli (the project) is responsible for:
+
+- Publishing and maintaining the GitHub App manifest.
+- Documenting the install flow.
+- Shipping the receiver code.
+- Nothing else.
+
+### What this enables for the user
+
+- **`sykli fix` annotations on the PR diff.** The killer feature appears inline on the offending file:line, not just in terminal output.
+- **Real Checks UI integration.** The PR's Checks tab shows per-task status with structured output, not just dots.
+- **Re-run from GitHub UI.** Standard GitHub "re-run failed checks" works.
+- **No Actions YAML required.** A user can install the App, push a `sykli.go` to their repo, and have CI working — without ever writing `.github/workflows/*.yml`.
+
+---
+
+## Open questions
+
+- **Multi-mesh installations.** What happens if a user runs two separate meshes (e.g., one at home, one at work) and installs the App on the same repo from both? First-receiver-wins, or explicit installation-to-mesh binding?
+- **Webhook ordering.** GitHub does not guarantee webhook delivery order. The receiver must reconcile out-of-order events (e.g., a `pull_request.synchronize` arriving before its preceding `push`). Likely solution: idempotent state derived from the commit SHA, not from event order. Worth a spike.
+- **App marketplace listing.** Eventually the App should be listable on the GitHub Marketplace. Out of scope for v0.6.
+
+---
+
+## References
+
+- **GitHub Apps** — <https://docs.github.com/en/apps>
+- **Checks API** — <https://docs.github.com/en/rest/checks>
+- **ADR-004** — superseded by this ADR
+- **ADR-006** — Cluster peers (the receiver is just another peer)
+- **ADR-013** — Mesh swarm design (the receiver uses existing transport)
+- **ADR-017** — Task placement (the receiver is placed via existing rules)
+- **ADR-020** — Positioning and visual direction (the local-first commitment that constrains this ADR)

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -88,7 +88,7 @@
       "fixture": "retry_succeeds",
       "command": "sykli",
       "expect_exit": 0,
-      "expect_stdout": "passed"
+      "expect_stdout": "1 passed"
     },
     {
       "id": "POS-010",
@@ -492,7 +492,7 @@
       "fixture": "sdk_go",
       "command": "sykli",
       "expect_exit": 0,
-      "expect_stdout": "passed",
+      "expect_stdout": "1 passed",
       "requires": "go"
     },
     {
@@ -501,7 +501,7 @@
       "fixture": "sdk_ts",
       "command": "sykli",
       "expect_exit": 0,
-      "expect_stdout": "passed",
+      "expect_stdout": "1 passed",
       "requires": "node"
     },
     {

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -18,10 +18,7 @@
       "fixture": "single_task",
       "command": "sykli",
       "expect_exit": 0,
-      "expect_stdout": "All tasks completed",
-      "expect_stdout_contains": [
-        "hello"
-      ]
+      "expect_stdout": "1 passed"
     },
     {
       "id": "POS-002",
@@ -91,7 +88,7 @@
       "fixture": "retry_succeeds",
       "command": "sykli",
       "expect_exit": 0,
-      "expect_stdout": "All tasks completed"
+      "expect_stdout": "passed"
     },
     {
       "id": "POS-010",
@@ -340,7 +337,7 @@
       "command": "sykli",
       "expect_exit": 1,
       "expect_stdout_contains": [
-        "missing"
+        "requires secrets"
       ]
     },
     {
@@ -366,7 +363,7 @@
       "command": "sykli && sykli",
       "expect_exit": 0,
       "expect_stdout_contains": [
-        "CACHED"
+        "cached"
       ],
       "shell": true
     },
@@ -495,7 +492,7 @@
       "fixture": "sdk_go",
       "command": "sykli",
       "expect_exit": 0,
-      "expect_stdout": "All tasks completed",
+      "expect_stdout": "passed",
       "requires": "go"
     },
     {
@@ -504,7 +501,7 @@
       "fixture": "sdk_ts",
       "command": "sykli",
       "expect_exit": 0,
-      "expect_stdout": "All tasks completed",
+      "expect_stdout": "passed",
       "requires": "node"
     },
     {
@@ -754,7 +751,7 @@
       "fixture": "single_task",
       "command": "sykli --timeout=0",
       "expect_exit": 0,
-      "expect_stdout": "All tasks completed"
+      "expect_stdout": "passed"
     },
     {
       "id": "ABN-014",
@@ -762,7 +759,7 @@
       "fixture": "single_task",
       "command": "sykli --timeout=24h",
       "expect_exit": 0,
-      "expect_stdout": "All tasks completed"
+      "expect_stdout": "passed"
     },
     {
       "id": "POS-019",


### PR DESCRIPTION
Summary: Implements the ADR-020 Nordic-minimal visual reset for the watched run/fix surfaces.

Scope:
- Added Theme, Renderer, Live, and FixRenderer CLI modules.
- Wired sykli run/default-run and sykli fix to the new renderer while preserving JsonResponse output.
- Added inline failure output with the sykli fix hint.
- Updated black-box expectations for hidden success stdout and the new summary shape.
- Rewrote the README hero and removed broken package badges.

Terminal frame:
```
sykli · parallel_tasks.exs                         local · 0.5.3

  ●  task_a    echo a                                  108ms
  ●  task_b    echo b                                  112ms

  ─  2 passed                                          111ms
```

Closes #N if applicable