### PR TITLE
chore: release 0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ temp/
 # Documentation (research notes - not for commit, but allow ADRs and committed guides)
 docs/*
 !docs/adr/
+!docs/releases/
 !docs/runtimes.md
 
 # Sykli runtime data (AI context, run history, logs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,136 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-29
+
+This release crystallizes the v0.6 line: a Nordic-minimal CLI, a fully decoupled runtime layer with deterministic-test defaults, SLSA v1.0 supply-chain attestations, an oracle-based AI agent evaluation harness, the FALSE-Protocol-first-class internal model, and the foundation for v0.7's GitHub-native CI integration. v0.5.1, v0.5.2, and v0.5.3 were development tags without CHANGELOG entries; their changes are folded in here.
+
+**Positioning lock-in.** ADR-020 names the project: *local-first CI for the next generation of software developers*. Every architectural decision in this release flows from that thesis. ADR-021 supersedes ADR-004 and frames the next line of work — sykli replaces GitHub Actions instead of running inside it, with a webhook receiver running on the user's own mesh.
+
+### Added
+
+#### CLI & user-facing
+- **v0.6 visual reset** — Nordic-minimal CLI per ADR-020. New modules `Sykli.CLI.Renderer`, `Theme`, `Live`, `FixRenderer`. One accent color (cold cyan-teal), glyph-driven status (`● ○ ✕ ─ ⠋`), right-aligned timing column, single redraw region for animations, hidden task stdout by default, single summary per run.
+- **`sykli mcp`** — MCP server for AI assistant integration (Claude Code, Cursor, Copilot). 5 tools, stdio transport.
+- **`sykli fix`** — AI-readable failure analysis with source context and git diff. Renders inline causality, "where it changed", and proposed remediation.
+- **`sykli query`** — structured queries against pipeline / history / health data without an LLM.
+- **`sykli plan`** — dry-run execution planning with git-diff-driven task selection.
+- **`sykli explain --pipeline`** — AI-readable pipeline structure (levels, critical path).
+- **`sykli run --json`** — structured machine-readable output for AI agents and tooling.
+- **Shared JSON envelope** — `Sykli.CLI.JsonResponse` provides `{ok, version, data, error}` across every `--json` command, including the `error_with_data` variant for validate-style failures. Agents parse one shape across all commands.
+- **`--runtime` CLI flag** + `mix sykli.runtime.info` task for inspecting runtime selection.
+- **Improved no-pipeline-found UX** with quick-start hint, language detection across all 5 SDKs, monorepo support (subdirectory detection).
+- **README rewrite** for the v0.6 thesis (650 → 220 lines, then re-cut for the visual reset hero).
+
+#### Runtime decoupling (RC.0–RC.7)
+- **`Sykli.Runtime.Resolver`** — single source of truth for runtime selection via priority chain (CLI flag → opts → app env → `SYKLI_RUNTIME` env → auto-detect → Shell fallback).
+- **`Sykli.Runtime.Fake`** — deterministic in-memory runtime; default for `:test` env so unit tests need no Docker.
+- **`Sykli.Runtime.Podman`** — rootless Podman runtime, full parity with the Docker runtime.
+- **Runtime isolation invariant** — no module outside `core/lib/sykli/runtime/` may name a specific runtime. Enforced by `core/test/sykli/runtime_isolation_test.exs` which greps the source tree.
+- **Test tiers** — `mix test` (unit, against Fake), `mix test.docker`, `mix test.podman`, `mix test.integration`. Default-excludes `:docker`, `:podman`, `:integration` tags.
+
+#### Supply chain & verification
+- **SLSA v1.0 provenance attestation** with DSSE envelope signing (`Sykli.Attestation`). Per-run and per-task envelopes.
+- **`SYKLI_SIGNING_KEY` / `SYKLI_ATTESTATION_KEY_FILE`** for HMAC and file-based signing keys.
+- **`Sykli.HTTP.ssl_opts/1`** — shared TLS verification options for all `:httpc` callers (OIDC, S3, SCM, webhooks).
+
+#### GitHub-native foundation (ADR-021 Phase 1)
+- **`Sykli.GitHub.App`** — JWT-signed App authentication, installation token acquisition, behaviour split (Real + Fake) with token caching (`Sykli.GitHub.App.Cache`).
+- **`Sykli.GitHub.Webhook.Receiver`** — Plug pipeline on Bandit; `/healthz` and `/webhook` endpoints; HMAC-SHA256 signature verification (`Sykli.GitHub.Webhook.Signature`); replay protection via `X-GitHub-Delivery` LRU (`Sykli.GitHub.Webhook.Deliveries`).
+- **`Sykli.GitHub.Checks`** — Checks API client (`create_suite/3`, `create_run/4`, `update_run/4`).
+- **`Sykli.GitHub.Clock`** + **`Sykli.GitHub.HttpClient`** — behaviour-split time and HTTP layers for deterministic testing.
+- **`Sykli.Mesh.Roles`** — single-node-per-role capability registry. New role `:webhook_receiver` placed by capability rules.
+- **New occurrence types** — `ci.github.webhook.received`, `ci.github.check_suite.opened`.
+- **`docs/github-native.md`** — App registration walkthrough.
+
+#### Mesh & determinism foundation
+- **`Sykli.Mesh.Transport.Sim`** — deterministic in-memory mesh transport for simulation testing. Includes `EventQueue`, `Network`, `Rng`, `SimNode`, `State`, `PidRef` submodules.
+- **`Sykli.Mesh.Transport.Erlang`** — production OTP-distribution transport.
+- **`CredoSykli.Check.NoWallClock`** — custom Credo check; fails on `System.monotonic_time`, `System.os_time`, `System.system_time`, `DateTime.utc_now`, `NaiveDateTime.utc_now`, `:os.system_time`, `:erlang.now`, and bare `:rand.uniform`.
+
+#### Evaluation & quality
+- **Oracle eval suite** — 55 ground-truth cases (20 initial + 20 adversarial + 15 mean) for AI-agent CI behavior validation. Run via `eval/oracle/run.sh`.
+- **Eval harness** — full Claude Code → build → oracle → report loop via `eval/harness/run.sh` for AI agent regression evaluation.
+
+#### FALSE Protocol & observability
+- **FALSE Protocol first-class** — internal events ARE `Sykli.Occurrence` structs (refactor; previously occurrences wrapped events).
+- **`chain_id`** — correlates retry chains across occurrences.
+- **Configurable `source` URI** via `SYKLI_SOURCE_URI` env or `:sykli, :source` app env.
+- **`:errored` task status** — distinct from `:failed` for infrastructure failures (timeouts, OIDC, missing secrets, process crashes). `:failed` gets causality analysis; `:errored` gets infrastructure diagnostics.
+- **`.sykli/context.json`** — added project + health sections; documented optional schema.
+- **Per-task log paths** in occurrence task entries.
+- **ULID run IDs** — monotonic, sortable, replace older random IDs.
+
+#### ADRs
+- **ADR-020** — Positioning, Audience, and Visual Direction (the local-first thesis).
+- **ADR-021** — GitHub-Native Integration via Webhook + Mesh Receiver (supersedes ADR-004).
+
+### Changed
+
+- **Cache fingerprint includes repo-relative workdir.** Project-scoped cache keys prevent cross-project pollution. **Breaking for occurrences from before this change** — old `.sykli/occurrence.json` payloads are not backward-compatible with the new cache-key format. Re-run pipelines to rebuild local cache state.
+- **Dead code removal** — −1102 lines of compiler warnings + unused modules + stale `Sykli.Executor.Server` references.
+- **`README.md`** — rewritten for the v0.6 thesis; broken `crates.io` and `hex.pm` badges removed.
+- **CLAUDE.md** — extensively updated: supervision tree, errored status, env vars, runtime isolation rule, NoWallClock rule, S3 circuit breaker, async SCM, JSON envelope shape.
+
+### Fixed
+
+- **K8s job lifecycle namespace handling** — uses manifest namespace, not coordinator default; prevents leaks across namespaces.
+- **Race condition in `execute_sync`** for fast-completing tasks.
+- **Gate occurrence JSON serialization** — gate fields now round-trip through JSON cleanly.
+- **Attestation generation without cache metadata** — no longer crashes when cache backend is unconfigured.
+- **Circuit breaker monotonic time assertion** — used the wrong time source.
+- **xmerl warning configuration** — silenced the noise on stderr.
+- **Cache fingerprint collisions** across projects sharing similar task graphs.
+- **35+ PR review comments** addressed across the release (Copilot + human reviewers).
+
+### Security
+
+- **SEC-001** — OIDC token requests now verify TLS (was using `:verify_none`).
+- **SEC-002** — `secret_refs` file source validates path containment, prevents host-path traversal.
+- **SEC-003** — Docker mount paths use `String.starts_with?(path, base <> "/")` to prevent prefix-trick traversals.
+- **SEC-004** — Webhook delivery has SSRF guard; rejects internal IP ranges and metadata endpoints.
+- **SEC-006** — `SecretMasker` now matches broader env var patterns (`_TOKEN`, `_SECRET`, `_KEY`, `_PASSWORD`, `_URL`, `_DSN`, `_URI`, `_CONN`).
+- **SEC-007** — Cache key now includes OIDC-derived runtime secrets to prevent cache leak across credentialed runs.
+- **OIDC JWT verification** — full RS256 verification against the provider's JWKS, not just decoding.
+- **S3 circuit breaker** — `TieredRepository` tracks consecutive failures in `persistent_term`; after 5, L2 writes skip for 60s cooldown.
+- **Async SCM status calls** (REL-005) — status posts fire via `Task.Supervisor.async_nolink` and never block the executor.
+- **Webhook signature verification** — HMAC-SHA256, constant-time comparison, body never logged on mismatch.
+- **Webhook replay protection** — bounded LRU of `X-GitHub-Delivery` IDs.
+
+### Reliability
+
+- **REL-002** — Graceful shutdown (SIGTERM) drains in-flight tasks within `SYKLI_DRAIN_TIMEOUT_MS` (default 30s).
+- **REL-003** — Concurrent runs no longer race on `.sykli/occurrence.json`; writes go through `Occurrence.Store` with three-tier persistence (ETS hot → ETF warm → JSON cold).
+- **REL-004** — S3 cache timeout no longer blocks executor; calls are bounded and circuit-broken.
+- **REL-006** — PubSub failures no longer silently swallow occurrence emission; structured warning logged.
+- **REL-007** — `RunRegistry` evicts terminated runs (was leaking).
+- **REL-008** — Telemetry duration units corrected (was emitting microseconds when contract said milliseconds).
+
+### Documentation
+
+- `docs/adr/020-positioning-and-visual-direction.md`
+- `docs/adr/021-github-native-via-webhook-mesh-receiver.md`
+- `docs/deep-dive-findings.md` — 37 tracked issues across security/reliability/architecture/test coverage; the SEC and REL series above are the closure.
+- `docs/runtimes.md` — runtime selection priority chain.
+- `docs/cache-key-investigation.md` — determinism investigation behind the cache fingerprint change.
+- `docs/eventqueue-flake-investigation.md` — property-test triage.
+- `docs/github-native.md` — Phase 1 setup walkthrough.
+- `CODEX_PROMPT_PHASE_1.md` and `CODEX_PROMPT_PHASE_2.md` — kickoff prompts for AI coding agents driving the GitHub-native rollout.
+
+### SDK & ecosystem
+
+- All five SDKs (Go, Rust, TypeScript, Elixir, Python) bumped to 0.6.0 in lockstep.
+- Python SDK adds `verify()` for cross-platform verification parity.
+- TypeScript, Rust, and Elixir SDKs gain gate support.
+- Comprehensive cross-SDK conformance suite added (`tests/conformance/`); resolves cross-SDK divergences.
+
+### Migration notes
+
+- **Old `.sykli/occurrence.json` payloads** are not backward-compatible with the new cache-key format. The first run after upgrading rebuilds cache state automatically; no user action required beyond expecting one cold run.
+- **GitHub integration**: ADR-004's "run inside GitHub Actions + Commit Status API" path remains supported as a documented fallback. The new GitHub-native path (ADR-021 Phase 1+) is opt-in via App registration.
+- **Tests requiring Docker** are now excluded by default. Run with `mix test.docker` (or `--include docker`) to execute them.
+- **`SYKLI_RUNTIME`** env var is the new way to force a specific runtime. CLI `--runtime` takes precedence.
+
 ## [0.5.0] - 2026-02-07
 
 ### Added

--- a/core/mix.exs
+++ b/core/mix.exs
@@ -1,7 +1,7 @@
 defmodule Sykli.MixProject do
   use Mix.Project
 
-  @version "0.5.3"
+  @version "0.6.0"
 
   def project do
     [

--- a/core/test/sykli/cli/renderer_test.exs
+++ b/core/test/sykli/cli/renderer_test.exs
@@ -9,7 +9,7 @@ defmodule Sykli.CLI.RendererTest do
       Renderer.render_run(
         "parallel_tasks.exs",
         "local",
-        "0.5.3",
+        "0.6.0",
         [
           %TaskResult{name: "task_a", command: "echo a", status: :passed, duration_ms: 108},
           %TaskResult{name: "task_b", command: "echo b", status: :passed, duration_ms: 112}
@@ -34,7 +34,7 @@ defmodule Sykli.CLI.RendererTest do
       Renderer.render_run(
         "build.exs",
         "local",
-        "0.5.3",
+        "0.6.0",
         [
           %TaskResult{name: "test", command: "go test ./...", status: :passed, duration_ms: 1800},
           %TaskResult{

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -1,0 +1,125 @@
+# sykli 0.6.0
+
+*Released 2026-04-29*
+
+**Local-first CI for the next generation of software developers.**
+
+This is the release that makes that one-liner mean something. The CLI looks the way the project sounds. The runtime layer is decoupled from the engine. The supply chain is signed. AI agents read your runs natively. And the foundation for replacing GitHub Actions — sykli running on your own mesh, GitHub talking to it directly — is in place.
+
+```
+sykli · build.exs                                  local · 0.6.0
+
+  ●  test         go test ./...                       1.8s
+  ●  build        go build ./cmd/app                  912ms
+  ●  lint         golangci-lint run                   220ms
+
+  ─  3 passed                                          2.9s
+```
+
+---
+
+## Highlights
+
+### The CLI looks designed now
+
+A full visual reset (ADR-020). One accent color, glyph-driven status, single redraw region for animations, hidden task stdout by default, one summary per run. No more "Level", no more "1L", no more debug headers. Failure mode draws a horizontal rule under the failed task and points at `sykli fix` for AI-readable analysis. Reference set for the aesthetic: Linear, Vercel CLI, Raycast.
+
+### Runtime decoupling — `:test` defaults to a Fake
+
+The execution layer is now properly separated from the engine. `Sykli.Runtime.Resolver` is the single source of truth for runtime selection (priority chain: CLI flag → opts → app env → `SYKLI_RUNTIME` → auto-detect → Shell). `Sykli.Runtime.Fake` is the new in-memory deterministic runtime that `:test` defaults to — your unit tests no longer need Docker. New: `Sykli.Runtime.Podman` (rootless container parity), `mix sykli.runtime.info` for inspection, `--runtime` CLI flag, and test tiers (`mix test.docker`, `mix test.podman`, `mix test.integration`).
+
+### `sykli fix` and friends — AI-readable failures
+
+Four new commands for AI-native CI:
+
+- **`sykli fix`** — failure analysis with source context, git provenance, and a single-line cause statement. The screenshot moment.
+- **`sykli mcp`** — MCP server so Claude Code, Cursor, and Copilot can read your run state directly without log scraping.
+- **`sykli query`** — structured queries against pipeline / history / health data without an LLM.
+- **`sykli plan`** — dry-run execution planning with git-diff-driven task selection.
+
+All `--json` output now flows through a shared envelope (`{ok, version, data, error}`) so agents parse one shape across every command.
+
+### SLSA v1.0 attestations
+
+Every run now produces a DSSE-signed SLSA v1.0 provenance envelope. Per-run and per-task attestations. Configure signing via `SYKLI_SIGNING_KEY` (HMAC) or `SYKLI_ATTESTATION_KEY_FILE` (file-based). The supply-chain story is no longer aspirational.
+
+### GitHub-native foundation (ADR-021 Phase 1)
+
+The first slab of the v0.7 line: sykli now ships a GitHub App, a webhook receiver (Plug + Bandit), a Checks API client, and a `:webhook_receiver` mesh role. A signed webhook arrives at the user's mesh, signature is verified (HMAC-SHA256, constant-time, body never logged on mismatch), the receiver opens a `queued` check suite. Phase 2 (pipeline dispatch from the webhook) is in progress; Phase 3 (PR-diff annotations from `sykli fix`) is next.
+
+This means: in v0.7, sykli replaces GitHub Actions instead of running inside it. Local-first throughout — the receiver lives on hardware you control, never on Sykli-owned infrastructure. ADR-021 supersedes ADR-004; the in-Actions integration remains as a documented fallback.
+
+### FALSE Protocol first-class
+
+Internal events are now `Sykli.Occurrence` structs end-to-end (refactor — events used to be wrapped *by* occurrences). New: `chain_id` for correlating retry chains, configurable `source` URI via `SYKLI_SOURCE_URI`, and an `:errored` task status distinct from `:failed` for infrastructure failures. `:failed` gets causality analysis; `:errored` gets infrastructure diagnostics.
+
+### Eval harness + oracle
+
+55 ground-truth oracle cases for AI-agent CI behavior validation. Run via `eval/oracle/run.sh`. The full Claude Code → build → oracle → report loop is in `eval/harness/run.sh` for AI-agent regression testing.
+
+### Hardening
+
+A full sweep across the security and reliability backlog:
+
+- **SEC-001..007** all closed: OIDC TLS verification, secret_refs path traversal, Docker mount containment, webhook SSRF guard, broader secret masking, OIDC-derived runtime cache keys.
+- **REL-002..008** closed: graceful shutdown, concurrent-run race fix, S3 cache circuit breaker, async SCM status calls, telemetry duration units, RunRegistry eviction, PubSub failure handling.
+- 35+ PR review comments addressed across the release.
+
+---
+
+## Breaking change
+
+**Cache fingerprint scheme now includes the repo-relative workdir.** This prevents cross-project cache pollution but means `.sykli/occurrence.json` payloads from before 0.6.0 are not backward-compatible.
+
+**What you need to do:** nothing. The first run after upgrade rebuilds local cache state automatically. Expect one cold run.
+
+---
+
+## Install / upgrade
+
+```bash
+# Single binary
+curl -fsSL https://raw.githubusercontent.com/false-systems/sykli/main/install.sh | bash
+
+# Or with a specific version
+curl -fsSL https://raw.githubusercontent.com/false-systems/sykli/main/install.sh | bash -s v0.6.0
+```
+
+SDKs (all bumped to 0.6.0 in lockstep):
+
+```bash
+# Go
+go get github.com/yairfalse/sykli/sdk/go@v0.6.0
+
+# Rust
+cargo add sykli@0.6.0
+
+# TypeScript
+npm install sykli@0.6.0
+
+# Python
+pip install sykli==0.6.0
+
+# Elixir
+{:sykli, "~> 0.6.0"}
+```
+
+---
+
+## What's next
+
+- **Phase 2** of the GitHub-native rollout (`CODEX_PROMPT_PHASE_2.md` in the repo): webhook → mesh placement → executor → check-run lifecycle. Per-task check runs transition through `queued` → `in_progress` → conclusion.
+- **Phase 3**: `sykli fix` annotations rendered onto the PR diff via the Checks API's annotation surface.
+- **Phase 4**: GitHub App marketplace listing.
+
+---
+
+## Thanks
+
+To everyone who pushed back on early drafts of the visual reset, who reviewed the runtime decoupling RC.0–RC.7 chain, who pointed out the cache-fingerprint cross-project-pollution bug, and to the Codex agents that shipped the visual reset (PR #123) and the GitHub-native foundation (PR #125) cleanly.
+
+---
+
+**Full changelog:** see [`CHANGELOG.md`](../../CHANGELOG.md#060---2026-04-29) for the comprehensive list of additions, changes, fixes, and security closures across all 142 commits.
+
+**Architectural reference:** [`ADR-020`](../adr/020-positioning-and-visual-direction.md) (positioning + visual direction), [`ADR-021`](../adr/021-github-native-via-webhook-mesh-receiver.md) (GitHub-native via webhook + mesh receiver).

--- a/sdk/elixir/mix.exs
+++ b/sdk/elixir/mix.exs
@@ -4,7 +4,7 @@ defmodule SykliSdk.MixProject do
   def project do
     [
       app: :sykli_sdk,
-      version: "0.5.3",
+      version: "0.6.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sykli"
-version = "0.5.3"
+version = "0.6.0"
 description = "AI-native CI pipeline SDK for Python"
 readme = "README.md"
 license = "MIT"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sykli"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 description = "CI pipelines defined in Rust instead of YAML"
 license = "MIT"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sykli",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "CI pipelines defined in TypeScript instead of YAML",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -1,7 +1,7 @@
 {
   "suite": "sykli-blackbox",
   "version": "1.0.0",
-  "target": "sykli 0.5.3",
+  "target": "sykli 0.6.0",
   "categories": {
     "POS": "Positive - system works as promised",
     "NEG": "Negative - system rejects what it should",
@@ -60,7 +60,7 @@
       "fixture": "single_task",
       "command": "sykli --version",
       "expect_exit": 0,
-      "expect_stdout": "sykli 0.5.3"
+      "expect_stdout": "sykli 0.6.0"
     },
     {
       "id": "POS-007",


### PR DESCRIPTION
## Summary

Release 0.6.0. Bumps version `0.5.3` → `0.6.0` across the core engine and all five SDKs (Go, Rust, TypeScript, Elixir, Python), updates the two test fixtures that hardcode the version string, and adds the CHANGELOG entry covering the **142 commits since v0.5.2**.

## What ships in 0.6.0

| Theme | Highlights |
|---|---|
| **Visual reset (ADR-020)** | Nordic-minimal CLI: Renderer/Theme/Live/FixRenderer modules, glyph-driven status, single redraw region, README rewrite around the local-first thesis |
| **Runtime decoupling (RC.0–RC.7)** | `Sykli.Runtime.Resolver`, `.Fake`, `.Podman`; `:test` defaults to Fake (no Docker); test tiers; runtime isolation invariant |
| **Supply chain** | SLSA v1.0 provenance attestation with DSSE signing; `Sykli.HTTP.ssl_opts/1` everywhere |
| **AI-readable CI** | `sykli fix`, `sykli query`, `sykli plan`, `sykli mcp`; FALSE Protocol first-class; `chain_id`; `:errored` status; ULID run IDs |
| **Eval & quality** | Oracle suite (55 cases) + eval harness for AI-agent regression evaluation |
| **JSON envelope** | `Sykli.CLI.JsonResponse` shared shape across all `--json` commands; `sykli run --json` |
| **Mesh foundation** | `Sykli.Mesh.Transport.Sim` (deterministic), `.Erlang` (production); custom Credo `NoWallClock` check |
| **GitHub-native foundation (ADR-021 Phase 1)** | App auth, webhook receiver (Plug + Bandit), Checks API client, signature verification, replay LRU, `Sykli.Mesh.Roles` |
| **Hardening** | SEC-001..007 closed; REL-002..008 closed; 35+ PR review fixes |

## Breaking change

**Cache fingerprint now includes the repo-relative workdir** (project-scoped cache keys prevent cross-project pollution). Old `.sykli/occurrence.json` payloads are not backward-compatible. First run after upgrade rebuilds local cache state automatically — expect one cold run.

The legacy in-Actions GitHub integration (ADR-004) remains as a documented fallback. The new GitHub-native path (ADR-021 Phase 1) is opt-in via App registration.

## Validation

- [x] \`mix format\` — clean
- [x] \`mix test\` — 1433 tests, 0 failures, 1 skipped (13 excluded for tier tags)
- [x] \`mix escript.build\` — built clean
- [x] \`test/blackbox/run.sh\` — 92/92 passing
- [x] All five SDK version files bumped in lockstep
- [x] Test fixtures hardcoding "0.5.3" updated to "0.6.0" (renderer test + blackbox dataset)

## Post-merge

After this PR merges to \`main\`, tag and ship:

\`\`\`
git checkout main && git pull
git tag -a v0.6.0 -m "Release 0.6.0"
git push origin v0.6.0
\`\`\`

If a release workflow is wired to the tag, GitHub Releases / package registry pushes happen automatically. Otherwise: build escript, attach to a manual GitHub Release, push the SDKs to npm / crates.io / hex.pm / PyPI as desired.

## Test plan

- [x] CHANGELOG entry organized by Keep-a-Changelog categories (Added / Changed / Fixed / Security / Reliability / Documentation / SDK / Migration notes)
- [x] All version bumps verified via grep (no stray "0.5.3" left)
- [x] ADR cross-references in CHANGELOG resolve to real files

🤖 Generated with [Claude Code](https://claude.com/claude-code)