### PR TITLE
test: smoke Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,7 +3,7 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
+    # Optional: Only run on selected file changes
     # paths:
     #   - "src/**/*.ts"
     #   - "src/**/*.tsx"
@@ -41,4 +41,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
Tiny no-op PR to verify claude-code-review.yml runs end-to-end with the configured slash-command prompt. This PR is for workflow verification only and should be closed after the check result is captured.