### PR TITLE
ci(release): pin OTP patch for Burrito runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: '26'
+          otp-version: '26.2.5.14'
           elixir-version: '1.17'
 
       - name: Install dependencies


### PR DESCRIPTION
Summary: pins release builds to OTP 26.2.5.14 because Burrito/Beam Machine currently returns 404 for the floating OTP 26.2.5.20 runtime selected by setup-beam.

Scope:
- Change release.yml setup-beam from floating `26` to exact `26.2.5.14`.
- Verified Beam Machine has 26.2.5.14 artifacts for linux x86_64, linux aarch64, and macOS universal via HEAD requests.

Context:
- v0.6.0 tag run 25216055160 failed after #134 merged because Burrito requested OTP-26.2.5.20 and the CDN returned 404.
- After this merges, retag v0.6.0 to the new main HEAD and rerun the release workflow.