### PR TITLE
docs: add three Codex prompts to close v0.6 outstanding work

### DIFF
--- a/CODEX_PROMPT_PHASE_2_5_FIXES.md
+++ b/CODEX_PROMPT_PHASE_2_5_FIXES.md
@@ -1,0 +1,138 @@
+# Codex prompt — Phase 2.5 findings remediation
+
+Paste the block below into Codex's chat to start.
+
+---
+
+You are an engineering agent assigned to **fixing the 11 contract gaps** found by the Phase 2.5 oracle expansion (PR #129). The findings are documented in **`eval/oracle/findings-phase-2-5.md`**. The cases live in **`test/blackbox/dataset.json`**, currently marked `expected_failure: true` so they don't break CI.
+
+This prompt closes the bug-tracking chain that the Phase 2.5 prompt assumed but didn't enforce: failing cases must drive bug fixes, and the `expected_failure: true` mark must be **removed** as each bug is fixed (not left as a permanent shrug). **Take no prisoners.** A finding is closed only when:
+
+1. A GitHub issue exists tracking it.
+2. A fix PR closes that issue.
+3. The corresponding case in `dataset.json` no longer has `expected_failure: true`.
+4. The case passes naturally — without `expected_failure` — under the fixed code.
+
+## Read first, in order
+
+1. **`CLAUDE.md`** at repo root — conventions, build/test commands, runtime isolation rule, NoWallClock rule, JSON envelope.
+2. **`eval/oracle/findings-phase-2-5.md`** — the canonical list of 11 findings with severity, observed behavior, expected behavior, and requirement source.
+3. **`test/blackbox/dataset.json`** — find every case with `"expected_failure": true` and its `"findings":` field. These are the cases you will be flipping.
+4. **`test/blackbox/run.sh`** — see how `expected_failure` is interpreted by the runner. Removing the flag must result in the case being evaluated normally.
+5. **The relevant requirement source per finding** — most cite CLAUDE.md sections, ADRs, or CHANGELOG entries. Read the source before writing the fix; some findings may turn out to indicate the *requirement* was wrong.
+
+## The 11 findings — fix order is by severity, then ease
+
+| # | Case | Severity | One-line gap | Requirement source |
+|---|---|---|---|---|
+| 1 | **GH-004** | **Critical** | A task command can copy `/etc/passwd` into the workspace | CLAUDE.md §Path containment; CHANGELOG 0.2.0 path-traversal fix |
+| 2 | **ABN-015** | High | A task timeout is reported as `:failed` instead of `:errored` | CLAUDE.md §TaskResult Status Values |
+| 3 | **DET-006** | High | NoWallClock Credo check does not reject `DateTime.utc_now` in a fixture violation file | CLAUDE.md §No wall-clock or global RNG |
+| 4 | **SDK-001** | High | `tests/conformance/run.sh 01-basic` fails for non-Go SDK emitters | CLAUDE.md §SDKs; SDK READMEs |
+| 5 | **SDK-002** | High | Capability conformance fails through the runner | CHANGELOG 0.5.0 capabilities; SDK READMEs |
+| 6 | **SDK-003** | High | Gate conformance fails through the runner | CHANGELOG 0.5.0 gates; SDK READMEs |
+| 7 | **SDK-004** | High | Task input conformance fails through the runner | README §Content-addressed caching; SDK READMEs |
+| 8 | **SDK-006** | High | Empty-provides conformance fails through the runner | CHANGELOG 0.5.0 empty `provides` fix |
+| 9 | **CACHE-006** | Medium | `sykli cache stats --json` prints help text instead of envelope JSON | CLAUDE.md §JSON output |
+| 10 | **DET-003** | Medium | Two identical runs differ after stripping known-variable fields | ADR-020 determinism; CLAUDE.md §FALSE Protocol Occurrences |
+| 11 | **SDK-005** | Medium | Duplicate dependency edge conformance fails through the runner | SDK READMEs |
+
+## Critical context — the most likely places to misstep
+
+- **GH-004 first, alone, fast.** The path-traversal finding is Critical security. It ships before any other fix. It also gets its own dedicated PR with a tight title (`fix(security): prevent host path read from task commands`) so the security signal is visible in `git log --oneline`. Do not bundle GH-004 into a multi-finding PR.
+- **`expected_failure: true` is a temporary shrug, not a contract.** Every case currently flagged with it is a *known-broken* contract assertion that the runner is hiding. Removing the flag without fixing the bug breaks CI. Removing the flag *with* the fix is the deliverable. Removing it *and not flipping* the underlying behavior is wrong both ways.
+- **Fix the bug, not the case.** If a case is poorly written and its current red is "noise" rather than a real gap, the right move is to **delete or rewrite the case**, not silently tighten its expectations. Document any such case in the PR body. The Phase 2.5 prompt's philosophy still applies: a case that doesn't catch a real gap is not a case worth keeping.
+- **One issue per finding, regardless of how the fixes group.** Even if SDK-001..006 share a root cause and are fixed in one PR, file 6 issues and have the PR close all 6 (`Closes #N1, Closes #N2, …`). The issues are the audit trail; the PRs are the cure.
+- **The runtime isolation rule applies.** No module outside `core/lib/sykli/runtime/` may name a runtime by class. If GH-004's fix involves the executor or target layer hardening path containment, the fix lives in `target/local.ex` or `services/`, not by adding a `Sykli.Runtime.Hardened` module.
+- **NoWallClock applies to your fixes.** Don't introduce `DateTime.utc_now` while fixing DET-006; the check is exactly what's broken. Fix the *check*, not by routing around it.
+- **Default `:test` runtime is `Sykli.Runtime.Fake`.** Tests don't need Docker. If a fix's test does need Docker, tag `@tag :docker` and run tier `mix test.docker` to verify; don't change the default.
+- **The fix can change requirements.** If when fixing ABN-015 you discover the codebase's intent is actually that timeouts are command failures (not infrastructure), then the *requirement* was wrong, not the implementation. In that case: amend CLAUDE.md, delete the case, document the reasoning in the issue, and close the issue as `not a bug` rather than fixing nothing.
+
+## Scope — what to do, in order
+
+1. **Open 11 GitHub issues**, one per finding. Use this body template:
+   ```
+   ## Finding (Phase 2.5)
+
+   - **Case:** <CASE-ID>
+   - **Severity:** <Critical|High|Medium>
+   - **Source:** <requirement document and section>
+   - **Observed:** <one sentence from the findings doc>
+   - **Expected:** <one sentence from the findings doc>
+
+   ## How to reproduce
+
+   <one shell snippet that triggers the failing case>
+
+   ## Definition of done
+
+   - The contract gap is fixed in `core/` (or the requirement is amended in `CLAUDE.md` if the case was wrong).
+   - `dataset.json` case `<CASE-ID>` no longer carries `expected_failure: true` and passes naturally.
+   - This issue is closed by a PR.
+   ```
+   Title: `[Phase 2.5] <CASE-ID>: <one-line gap>`. Label: `bug` + `phase-2-5`.
+
+2. **Fix GH-004 first**, alone, in its own PR. Title: `fix(security): prevent host path read from task commands`. Closes the GH-004 issue. Removes `expected_failure: true` from GH-004 in `dataset.json`. The case must pass.
+
+3. **Fix the SDK conformance findings (SDK-001..006) next**, likely in one or two PRs since they share infrastructure (the conformance runner + the per-SDK emitters). One PR if root cause is shared; up to three if the root causes split cleanly. Each PR closes the relevant issues by ID. `expected_failure: true` is removed from each fixed case.
+
+4. **Fix the remaining Highs (ABN-015, DET-006)** — each in a dedicated PR.
+
+5. **Fix the Mediums (CACHE-006, DET-003, SDK-005)** — can bundle into one PR titled `fix: close remaining Phase 2.5 medium-severity findings`.
+
+6. After all 11 are closed, **delete the `expected_failure: true` predicate from `test/blackbox/run.sh`** if no other case in the dataset uses it. (`grep '"expected_failure"' test/blackbox/dataset.json` → no matches → delete the predicate.) The mechanism was a Phase 2.5 stopgap, not a permanent feature. Removing it is the final cleanup PR.
+
+## Out of scope — DO NOT TOUCH
+
+- ✗ Adding new oracle/black-box cases. The 11 findings are the bounded scope.
+- ✗ ADRs. No new ADRs, no edits.
+- ✗ The release tag, README, CLAUDE.md positioning. **Different Codex prompt.**
+- ✗ The PR review feature. **Different Codex prompt.**
+- ✗ Refactoring unrelated code. If you reach for an "while I'm here" cleanup, stop. Open it as a follow-up issue instead.
+- ✗ Adding new dependencies.
+- ✗ Changing the Phase 2.5 case shape beyond removing `expected_failure: true`. The cases were written to fail; they should now pass under the same shape.
+
+## Conventions (from CLAUDE.md, non-negotiable)
+
+- Behaviours over protocols. Structured `Sykli.Error` codes, never bare strings.
+- `mix format && mix test && mix credo && mix escript.build` clean before commit.
+- `test/blackbox/run.sh` clean before PR. Specifically: every fixed case must show `passed`, not `xfail`.
+- One PR per logical fix (with the SDK-conformance bundle exception above). Each PR title includes the closed case ID(s).
+- Commit messages cite the case ID and the requirement source.
+- All commits end with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+- Never push to main. Branch + PR.
+
+## Acceptance criteria
+
+After all PRs in this remediation pass merge:
+
+- [ ] **11 GitHub issues** closed (or reframed-and-closed for any finding that turned out to be a wrong requirement).
+- [ ] **`grep '"expected_failure": true' test/blackbox/dataset.json`** returns nothing. The mechanism is gone.
+- [ ] **`grep "expected_failure" test/blackbox/run.sh`** returns nothing (the predicate is removed from the runner).
+- [ ] **`test/blackbox/run.sh`** passes 100% naturally — no expected-fail accounting.
+- [ ] **`tests/conformance/run.sh`** passes for all five SDKs across all listed cases.
+- [ ] **`mix test`, `mix credo`, `mix escript.build`** clean.
+- [ ] **`eval/oracle/findings-phase-2-5.md`** is annotated: each row gains a `Closed by #PR-N` column, and the doc's preamble is updated to "All findings closed as of <date>."
+- [ ] **No regressions** in the 0.6.0 acceptance criteria from the release-and-docs prompt (run those checks again).
+
+## Anti-patterns — do not do these
+
+- ✗ Don't bundle GH-004 (Critical security) with anything else. Solo PR, fast review, fast merge.
+- ✗ Don't remove `expected_failure: true` from a case without fixing the underlying bug. The mark is hiding broken behavior; removing it without fixing is a CI break.
+- ✗ Don't fix the case without fixing the bug. "Make the test pass by changing the assertion" is the inverse failure mode.
+- ✗ Don't open a single mega-PR closing all 11 issues. The audit trail (one PR closes one finding) is what makes this pass auditable. SDK conformance bundle is the single permitted exception.
+- ✗ Don't introduce `expected_failure` for *new* known-broken behavior discovered during this work. Open an issue and either fix it in scope or defer to a follow-up — but don't extend the shrug.
+- ✗ Don't touch the release artifacts, the README, CLAUDE.md, or ADRs.
+- ✗ Don't auto-amend, don't `--no-verify`, don't bypass signing.
+
+## Things to ask if you can
+
+- For SDK conformance findings — should the fix preserve the existing emitted JSON shape (and update conformance fixtures) or change the shape to a new canonical form (and bump SDK semver)? **Default: preserve shape, update fixtures, no semver bump.** Conformance was meant to detect drift; the fix tightens behavior, not the schema.
+- For DET-006 — if the NoWallClock check has a bug that lets `DateTime.utc_now` slip through under specific configurations, should the fix tighten the check across all envs or only the simulator-facing module set? **Default: tighten across all envs that currently run `mix credo`.**
+- For ABN-015 — if the timeout/errored mapping requires changing `Sykli.Executor.run/3`'s status resolution, that's a semantically loaded change. Confirm before merging by re-running the existing executor test suite + a manual smoke against `sykli --timeout=1s` on a 10-second sleep task.
+
+If you cannot ask, use the defaults.
+
+---
+
+**End of prompt.** This is the prompt that closes Phase 2.5. After every PR in this pass merges, the oracle suite has zero `expected_failure` cases, every finding has an issue and a fix PR in `git log`, and the next Codex prompt (PR review primitives) can build on a clean baseline.

--- a/CODEX_PROMPT_PR_REVIEW_PRIMITIVES.md
+++ b/CODEX_PROMPT_PR_REVIEW_PRIMITIVES.md
@@ -1,0 +1,161 @@
+# Codex prompt — PR review primitives (`sykli review`) for v0.6.x
+
+Paste the block below into Codex's chat to start.
+
+---
+
+You are an engineering agent assigned to **building the `sykli review` command and its first five primitives**, the headline new feature of v0.6.x. The command is referenced in the README ("Agentic review as code") and the Roadmap, and was named in ADR-022 as the canonical way reviews become first-class graph nodes.
+
+This is a **substantial feature build** — more than a single Codex run might fit. **Scope it as three commits**, all on one branch, in one PR titled `feat(review): sykli review with five primitives (v0.6.x)`. Ship it as `v0.6.1`. **Take no prisoners.** No demoware, no half-implemented primitives, no hand-waving on the agent-executor abstraction.
+
+This prompt assumes:
+
+1. **PR #127's release-and-docs cleanup has merged** — `v0.6.0` is tagged, README and CLAUDE.md match ADR-022, the package-lock is fresh.
+2. **The Phase 2.5 remediation pass has merged** — `expected_failure: true` is gone from `dataset.json`, all 11 findings closed.
+
+If those baselines are not in place, **stop and surface it.** Do not proceed against an inconsistent main.
+
+## Mission
+
+Implement `sykli review` with five primitives, structured outputs, and an agent-executor abstraction. The command is the first place where ADR-022's claim — *"agents are executors inside the graph, not magical reviewers"* — becomes code.
+
+## Read first, in order
+
+1. **`CLAUDE.md`** at repo root — always-on operating manual. Conventions, JSON envelope, runtime isolation rule, NoWallClock rule.
+2. **`docs/adr/022-execution-graph-compiler-reframing.md`** — the positioning ADR. The "What this enables" section names the five primitives.
+3. **`docs/adr/021-github-native-via-webhook-mesh-receiver.md`** — Phase 3 of ADR-021 mentions `sykli fix` annotations on the PR diff. Your work here is *adjacent* but distinct: review primitives are produced by `sykli review`; Checks API integration is a separate path. Read so you don't duplicate.
+4. **`README.md` "Agentic review as code" section** — the user-visible promise the implementation must fulfill.
+5. **`core/lib/sykli/cli.ex`** — command dispatch surface. You will add a `review` branch.
+6. **`core/lib/sykli/cli/json_response.ex`** — the shared envelope. `sykli review --json` flows through it.
+7. **`core/lib/sykli/fix.ex` + `core/lib/sykli/fix/output.ex`** — closest existing analog. `sykli fix` reads the latest occurrence and renders structured analysis. Your `sykli review` reads a diff and renders structured findings. Same shape, different input source.
+8. **`core/lib/sykli/git.ex` and `core/lib/sykli/git_context.ex`** — diff and git-state utilities. Reuse them.
+
+## Critical context — the most likely places to misstep
+
+- **A primitive is a typed contract, not a prompt.** Every primitive declares: name, input schema, output schema (JSON Schema), executor type. The `Sykli.Review.Primitive` struct is the runtime carrier. The prompt-template-for-an-LLM is one *implementation* of a primitive's executor — not the primitive itself. Confusing the two will produce code that's "send this to Claude with this prompt" instead of "fulfill this contract however you can."
+- **Agents are executors, not the system.** The five primitives ship with **deterministic default executors** that produce real output without an LLM. Claude / Codex / local models can replace any executor, but the default ships green. *No primitive may require an external API to be useful.*
+- **Output is structured JSON, not prose.** Each primitive emits a JSON document conforming to the primitive's output schema. A free-text "summary" field is allowed; *all other fields are typed.* The graph-node consumer reads JSON; the human consumer reads a rendered terminal frame derived from the JSON.
+- **Reviews are graph nodes; the command is the executor.** The user adds `s.Task("review/security").Run("sykli review --primitive security --diff main...HEAD").Outputs("security.json")` to their `sykli.go`. Sykli executes it like any other task. The task's output file is the structured review. Other tasks can `InputFrom(...)` it.
+- **Don't reach for the GitHub API.** The Checks API integration of these reviews is **not in this PR**. ADR-021 Phase 3 owns that. Your `sykli review` writes JSON to disk and stdout; it does not call GitHub. Period.
+- **Default `:test` runtime is `Sykli.Runtime.Fake`.** Tests do not call out to real LLMs, do not network. If a primitive's default executor needs HTTP, it goes through `Sykli.HTTP.ssl_opts/1` and is mocked in tests via behaviour-split — same pattern as `Sykli.GitHub.HttpClient`.
+- **NoWallClock + runtime isolation still apply.** Routing time through the existing `Sykli.GitHub.Clock`-style behaviour split is acceptable; rolling your own `:os.system_time/0` is not.
+
+## Scope — the three commits
+
+This work is one PR, three commits, in this order. Each commit is independently buildable + tested.
+
+### Commit 1: ADR-023 + primitive contract module
+
+Title: `feat(review): add ADR-023 and Sykli.Review.Primitive contract`
+
+Files:
+- `docs/adr/023-pr-review-primitives.md` — Architecture Decision Record. Status: Accepted (this is the authoritative spec). Sections:
+  - Context: ADR-022 reframed reviews as graph nodes. This ADR specifies what a primitive is.
+  - Decision: a Primitive is `{name, version, input_schema, output_schema, default_executor, optional_executors}`. The `sykli review` command resolves a primitive name → executor → produces output.
+  - The five primitives' purposes, input fields, and output schemas (one paragraph each + JSON Schema fragment).
+  - The executor abstraction: `Sykli.Review.Executor.Behaviour` with `run/2` returning `{:ok, Sykli.Review.Result.t()} | {:error, %Sykli.Error{}}`. Implementations: `.Deterministic` (default), `.Claude`, `.Codex`. Selection by env (`SYKLI_REVIEW_EXECUTOR=deterministic|claude|codex`) or `--executor` flag.
+  - Out of scope (this ADR / this v0.6.x ship): the Checks API rendering of review outputs (ADR-021 Phase 3); review primitive marketplace; multi-agent-disagreement aggregation.
+- `core/lib/sykli/review.ex` — public API: `Sykli.Review.run(primitive_name, opts)`, `Sykli.Review.list_primitives/0`, `Sykli.Review.Primitive` struct.
+- `core/lib/sykli/review/primitive.ex` — the struct.
+- `core/lib/sykli/review/result.ex` — the result struct (carries the JSON output + metadata).
+- `core/lib/sykli/review/executor/behaviour.ex` — the behaviour.
+- `core/lib/sykli/review/executor/deterministic.ex` — base impl that primitives default to.
+- `core/lib/sykli/review/registry.ex` — name → primitive mapping. ETS-backed at app start.
+- Tests: `core/test/sykli/review/primitive_test.exs`, `registry_test.exs`, `executor/behaviour_test.exs` covering: registry registration, primitive validation, executor behaviour contract.
+
+This commit ships **no primitives yet** and **no CLI command**. Just the contract and the registry. Foundation only.
+
+### Commit 2: Five primitives + CLI command
+
+Title: `feat(review): add sykli review CLI and five primitives`
+
+Files:
+- `core/lib/sykli/review/primitives/security.ex` — `review/security`. Inputs: diff range. Output: `{summary, severity, findings: [{file, line, kind, evidence, suggested_fix}]}`. Default executor scans the diff for hard-coded secrets via pattern matching (reuse `Sykli.Services.SecretMasker` patterns) + obvious smells (curl piped to bash, eval(env), `--insecure`, etc.). Pure deterministic.
+- `core/lib/sykli/review/primitives/api_breakage.ex` — `review/api-breakage`. Inputs: diff range, optional language hint. Output: `{summary, breakages: [{symbol, kind, before, after, severity}]}`. Default executor walks the diff hunks looking for removed/renamed exported symbols by simple language-aware pattern (Go: `^func [A-Z]`, `^type [A-Z]`; Elixir: `def `, `defp ` distinction; etc.). Pure deterministic.
+- `core/lib/sykli/review/primitives/observability_regression.ex` — `review/observability-regression`. Inputs: diff range. Output: `{summary, regressions: [{kind, file, line, evidence}]}`. Default executor flags removed `Logger.*` calls, removed `:telemetry.execute` calls, removed structured fields. Pure deterministic.
+- `core/lib/sykli/review/primitives/test_coverage_gap.ex` — `review/test-coverage-gap`. Inputs: diff range. Output: `{summary, gaps: [{file, kind, evidence}]}`. Default executor flags new functions/modules in the diff that have no corresponding test file changes (heuristic: every `lib/foo/bar.ex` change should have a `test/foo/bar_test.exs` change in the same diff).
+- `core/lib/sykli/review/primitives/architecture_boundary.ex` — `review/architecture-boundary`. Inputs: diff range. Output: `{summary, violations: [{from, to, rule, evidence}]}`. Default executor checks the existing runtime-isolation invariant + a small declarative ruleset in `core/config/architecture.exs`: e.g., "no module under `cli/` may import a `runtime/` module by class name." Reuses `Sykli.Runtime.Resolver`-style isolation tests.
+- CLI wiring: `core/lib/sykli/cli.ex` adds `["review" | review_args]` branch dispatching to `Sykli.CLI.Review.run/1`. New module `core/lib/sykli/cli/review.ex` parses flags (`--primitive`, `--diff`, `--executor`, `--json`, `--output`), calls `Sykli.Review.run/2`, renders.
+- Renderer: `core/lib/sykli/cli/review_renderer.ex` — terminal output for review results. Follow ADR-020 visual rules: glyphs, accent color, no banned vocabulary. Failure mode (severity ≥ medium) draws a horizontal rule and shows a per-finding block. Stdout JSON via `Sykli.CLI.JsonResponse`.
+- Tests: per-primitive deterministic tests against fixture diffs in `core/test/fixtures/review/<primitive>/`. Each fixture is a `.diff` file and the expected output JSON.
+- One end-to-end black-box case per primitive in `test/blackbox/dataset.json` (`REVIEW-001..005`), each with `expected_exit: 0` and `expect_json_keys: ["ok", "version", "data", "error"]` plus a primitive-specific jq assertion.
+
+### Commit 3: Documentation, dogfood, and roadmap update
+
+Title: `docs(review): wire sykli review into README, CLAUDE.md, and the dogfood pipeline`
+
+Files:
+- `README.md` — replace the "Agentic review as code" section's example with **the now-real** code path. Drop the inline "roadmap" caveat from the example since the command exists. Update the Roadmap section: review primitives moves from "in development" to shipped in 0.6.x.
+- `CLAUDE.md` — add a `Sykli.Review` row to the Key Modules table. Add a brief "Review primitives" subsection under Architectural references explaining the contract and the Default→Claude→Codex executor chain. No more than 15 lines.
+- `docs/reviews.md` — new doc walking through: how to add a primitive, how to swap an executor, the JSON Schema for each shipped primitive's output, the env vars (`SYKLI_REVIEW_EXECUTOR`, primitive-specific overrides). ~100 lines.
+- `sykli.exs` (the dogfood pipeline at repo root) — add a `review/security` task wired into the build to dogfood the feature on every CI run.
+- `CHANGELOG.md` — new `[0.6.1]` entry under Added: review primitives feature, five primitives, executor abstraction, ADR-023.
+
+## Out of scope — DO NOT TOUCH
+
+- ✗ Calling the Checks API to upload review results to GitHub. **ADR-021 Phase 3.** This PR's `sykli review` writes JSON to disk + stdout, full stop.
+- ✗ Calling Claude / Codex / any external LLM API in this PR. The `.Claude` and `.Codex` executor modules are stubs that return `{:error, :not_implemented}` — they exist to prove the abstraction; they will be wired in a follow-up PR with proper auth + cost handling.
+- ✗ Adding new primitives beyond the five named. Six or seven seems "easy" — it's not. Each primitive is a long-lived contract.
+- ✗ The webhook receiver, Phase 2 dispatch path, anything under `core/lib/sykli/github/`. Untouched.
+- ✗ The visual reset modules (`Sykli.CLI.Renderer/Theme/Live/FixRenderer`). Reuse the Theme; do not modify.
+- ✗ The runtime decoupling (`Sykli.Runtime.*`). Untouched.
+- ✗ Adding `sykli review` as a runnable task on a node that doesn't have `git` available. Document the dependency; don't try to bundle git.
+- ✗ Re-introducing `expected_failure: true` for any new known-broken behavior. Open issues instead.
+
+## Conventions (from CLAUDE.md, non-negotiable)
+
+- Behaviour + Real + Fake split for the executor layer.
+- Structured `Sykli.Error` codes: `review.primitive.unknown`, `review.diff.invalid`, `review.executor.unavailable`, etc.
+- `:httpc` callers — `Sykli.HTTP.ssl_opts/1`. Not relevant for the deterministic executors but applies to the Claude/Codex stubs.
+- Stateless modules where possible. The registry is one ETS table at app start; primitives are pure functions. No GenServer per primitive.
+- `mix format && mix test && mix credo && mix escript.build` clean.
+- All commits end with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+
+## Implementation sequence
+
+1. Verify the baseline: `git rev-parse v0.6.0` resolves; `grep '"expected_failure": true' test/blackbox/dataset.json` returns nothing; `head -10 docs/adr/022-execution-graph-compiler-reframing.md | grep "Status: Accepted"` matches. **If any of these fail, STOP** and surface that the prerequisite Codex prompts haven't completed.
+2. Branch: `git checkout main && git pull && git checkout -b feat/review-primitives`.
+3. Commit 1: ADR-023 + contract modules + registry + behaviour + deterministic-base. Tests for the contract surface only (no primitives yet).
+4. Commit 2: five primitive modules + CLI wiring + renderer + per-primitive fixture tests + black-box `REVIEW-*` cases.
+5. Commit 3: README + CLAUDE.md + `docs/reviews.md` + dogfood pipeline + `[0.6.1]` CHANGELOG entry.
+6. Pre-PR gate: `cd core && mix format && mix test && mix credo && mix escript.build`. Then `test/blackbox/run.sh` and `tests/conformance/run.sh`. All clean.
+7. Push, open PR `feat(review): sykli review with five primitives (v0.6.x)`. Body: 1-line summary; bulleted scope per commit; a screenshot of `sykli review --primitive security --diff HEAD~3...HEAD --json | jq '.data'` output run against the repo itself.
+8. After the PR merges, follow up with: `mix.exs` bump to `0.6.1`; SDK manifest bumps to `0.6.1`; CHANGELOG date stamp; tag `v0.6.1`; `gh release create v0.6.1 --notes-file docs/releases/v0.6.1.md` (write that release-notes file as part of this commit chain or a follow-up — your call, document in the PR which).
+
+## Acceptance criteria
+
+- [ ] `./core/sykli review --help` prints usage with the five primitive names and the `--executor`, `--diff`, `--primitive`, `--json`, `--output` flags.
+- [ ] `./core/sykli review --primitive security --diff HEAD~3...HEAD --json` (run on the sykli repo itself) emits a valid JSON envelope with primitive-specific data.
+- [ ] All five primitives pass their fixture tests under `mix test`.
+- [ ] All five `REVIEW-001..005` black-box cases pass without `expected_failure`.
+- [ ] **`SYKLI_REVIEW_EXECUTOR=claude sykli review …`** returns `{ok: false, error: {code: "review.executor.unavailable", …}}` cleanly — the stub is honest about not being wired.
+- [ ] **`SYKLI_REVIEW_EXECUTOR=deterministic`** is the default; running with no env var produces the same output as setting it explicitly.
+- [ ] `mix credo` (NoWallClock satisfied), `mix format` clean.
+- [ ] `tests/conformance/run.sh` still passes for all five SDKs.
+- [ ] ADR-023 status: `Accepted`. README's "Agentic review as code" example is now copy-paste-runnable. Roadmap updated. CLAUDE.md updated.
+- [ ] The dogfood `sykli.exs` pipeline includes a `review/security` task and that task passes on a clean main.
+- [ ] No call to a real LLM API made anywhere in test or default execution paths.
+
+## Anti-patterns — do not do these
+
+- ✗ Don't ship a primitive whose default executor returns `{:error, :requires_llm}`. Every primitive must produce useful output without an external API. **No demoware.**
+- ✗ Don't make the Claude/Codex stubs *do* anything. They exist to prove the abstraction. Wiring them is a follow-up PR with explicit cost/auth design.
+- ✗ Don't smuggle "send this prompt to an LLM" logic into a deterministic executor. If a primitive can only be useful with an LLM, the primitive is wrong-sized for v0.6.x — defer it.
+- ✗ Don't make `sykli review` post to GitHub. JSON to stdout/disk, full stop. The Checks API path is ADR-021 Phase 3.
+- ✗ Don't introduce a new logging library, a new HTTP library, or a new schema validator. Use what's in `mix.lock`. JSON Schema validation can be done with simple pattern matching for v0.6.x; full schema enforcement is a follow-up.
+- ✗ Don't bundle this with the release-and-docs cleanup or the Phase 2.5 fixes. **Three separate prompts, three separate PRs.** Confirm baselines before starting.
+- ✗ Don't `expected_failure` your way out of a hard test. If a primitive can't handle a corner case, fix it or deliberately defer it via a documented limitation in `docs/reviews.md`.
+- ✗ Don't auto-amend, don't `--no-verify`, don't bypass signing.
+
+## Things to ask if you can
+
+- Should `sykli review --primitive security` exit non-zero when severity ≥ medium, like a linter, or always exit 0 with severity in the JSON? **Default: exit 0 always; severity is in the data.** Graph nodes consume the JSON; non-zero exit is the graph engine's job to interpret per-task.
+- Should the deterministic security executor ship with a regex set inline or load from `core/config/review_security.exs`? **Default: inline + override via config file.** Easy to override, no required config.
+- Should `sykli review` cache its outputs by diff hash? **Default: no for v0.6.x.** Reviews are quick; caching adds invalidation complexity. Defer.
+- For `review/test-coverage-gap`, the heuristic is fragile (file naming convention). Should it support a project-specific mapping? **Default: yes, via `core/config/review_coverage.exs` with `{lib_path_pattern, test_path_pattern}` pairs.** Default mapping covers Elixir + Go conventions.
+
+If you cannot ask, use the defaults.
+
+---
+
+**End of prompt.** This is the v0.6.x feature ship. After this PR merges + 0.6.1 tags, ADR-022's positioning ("agents are executors inside the graph") has its first concrete implementation, and the next phase (ADR-021 Phase 3 — review annotations on the PR diff via Checks API) has a real artifact to render.

--- a/CODEX_PROMPT_RELEASE_AND_DOCS.md
+++ b/CODEX_PROMPT_RELEASE_AND_DOCS.md
@@ -1,0 +1,120 @@
+# Codex prompt — Release v0.6.0 properly + close all docs/positioning gaps
+
+Paste the block below into Codex's chat to start.
+
+---
+
+You are an engineering agent assigned to **a release-and-docs cleanup pass** in the `sykli` repository (working directory: `/Users/yair/projects/sykli`, default branch: `main`, remote: `git@github.com:false-systems/sykli.git`).
+
+This is not a feature pass. It is a **finishing pass** on the v0.6.0 release that landed in PR #127 + adjacent docs PRs. The repo is currently in an inconsistent state: code claims `0.6.0`, the last actual release is `v0.5.2`, the README and CLAUDE.md are stale on the new positioning, ADR-022 is marked `Proposed` despite being applied. Your job is to make the release, the documentation, and the canonical positioning all agree. **Take no prisoners. No half-fixes.**
+
+You produce **one PR** (or two, if you split release tagging from doc fixes — see "Splitting" below). Either way, by the time this work merges, every problem listed below is closed.
+
+## Read first, in order
+
+1. **`CLAUDE.md`** at repo root — always-on operating manual. Conventions, build/test commands, the runtime isolation + NoWallClock + JSON envelope rules.
+2. **`docs/adr/022-execution-graph-compiler-reframing.md`** — the canonical positioning. Lead sentence: *"sykli is a compiler for programmable execution graphs."* CI is one use case.
+3. **`docs/adr/020-positioning-and-visual-direction.md`** — superseded for *positioning*; the *visual direction* section remains canonical. Read both clauses in ADR-022's "What does not change" section.
+4. **`docs/releases/v0.6.0.md`** — the release notes file written for this release. Use it as the GitHub Release body.
+5. **`CHANGELOG.md`** entry `[0.6.0] - 2026-04-29` — the canonical change list for this release.
+6. **`README.md`** and **`install.sh`** — installer fetches `releases/latest`. There is currently no `v0.6.0` release, so the installer ships v0.5.2.
+
+## The list (every item below must be closed)
+
+### Release tagging (Critical — without this, the rest is moot)
+
+- [ ] Tag `v0.6.0` at the current `main` HEAD.
+- [ ] Push the tag to origin.
+- [ ] Verify the tag triggers `.github/workflows/release.yml`. If the release workflow does **not** auto-fire on tag, run the equivalent steps locally:
+  - Build the escript (`cd core && mix escript.build`) plus the Burrito-packaged binaries the existing release workflow produces.
+  - Create a GitHub Release at `v0.6.0`, mark it Latest.
+  - Use **`docs/releases/v0.6.0.md`** as the Release body (`gh release create v0.6.0 --notes-file docs/releases/v0.6.0.md`).
+  - Upload all binary artifacts the previous releases (v0.5.2, v0.5.1) had — same naming convention (`sykli-{linux,macos}-{x86_64,aarch64}`).
+- [ ] Verify `curl -fsSL https://raw.githubusercontent.com/yairfalse/sykli/main/install.sh | bash` installs the new binary and `sykli --version` reports `0.6.0`.
+
+### CLAUDE.md (High — operating manual still says the old thing)
+
+- [ ] Rewrite the `## What is Sykli?` section to match ADR-022. Drop the words "AI-native CI engine." The new lead sentence is the ADR-022 thesis: *"sykli is a compiler for programmable execution graphs."* CI is one use case.
+- [ ] Keep the rest of the section's substance: SDKs, JSON task graph emission, BEAM execution, FALSE Protocol occurrences. Reframe them as consequences of the graph model, not as defining features of CI.
+
+### README (High — multiple stale strings + missing commands + hero confusion)
+
+- [ ] Update the hero terminal frame at the top of README.md (around line 34) — replace `local · 0.5.3` with `local · 0.6.0`.
+- [ ] Update the SDK install table (around lines 165, 167):
+  - `sykli = "0.5"` → `sykli = "0.6"`
+  - `{:sykli_sdk, "~> 0.5.1"}` → `{:sykli_sdk, "~> 0.6.0"}`
+  - Leave the unpinned rows (`go get …@latest`, `npm install sykli`, `pip install sykli`) alone.
+- [ ] Add the three real CLI commands missing from the `## CLI` section: `sykli context`, `sykli query`, `sykli report`. Source of truth: `./core/sykli --help`. Do not invent commands; only add ones that exist.
+- [ ] Resolve the "sykli review in the hero" confusion. The Go example block at the top (lines ~10–30) calls `sykli review --primitive api-breakage`, which is a roadmap-only command. Two acceptable resolutions, pick one:
+  1. Keep the hero copy-pasteable: drop the `review` task from the hero example. Move it to a dedicated "Agentic review as code" section example below.
+  2. Add an inline `// roadmap: ships in 0.6.x — see Roadmap section` comment immediately above the `s.Task("review")` line in the hero.
+
+### Lockfile (High — committed package-lock.json points at 0.5.3)
+
+- [ ] In `sdk/typescript/`, run `npm install` (no args) to regenerate `package-lock.json` against the new `0.6.0` package.json. Commit the regenerated lockfile.
+- [ ] If `node_modules/` shows up in the diff, do not commit it; the existing `.gitignore` covers it.
+
+### ADR housekeeping (Medium)
+
+- [ ] Flip **ADR-022** from `**Status:** Proposed` to `**Status:** Accepted`. The README rewrite shipped; the repo About changed; treating the ADR as merely Proposed is dishonest about adopted state.
+- [ ] **ADR-020** stays `Proposed` overall (its visual direction is still proposal-grade until promoted in a future ADR), but add a one-line note immediately below its Status line: `> Positioning section superseded by ADR-022 (2026-05-01). Visual direction remains canonical.` This makes the partial-supersedence visible to anyone reading ADR-020 cold.
+
+### Workflow secret + slash command verification (Medium)
+
+PR #132 added `claude.yml` and `claude-code-review.yml`. Verify both are wired correctly:
+
+- [ ] Confirm the `CLAUDE_CODE_OAUTH_TOKEN` secret is set in repo Actions secrets. Run `gh secret list` to check. If missing, document it in the PR body and **do not silently assume it's set** — flag it.
+- [ ] Open a tiny test PR (no-op edit, e.g., a typo fix in a comment) targeting `main` from a fresh branch to see whether `claude-code-review.yml` runs end-to-end. Verify `claude-code-review.yml`'s slash-command syntax (`prompt: '/code-review:code-review …'`) actually invokes a review run. If it errors, capture the error and surface it — do not "fix" it by changing the prompt format unless the error is unambiguous.
+
+## Splitting
+
+You may produce **one combined PR** (recommended for tight review) or **two PRs**:
+
+1. `chore(release): tag v0.6.0 and ship binaries` — release tag, GitHub Release creation, binary uploads. No code or doc changes. Merges fast.
+2. `docs: close v0.6 positioning + staleness gaps` — README + CLAUDE.md + ADRs + lockfile + workflow verification. Merges after #1.
+
+If splitting, do them in that order. If combining, the title is `chore: complete v0.6.0 release + close docs gaps`.
+
+## Out of scope — DO NOT TOUCH
+
+- ✗ Any module under `core/lib/sykli/` (this is a release/docs pass, not feature work).
+- ✗ Any new ADR (only edits to ADR-020 status note + ADR-022 status flip).
+- ✗ Phase 2.5 findings (`eval/oracle/findings-phase-2-5.md`) — **separate Codex prompt remediates these**. Do not remove `expected_failure: true` from any case here.
+- ✗ The PR review feature (`sykli review`) — separate Codex prompt builds it.
+- ✗ Changes to `.github/workflows/release.yml`, `.github/workflows/sykli-ci.yml`, or `.github/workflows/ci.yml` unless you find them broken during the release run, in which case fix the smallest possible thing and document why.
+
+## Conventions (from CLAUDE.md, non-negotiable)
+
+- `mix format && mix test && mix credo && mix escript.build` before commit.
+- No new dependencies.
+- `~s()` parens gotcha; heredoc gotcha. Fixtures stay single-line where possible.
+- Commits ending with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+- Never push directly to `main`. Branch + PR only.
+
+## Acceptance criteria
+
+Every item below must be true before requesting review:
+
+- [ ] `git tag --list | grep v0.6.0` returns the tag.
+- [ ] `gh release list | head -1` shows `v0.6.0` as Latest.
+- [ ] `curl -fsSL https://raw.githubusercontent.com/yairfalse/sykli/main/install.sh | bash` (run in a clean dir) installs a binary that reports `sykli 0.6.0`.
+- [ ] `grep -E "0\.5\.3|0\.5\.1" README.md sdk/typescript/package-lock.json` returns nothing.
+- [ ] `grep "AI-native CI" CLAUDE.md` returns nothing.
+- [ ] `head -10 docs/adr/022-execution-graph-compiler-reframing.md | grep "Status:"` returns `Status: Accepted`.
+- [ ] `head -10 docs/adr/020-positioning-and-visual-direction.md` includes the partial-supersedence note.
+- [ ] `./core/sykli --help` and the README CLI section list the same commands.
+- [ ] `cd core && mix test && mix credo` clean. `test/blackbox/run.sh` passes (any pre-existing `expected_failure` cases stay as they are — out of scope).
+- [ ] Workflow secret check is documented in the PR body (set / missing / unverified).
+
+## Anti-patterns — do not do these
+
+- ✗ Don't merge the docs PR without tagging the release. The whole point is they go together.
+- ✗ Don't ship binaries that don't pass `sykli --version` reporting `0.6.0`.
+- ✗ Don't paper over the `claude-code-review.yml` slash-command issue if you find one — surface it.
+- ✗ Don't touch any `expected_failure: true` case in `dataset.json`. **That is a different prompt's job.**
+- ✗ Don't add a "review primitive" section to the README beyond what's already there. **That is a different prompt's job.**
+- ✗ Don't auto-amend, don't `--no-verify`, don't bypass signing.
+
+---
+
+**End of prompt.** When this PR (or pair) merges, the v0.6.0 release is real, the docs match it, and the next two Codex prompts (Phase 2.5 fixes + PR review primitives) can run cleanly against a coherent baseline.


### PR DESCRIPTION
## Summary

Three sequenced Codex prompts that, run in order, close every problem flagged in the review of PRs #127–#132 and ship the v0.6.x feature lacuna named in ADR-022.

## The three prompts

| Order | File | Scope | Estimated PRs it generates |
|---|---|---|---|
| **1** | \`CODEX_PROMPT_RELEASE_AND_DOCS.md\` (120 lines) | Tag v0.6.0, ship binaries, sync README + CLAUDE.md to ADR-022, flip ADR-022 to Accepted, regenerate typescript lockfile, fix README hero confusion, verify Claude Code workflow secret | 1 (or 2 if split: release-tag + docs-sync) |
| **2** | \`CODEX_PROMPT_PHASE_2_5_FIXES.md\` (138 lines) | Open 1 issue per Phase 2.5 finding (11 total), fix each in a dedicated PR starting with GH-004 (Critical, path traversal). Removes \`expected_failure: true\` from each case as the underlying bug is fixed; deletes the predicate from run.sh after all 11 close | ~6 (1 GH-004 solo, 1 SDK conformance bundle, 4 individual + 1 cleanup) |
| **3** | \`CODEX_PROMPT_PR_REVIEW_PRIMITIVES.md\` (161 lines) | Build \`sykli review\` with 5 primitives + executor abstraction from ADR-022 + new ADR-023. Ships as v0.6.1 | 1 (3-commit feature PR + a 0.6.1 release follow-up) |

## Sequencing

Strict order: **1 → 2 → 3**. Each prompt explicitly checks its prerequisites and stops if the baseline is wrong.

- Prompt 2 needs prompt 1 done (clean v0.6.0 baseline before remediation).
- Prompt 3 needs prompts 1+2 done (clean baseline + zero \`expected_failure\` cases before adding the feature).

## What's flagged that the prompts close

### Critical
- v0.6.0 not tagged, installer ships v0.5.2 → **Prompt 1**
- 11 Phase 2.5 findings hidden by \`expected_failure: true\`, including a Critical security gap (GH-004 path traversal) → **Prompt 2**
- Zero GitHub issues track those findings → **Prompt 2**

### High
- CLAUDE.md "What is Sykli?" still says "AI-native CI engine" — contradicts ADR-022 → **Prompt 1**
- ADR-022 marked Proposed despite being applied → **Prompt 1**
- README terminal frame stuck on \`0.5.3\` → **Prompt 1**
- README SDK install table stuck on \`0.5\` and \`0.5.1\` → **Prompt 1**
- \`sdk/typescript/package-lock.json\` still says \`0.5.3\` → **Prompt 1**

### Medium
- \`expected_failure: true\` mechanism encodes broken behavior as spec → **Prompt 2** (mechanism removed entirely)
- README missing \`sykli context\`, \`query\`, \`report\` from CLI section → **Prompt 1**
- Workflow secret + slash-command verification (PR #132) → **Prompt 1**

### Low
- README hero example uses \`sykli review\` (roadmap-only) — drop or mark inline → **Prompt 1** + made real by **Prompt 3**

## What \`take no prisoners\` looks like in the prompts

- Each prompt has explicit acceptance criteria. Examples from prompt 1: \`grep "AI-native CI" CLAUDE.md\` returns nothing; \`gh release list | head -1\` shows \`v0.6.0\` as Latest; \`curl … install.sh | bash\` produces \`sykli 0.6.0\`.
- Prompt 2 forbids removing \`expected_failure\` without fixing the underlying bug, AND forbids fixing the bug while leaving the case red.
- Prompt 3 explicitly forbids "demoware" — every primitive must produce useful output without an external LLM API. Default executor is deterministic; Claude/Codex executor stubs return a structured error.
- All three forbid auto-amend, \`--no-verify\`, signing bypass, scope creep into other prompts' territory.

## What the prompts do NOT do

- They are **prompts**, not implementations. This PR ships only the markdown files. Codex runs each one separately to produce the actual implementation PRs.
- They reference ADR-023 (defined inside Prompt 3 itself) as the spec for review primitives. Prompt 3's first commit creates ADR-023; prompts 1–2 don't touch it.

## Test plan

- [x] All three prompts cite real, current paths (CLAUDE.md, ADRs, dataset.json, findings doc, fix module, etc.).
- [x] Cross-references between prompts are explicit (each names the others as out-of-scope).
- [x] Acceptance criteria are observable (greppable strings, exit codes, command outputs) — not opinions.
- [ ] Once merged: paste each into a fresh Codex run in order, expect one or more PRs per prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)