### PR TITLE
ci(release): use current macOS Intel runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             os: ubuntu-latest
             burrito_target: linux_aarch64
           - target: macos-x86_64
-            os: macos-13
+            os: macos-15-intel
             burrito_target: macos_x86_64
           - target: macos-aarch64
             os: macos-14


### PR DESCRIPTION
Summary: replaces the retired/stuck macOS 13 Intel runner with the current GitHub-hosted Intel macOS label.

Scope:
- Change the macos-x86_64 release build from `macos-13` to `macos-15-intel`.

Context:
- v0.6.0 tag run 25235729344 built linux-x86_64, linux-aarch64, and macos-aarch64 successfully, then sat with macos-x86_64 queued and no runner assigned.
- GitHub Actions guidance says macOS 13 is retired and Intel macOS users should migrate to `macos-15-intel`.
- After this merges, retag v0.6.0 to the new main HEAD and rerun the release workflow.