### PR TITLE
chore: complete v0.6.0 release + close docs gaps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             os: ubuntu-latest
             burrito_target: linux_aarch64
           - target: macos-x86_64
-            os: macos-15-large
+            os: macos-13
             burrito_target: macos_x86_64
           - target: macos-aarch64
             os: macos-14
@@ -40,7 +40,16 @@ jobs:
 
       - name: Install Zig (macOS)
         if: runner.os == 'macOS'
-        run: brew install zig xz
+        run: |
+          brew install xz
+          case "${{ matrix.burrito_target }}" in
+            macos_x86_64) zig_arch="x86_64-macos" ;;
+            macos_aarch64) zig_arch="aarch64-macos" ;;
+            *) echo "unsupported macOS target: ${{ matrix.burrito_target }}" && exit 1 ;;
+          esac
+          curl -fsSLO "https://ziglang.org/download/0.15.2/zig-$zig_arch-0.15.2.tar.xz"
+          tar -xf "zig-$zig_arch-0.15.2.tar.xz"
+          echo "$PWD/zig-$zig_arch-0.15.2" >> $GITHUB_PATH
 
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
@@ -73,6 +82,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -97,4 +108,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: release/*
-          generate_release_notes: true
+          body_path: docs/releases/v0.6.0.md
+          make_latest: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is Sykli?
 
-AI-native CI engine. Pipelines are written as real code (Go/Rust/TypeScript/Elixir/Python SDKs), emitted as JSON task graphs, and executed by an Elixir/BEAM engine. Every run produces structured context (FALSE Protocol occurrences) that AI assistants can read directly — no log parsing.
+sykli is a compiler for programmable execution graphs. Graphs are written as real code (Go/Rust/TypeScript/Elixir/Python SDKs), emitted as JSON task plans, and executed by an Elixir/BEAM engine. CI is one use case of the graph model; every run also produces structured context (FALSE Protocol occurrences) that agents and downstream tools can read directly — no log parsing.
 
 ## Build & Test Commands
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ func main() {
         After("test").
         Outputs("app")
 
+    // roadmap: ships in 0.6.x — see Roadmap section
     s.Task("review").
         Run("sykli review --primitive api-breakage --diff main...HEAD").
         After("test").
@@ -31,7 +32,7 @@ func main() {
 ```
 
 ```
-sykli · pipeline.go                                local · 0.5.3
+sykli · pipeline.go                                local · 0.6.0
 
   ●  test     go test ./...                        108ms
   ●  build    go build -o app                      612ms
@@ -162,9 +163,9 @@ Requires Elixir 1.14+.
 | Language | Install | File |
 |----------|---------|------|
 | **Go** | `go get github.com/yairfalse/sykli/sdk/go@latest` | `sykli.go` |
-| **Rust** | `sykli = "0.5"` in Cargo.toml | `sykli.rs` |
+| **Rust** | `sykli = "0.6"` in Cargo.toml | `sykli.rs` |
 | **TypeScript** | `npm install sykli` | `sykli.ts` |
-| **Elixir** | `{:sykli_sdk, "~> 0.5.1"}` in mix.exs | `sykli.exs` |
+| **Elixir** | `{:sykli_sdk, "~> 0.6.0"}` in mix.exs | `sykli.exs` |
 | **Python** | `pip install sykli` | `sykli.py` |
 
 All SDKs share the same API surface. The file lives at the project root.
@@ -222,9 +223,12 @@ sykli delta               # only tasks affected by git changes
 sykli watch               # re-run on file changes
 sykli explain             # show last run as AI-readable report
 sykli fix                 # AI-readable failure analysis with source context
+sykli context             # generate AI context file (.sykli/context.json)
+sykli query               # query pipeline, history, and health data
 sykli graph               # mermaid / DOT diagram of the DAG
 sykli verify              # cross-platform verification via mesh
 sykli history             # recent runs
+sykli report              # show last run summary with task results
 sykli cache stats         # cache hit rates
 sykli daemon start        # start a mesh node on this host
 sykli mcp                 # MCP server (Claude Code, Cursor, Copilot)

--- a/core/mix.exs
+++ b/core/mix.exs
@@ -52,7 +52,7 @@ defmodule Sykli.MixProject do
       {:yaml_elixir, "~> 2.9"},
       {:file_system, "~> 1.0"},
       {:telemetry, "~> 1.3"},
-      {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
+      {:credo, "~> 1.7", runtime: false},
       {:mix_audit, "~> 2.1", only: :dev, runtime: false},
       {:stream_data, "~> 1.1", only: :test}
     ]

--- a/docs/adr/020-positioning-and-visual-direction.md
+++ b/docs/adr/020-positioning-and-visual-direction.md
@@ -1,6 +1,8 @@
 # ADR-020: Positioning, Audience, and Visual Direction
 
 **Status:** Proposed
+> Positioning section superseded by ADR-022 (2026-05-01). Visual direction remains canonical.
+
 **Date:** 2026-04-27
 
 ---

--- a/docs/adr/022-execution-graph-compiler-reframing.md
+++ b/docs/adr/022-execution-graph-compiler-reframing.md
@@ -1,6 +1,6 @@
 # ADR-022: Reframing sykli as an Execution Graph Compiler
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-01
 **Supersedes:** ADR-020 (positioning section only; visual direction preserved)
 

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sykli",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sykli",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.0.0",


### PR DESCRIPTION
Summary: closes the v0.6.0 release/docs drift so the release, docs, ADR state, and installer path can converge on 0.6.0.\n\nScope:\n- Reframes CLAUDE.md around ADR-022's execution graph compiler positioning.\n- Updates README hero/version/install table/CLI command list and marks the hero review task as roadmap.\n- Accepts ADR-022 and marks ADR-020 positioning as superseded while preserving visual direction.\n- Regenerates sdk/typescript/package-lock.json root package metadata to 0.6.0.\n- Fixes release workflow blockers found on the first v0.6.0 tag run: macOS x86 runner label, pinned macOS Zig 0.15.2, release notes from docs/releases/v0.6.0.md, and Latest marking.\n- Makes Credo available at compile time for prod release builds while keeping it runtime:false, fixing the failed Burrito build.\n\nVerification:\n- mix format\n- mix test: 1433 tests, 0 failures, 1 skipped, 13 excluded\n- mix credo: no issues\n- mix escript.build\n- ./core/sykli --help\n- ./core/sykli --version -> sykli 0.6.0\n- test/blackbox/run.sh: 137 passed, 11 expected-red, 0 failed\n- Prod release smoke: local MIX_ENV=prod BURRITO_TARGET=linux_x86_64 mix release now compiles through sykli; local wrap stops only because local Zig is 0.16.0 and Burrito requires 0.15.2. Workflow now pins 0.15.2 on Linux and macOS.\n\nRelease status:\n- CLAUDE_CODE_OAUTH_TOKEN secret: set in repo Actions secrets.\n- v0.6.0 tag currently exists from the first attempt, but the workflow failed before release creation. After this PR merges, retag v0.6.0 at the merged HEAD and push the corrected tag so release.yml creates the GitHub Release from docs/releases/v0.6.0.md.\n- gh release view v0.6.0 currently reports release not found; v0.5.2 remains Latest until the corrected tag run succeeds.\n\nNotes:\n- The broad acceptance grep for 0.5.1 still matches a transitive npm package, local-pkg-0.5.1, inside package-lock.json. The stale sykli package-lock root version is fixed to 0.6.0; I did not alter unrelated transitive dependency metadata.