### PR TITLE
feat(graph): add review nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The engine runs on the BEAM VM. Same code on your laptop, in Docker, on Kubernet
 
 SYKLI Reviews are experimental. A review node represents a structured review step in the execution graph; it does not yet run Codex, Claude, or any other provider directly. It models the review step so future runners can execute agents in a controlled, inspectable way.
 
+The builder API is currently available in the Go SDK only. Rust, TypeScript, Elixir, and Python SDK builders still need parity work; until then, review nodes are an experimental Go-first graph feature.
+
 Agentic workflows need primitives, not prompts. Asking an LLM to "review this PR" is too underspecified to be repeatable. Defining a review node with constrained inputs, expected outputs, and explicit rules is.
 
 ```go

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ func main() {
         After("test").
         Outputs("app")
 
-    // roadmap: ships in 0.6.x — see Roadmap section
-    s.Task("review").
-        Run("sykli review --primitive api-breakage --diff main...HEAD").
+    s.Review("review:api-breakage").
+        Primitive("api-breakage").
+        Agent("local").
+        Diff("main...HEAD").
+        Context("README.md", "docs/architecture.md").
         After("test").
-        Outputs("review.json")
+        Outputs("reviews/api-breakage.json")
 
     s.Emit()
 }
@@ -36,12 +38,12 @@ sykli · pipeline.go                                local · 0.6.0
 
   ●  test     go test ./...                        108ms
   ●  build    go build -o app                      612ms
-  ●  review   sykli review --primitive ...         842ms
+  ○  review:api-breakage   api-breakage            planned
 
-  ─  3 passed                                      1.2s
+  ─  2 passed · 1 review planned                   720ms
 ```
 
-The `review` task is just another node in the graph. It can be executed locally, in GitHub Actions, in another CI provider, or by an agent-aware runtime. The graph doesn't care.
+The `review:api-breakage` node is not a shell task. It is a structured review node in the graph: primitive, agent identifier, diff input, context files, dependencies, outputs, and `deterministic: false`.
 
 ---
 
@@ -89,20 +91,18 @@ The engine runs on the BEAM VM. Same code on your laptop, in Docker, on Kubernet
 
 ## Agentic review as code
 
-Agentic workflows need primitives, not prompts. Asking an LLM to "review this PR" is too underspecified to be repeatable. Defining a review *task* with constrained inputs, expected outputs, and explicit rules is.
+SYKLI Reviews are experimental. A review node represents a structured review step in the execution graph; it does not yet run Codex, Claude, or any other provider directly. It models the review step so future runners can execute agents in a controlled, inspectable way.
+
+Agentic workflows need primitives, not prompts. Asking an LLM to "review this PR" is too underspecified to be repeatable. Defining a review node with constrained inputs, expected outputs, and explicit rules is.
 
 ```go
-s.Task("review/api-breakage").
-    Run("sykli review --primitive api-breakage --diff main...HEAD").
-    Outputs("api-review.json")
-
-s.Task("review/security").
-    Run("sykli review --primitive security --diff main...HEAD").
-    Outputs("security-review.json")
-
-s.Task("review/observability-regression").
-    Run("sykli review --primitive observability-regression").
-    Outputs("obs-review.json")
+s.Review("review:api-breakage").
+    Primitive("api-breakage").
+    Agent("local").
+    Diff("main...HEAD").
+    Context("README.md", "docs/architecture.md").
+    After("test").
+    Outputs("reviews/api-breakage.json")
 ```
 
 A review primitive is a node with:
@@ -111,9 +111,11 @@ A review primitive is a node with:
 - **Expected outputs.** A structured JSON report at a known path. Not freeform commentary.
 - **Explicit rules.** What counts as an api breakage, what counts as a coverage gap, what counts as an architecture-boundary violation.
 
-Agents — Claude, Codex, local models, deterministic linters — are executors inside the graph. Different runtimes can fulfill the same primitive. The graph is the contract; the executor is an implementation detail.
+Task nodes model deterministic work such as build and test commands. Review nodes model non-deterministic evaluation work such as agent review; they are `deterministic: false` by default.
 
-Planned primitives: `review/security`, `review/api-breakage`, `review/observability-regression`, `review/test-coverage-gap`, `review/architecture-boundary`. The `sykli review` command is on the roadmap; the design above is the shape it will take.
+Agents — local tools, hosted models, or deterministic linters — are executors inside the graph. Different runtimes can fulfill the same primitive. The graph is the contract; the executor is an implementation detail.
+
+Planned primitives: `security-boundaries`, `api-breakage`, `behavior-regression`, `test-coverage-gap`, `architecture-boundary`. Provider calls, prompt templates, and review-result occurrences are future work.
 
 ## Use cases
 

--- a/core/lib/sykli/explain.ex
+++ b/core/lib/sykli/explain.ex
@@ -231,11 +231,14 @@ defmodule Sykli.Explain do
 
       history_hint = format_history_hint(task)
 
-      %{
+      base = %{
         name: task.name,
+        kind: Task.kind(task) |> Atom.to_string(),
         command: task.command,
         inputs: Task.inputs(task),
+        outputs: Task.outputs(task),
         depends_on: Task.depends_on(task),
+        deterministic: Task.deterministic?(task),
         blocks: task_blocks,
         cacheable: Task.cacheable?(task),
         level: Map.get(level_lookup, task.name, 0),
@@ -245,6 +248,15 @@ defmodule Sykli.Explain do
         estimated_duration_ms: Map.get(duration_map, task.name),
         history_hint: history_hint
       }
+
+      if Task.review?(task) do
+        base
+        |> Map.put(:primitive, Task.primitive(task))
+        |> Map.put(:agent, Task.agent(task))
+        |> Map.put(:context, Task.context(task))
+      else
+        base
+      end
     end)
     |> Enum.sort_by(& &1.level)
   end

--- a/core/lib/sykli/graph.ex
+++ b/core/lib/sykli/graph.ex
@@ -15,6 +15,11 @@ defmodule Sykli.Graph do
     defstruct [:from_task, :output, :dest]
   end
 
+  defmodule Review do
+    @moduledoc "Represents review-node metadata"
+    defstruct primitive: nil, agent: nil, context: [], deterministic: false
+  end
+
   defmodule Task do
     @moduledoc """
     Represents a single task in the pipeline.
@@ -61,9 +66,11 @@ defmodule Sykli.Graph do
     alias Sykli.Graph.Task.HistoryHint
     alias Sykli.Graph.Task.Capability
     alias Sykli.Graph.Task.Gate
+    alias Sykli.Graph.Review
 
     defstruct [
       :name,
+      :kind,
       :command,
       :inputs,
       :outputs,
@@ -116,7 +123,9 @@ defmodule Sykli.Graph do
       # Cross-platform verification mode ("cross_platform", "always", "never", or nil)
       :verify,
       # Secret references (env or file-based)
-      :secret_refs
+      :secret_refs,
+      # Review node metadata
+      :review
     ]
 
     @type t :: %__MODULE__{}
@@ -128,6 +137,11 @@ defmodule Sykli.Graph do
     @doc "Returns the task name."
     @spec name(t()) :: String.t()
     def name(%__MODULE__{name: n}), do: n
+
+    @doc "Returns the graph node kind."
+    @spec kind(t()) :: :task | :review
+    def kind(%__MODULE__{kind: :review}), do: :review
+    def kind(_), do: :task
 
     @doc "Returns the task command."
     @spec command(t()) :: String.t()
@@ -152,6 +166,32 @@ defmodule Sykli.Graph do
     @doc "Returns the outputs (map or list)."
     @spec outputs(t()) :: map() | [String.t()]
     def outputs(%__MODULE__{outputs: o}), do: o || %{}
+
+    @doc "Returns true when this node is a review."
+    @spec review?(t()) :: boolean()
+    def review?(%__MODULE__{} = task), do: kind(task) == :review
+
+    @doc "Returns the review primitive for review nodes."
+    @spec primitive(t()) :: String.t() | nil
+    def primitive(%__MODULE__{review: %Review{primitive: primitive}}), do: primitive
+    def primitive(_), do: nil
+
+    @doc "Returns the review agent for review nodes."
+    @spec agent(t()) :: String.t() | nil
+    def agent(%__MODULE__{review: %Review{agent: agent}}), do: agent
+    def agent(_), do: nil
+
+    @doc "Returns review context files."
+    @spec context(t()) :: [String.t()]
+    def context(%__MODULE__{review: %Review{context: context}}), do: context || []
+    def context(_), do: []
+
+    @doc "Returns whether the node is deterministic."
+    @spec deterministic?(t()) :: boolean()
+    def deterministic?(%__MODULE__{kind: :review, review: %Review{deterministic: value}}),
+      do: value
+
+    def deterministic?(_), do: true
 
     @doc "Returns the list of task dependencies."
     @spec depends_on(t()) :: [String.t()]
@@ -243,6 +283,7 @@ defmodule Sykli.Graph do
 
     @doc "Checks if the task is cacheable (has inputs defined)."
     @spec cacheable?(t()) :: boolean()
+    def cacheable?(%__MODULE__{kind: :review}), do: false
     def cacheable?(%__MODULE__{inputs: i}), do: i != nil && i != []
 
     @doc "Checks if the task has retry enabled."
@@ -326,15 +367,17 @@ defmodule Sykli.Graph do
 
   defp parse_task(map) do
     task_name = map["name"]
+    kind = parse_kind(map["kind"])
 
     with {:ok, services} <- parse_services(map["services"], task_name),
          {:ok, mounts} <- parse_mounts(map["mounts"], task_name) do
       {:ok,
        %Task{
          name: task_name,
+         kind: kind,
          command: map["command"],
          inputs: map["inputs"] || [],
-         outputs: normalize_outputs(map["outputs"]),
+         outputs: normalize_outputs(map["outputs"], kind),
          depends_on: (map["depends_on"] || []) |> Enum.uniq(),
          condition: map["when"] || map["condition"],
          # CI features
@@ -364,10 +407,26 @@ defmodule Sykli.Graph do
          gate: Task.Gate.from_map(map["gate"]),
          oidc: Task.CredentialBinding.from_map(map["oidc"]),
          verify: map["verify"],
-         secret_refs: parse_secret_refs(map["secret_refs"])
+         secret_refs: parse_secret_refs(map["secret_refs"]),
+         review: parse_review(map, kind)
        }}
     end
   end
+
+  defp parse_kind("review"), do: :review
+  defp parse_kind(:review), do: :review
+  defp parse_kind(_), do: :task
+
+  defp parse_review(map, :review) do
+    %Review{
+      primitive: map["primitive"],
+      agent: map["agent"],
+      context: map["context"] || [],
+      deterministic: Map.get(map, "deterministic", false)
+    }
+  end
+
+  defp parse_review(_map, _kind), do: nil
 
   defp parse_task_inputs(nil), do: []
 
@@ -440,16 +499,19 @@ defmodule Sykli.Graph do
 
   # Handle both v1 (list) and v2 (map) output formats
   # v2 keeps outputs as map for named artifact passing
-  defp normalize_outputs(nil), do: %{}
+  defp normalize_outputs(nil, :review), do: []
+  defp normalize_outputs(nil, _kind), do: %{}
 
-  defp normalize_outputs(outputs) when is_list(outputs) do
+  defp normalize_outputs(outputs, :review) when is_list(outputs), do: outputs
+
+  defp normalize_outputs(outputs, _kind) when is_list(outputs) do
     # v1: list of paths - convert to auto-named map for consistency
     outputs
     |> Enum.with_index()
     |> Map.new(fn {path, idx} -> {"output_#{idx}", path} end)
   end
 
-  defp normalize_outputs(outputs) when is_map(outputs), do: outputs
+  defp normalize_outputs(outputs, _kind) when is_map(outputs), do: outputs
 
   @doc """
   Expands matrix tasks into individual tasks.

--- a/core/lib/sykli/plan.ex
+++ b/core/lib/sykli/plan.ex
@@ -139,6 +139,7 @@ defmodule Sykli.Plan do
 
         base = %{
           name: name,
+          kind: Task.kind(task) |> Atom.to_string(),
           command: task.command,
           reason: reason_str,
           triggered_by: triggered_by,
@@ -146,8 +147,21 @@ defmodule Sykli.Plan do
           cache_reason: if(cache_info.reason, do: Atom.to_string(cache_info.reason)),
           level: level,
           depends_on: Task.depends_on(task),
+          deterministic: Task.deterministic?(task),
           blocks: task_blocks
         }
+
+        base =
+          if Task.review?(task) do
+            base
+            |> Map.put(:primitive, Task.primitive(task))
+            |> Map.put(:agent, Task.agent(task))
+            |> Map.put(:inputs, Task.inputs(task))
+            |> Map.put(:context, Task.context(task))
+            |> Map.put(:outputs, Task.outputs(task))
+          else
+            base
+          end
 
         # Add depends_on_affected for dependent tasks
         if affected_info.reason == :dependent do
@@ -188,6 +202,7 @@ defmodule Sykli.Plan do
     %{
       version: @schema_version,
       from: from,
+      nodes: build_nodes(graph),
       changed_files: changed_files,
       plan: %{
         task_count: length(plan_tasks),
@@ -204,6 +219,30 @@ defmodule Sykli.Plan do
   defp format_reason(:direct), do: "direct"
   defp format_reason(:dependent), do: "dependent"
   defp format_reason(other), do: to_string(other)
+
+  defp build_nodes(graph) do
+    graph
+    |> Enum.map(fn {name, task} ->
+      base = %{
+        id: name,
+        kind: Task.kind(task) |> Atom.to_string(),
+        inputs: Task.inputs(task),
+        outputs: Task.outputs(task),
+        depends_on: Task.depends_on(task),
+        deterministic: Task.deterministic?(task)
+      }
+
+      if Task.review?(task) do
+        base
+        |> Map.put(:primitive, Task.primitive(task))
+        |> Map.put(:agent, Task.agent(task))
+        |> Map.put(:context, Task.context(task))
+      else
+        Map.put(base, :command, task.command)
+      end
+    end)
+    |> Enum.sort_by(& &1.id)
+  end
 
   defp build_duration_map(nil), do: %{}
 

--- a/core/lib/sykli/validate.ex
+++ b/core/lib/sykli/validate.ex
@@ -232,7 +232,7 @@ defmodule Sykli.Validate do
     |> Enum.filter(fn t -> valid_name?(t["name"]) end)
     |> Enum.reject(fn t ->
       # Gate tasks don't need a command
-      t["gate"] != nil
+      t["gate"] != nil or t["kind"] == "review"
     end)
     |> Enum.filter(fn t ->
       cmd = t["command"]

--- a/core/test/core_test.exs
+++ b/core/test/core_test.exs
@@ -7,6 +7,25 @@ defmodule SykliTest do
     assert Map.has_key?(graph, "test")
   end
 
+  test "parses review nodes with metadata" do
+    json =
+      ~s({"tasks":[{"name":"test","command":"go test ./..."},{"name":"review:api-breakage","kind":"review","primitive":"api-breakage","agent":"local","inputs":["main...HEAD"],"context":["README.md","docs/architecture.md"],"outputs":["reviews/api-breakage.local.json"],"depends_on":["test"],"deterministic":false}]})
+
+    assert {:ok, graph} = Sykli.Graph.parse(json)
+    review = Map.fetch!(graph, "review:api-breakage")
+
+    assert Sykli.Graph.Task.review?(review)
+    assert Sykli.Graph.Task.kind(review) == :review
+    assert Sykli.Graph.Task.primitive(review) == "api-breakage"
+    assert Sykli.Graph.Task.agent(review) == "local"
+    assert Sykli.Graph.Task.inputs(review) == ["main...HEAD"]
+    assert Sykli.Graph.Task.context(review) == ["README.md", "docs/architecture.md"]
+    assert Sykli.Graph.Task.outputs(review) == ["reviews/api-breakage.local.json"]
+    assert Sykli.Graph.Task.depends_on(review) == ["test"]
+    refute Sykli.Graph.Task.deterministic?(review)
+    refute Sykli.Graph.Task.cacheable?(review)
+  end
+
   test "topo sort with no deps" do
     json = ~s({"tasks":[{"name":"a","command":"a"},{"name":"b","command":"b"}]})
     {:ok, graph} = Sykli.Graph.parse(json)

--- a/core/test/sykli/plan_test.exs
+++ b/core/test/sykli/plan_test.exs
@@ -170,26 +170,22 @@ defmodule Sykli.PlanTest do
           }
         ])
 
-      case Plan.generate(graph, from: "HEAD", path: ".") do
-        {:ok, plan} ->
-          review = Enum.find(plan.nodes, &(&1.id == "review:api-breakage"))
+      assert {:ok, plan} = Plan.generate(graph, from: "HEAD", path: ".")
 
-          assert review.kind == "review"
-          assert review.primitive == "api-breakage"
-          assert review.agent == "local"
-          assert review.inputs == ["main...HEAD"]
-          assert review.context == ["README.md", "docs/architecture.md"]
-          assert review.outputs == ["reviews/api-breakage.local.json"]
-          assert review.depends_on == ["test"]
-          assert review.deterministic == false
+      review = Enum.find(plan.nodes, &(&1.id == "review:api-breakage"))
 
-          task = Enum.find(plan.nodes, &(&1.id == "test"))
-          assert task.kind == "task"
-          assert task.deterministic == true
+      assert review.kind == "review"
+      assert review.primitive == "api-breakage"
+      assert review.agent == "local"
+      assert review.inputs == ["main...HEAD"]
+      assert review.context == ["README.md", "docs/architecture.md"]
+      assert review.outputs == ["reviews/api-breakage.local.json"]
+      assert review.depends_on == ["test"]
+      assert review.deterministic == false
 
-        {:error, _} ->
-          :ok
-      end
+      task = Enum.find(plan.nodes, &(&1.id == "test"))
+      assert task.kind == "task"
+      assert task.deterministic == true
     end
   end
 

--- a/core/test/sykli/plan_test.exs
+++ b/core/test/sykli/plan_test.exs
@@ -152,6 +152,45 @@ defmodule Sykli.PlanTest do
           :ok
       end
     end
+
+    test "plan exposes review nodes as non-deterministic graph nodes" do
+      {:ok, graph} =
+        parse_graph([
+          %{"name" => "test", "command" => "mix test"},
+          %{
+            "name" => "review:api-breakage",
+            "kind" => "review",
+            "primitive" => "api-breakage",
+            "agent" => "local",
+            "inputs" => ["main...HEAD"],
+            "context" => ["README.md", "docs/architecture.md"],
+            "outputs" => ["reviews/api-breakage.local.json"],
+            "depends_on" => ["test"],
+            "deterministic" => false
+          }
+        ])
+
+      case Plan.generate(graph, from: "HEAD", path: ".") do
+        {:ok, plan} ->
+          review = Enum.find(plan.nodes, &(&1.id == "review:api-breakage"))
+
+          assert review.kind == "review"
+          assert review.primitive == "api-breakage"
+          assert review.agent == "local"
+          assert review.inputs == ["main...HEAD"]
+          assert review.context == ["README.md", "docs/architecture.md"]
+          assert review.outputs == ["reviews/api-breakage.local.json"]
+          assert review.depends_on == ["test"]
+          assert review.deterministic == false
+
+          task = Enum.find(plan.nodes, &(&1.id == "test"))
+          assert task.kind == "task"
+          assert task.deterministic == true
+
+        {:error, _} ->
+          :ok
+      end
+    end
   end
 
   # Helpers

--- a/core/test/sykli/validate_test.exs
+++ b/core/test/sykli/validate_test.exs
@@ -196,6 +196,16 @@ defmodule Sykli.ValidateTest do
       refute Enum.any?(result.errors, &(&1.type == :missing_command))
     end
 
+    test "exempts review nodes from command requirement" do
+      json =
+        ~s({"tasks": [{"name": "review:api-breakage", "kind": "review", "primitive": "api-breakage", "agent": "local"}]})
+
+      result = Validate.validate_json(json)
+
+      assert result.valid == true
+      refute Enum.any?(result.errors, &(&1.type == :missing_command))
+    end
+
     test "passes when command is present" do
       json = ~s({"tasks": [{"name": "test", "command": "echo hello"}]})
 

--- a/sdk/go/sykli.go
+++ b/sdk/go/sykli.go
@@ -1015,7 +1015,7 @@ func (t *Task) After(tasks ...string) *Task {
 // The condition is evaluated at runtime based on CI context variables:
 //   - branch == 'main' - run only on main branch
 //   - branch != 'main' - run on all branches except main
-//   - tag != ” - run only when a tag is present
+//   - tag != '' - run only when a tag is present
 //   - event == 'push' - run only on push events
 //   - ci == true - run only in CI environment
 func (t *Task) When(condition string) *Task {

--- a/sdk/go/sykli.go
+++ b/sdk/go/sykli.go
@@ -68,6 +68,7 @@ func init() {
 // Pipeline represents a CI pipeline with tasks and resources.
 type Pipeline struct {
 	tasks       []*Task
+	reviews     []*Review
 	dirs        []*Directory
 	caches      []*CacheVolume
 	templates   map[string]*Template
@@ -99,6 +100,7 @@ func WithK8sDefaults(opts K8sOptions) PipelineOption {
 func New(opts ...PipelineOption) *Pipeline {
 	p := &Pipeline{
 		tasks:     make([]*Task, 0),
+		reviews:   make([]*Review, 0),
 		dirs:      make([]*Directory, 0),
 		caches:    make([]*CacheVolume, 0),
 		templates: make(map[string]*Template),
@@ -519,39 +521,52 @@ type gateConfig struct {
 
 // Task represents a single task in the pipeline.
 type Task struct {
-	pipeline     *Pipeline
-	name         string
-	command      string
-	container    string
-	workdir      string
-	env          map[string]string
-	mounts       []Mount
-	inputs       []string      // v1-style input file patterns
-	taskInputs   []TaskInput   // v2-style inputs from other tasks
-	outputs      map[string]string
-	dependsOn    []string
-	when         string
-	whenCond     Condition              // Type-safe condition (alternative to string)
-	secrets      []string               // v1-style secret names
-	secretRefs   []SecretRef            // v2-style typed secret references
-	matrix       map[string][]string
-	services     []Service
-	retry        int
-	timeout      int                    // seconds
-	k8sOptions   *K8sOptions            // Target-specific K8s options
-	k8sRaw       string                 // Raw K8s JSON for advanced options
-	targetName   string                 // Per-task target override
-	requires     []string               // Required node labels for placement
+	pipeline   *Pipeline
+	name       string
+	command    string
+	container  string
+	workdir    string
+	env        map[string]string
+	mounts     []Mount
+	inputs     []string    // v1-style input file patterns
+	taskInputs []TaskInput // v2-style inputs from other tasks
+	outputs    map[string]string
+	dependsOn  []string
+	when       string
+	whenCond   Condition   // Type-safe condition (alternative to string)
+	secrets    []string    // v1-style secret names
+	secretRefs []SecretRef // v2-style typed secret references
+	matrix     map[string][]string
+	services   []Service
+	retry      int
+	timeout    int         // seconds
+	k8sOptions *K8sOptions // Target-specific K8s options
+	k8sRaw     string      // Raw K8s JSON for advanced options
+	targetName string      // Per-task target override
+	requires   []string    // Required node labels for placement
 	// AI-native fields
-	semantic     Semantic
-	aiHooks      AiHooks
+	semantic Semantic
+	aiHooks  AiHooks
 	// Capability-based dependencies
-	provides     []struct{ name, value string }
-	needs        []string
+	provides []struct{ name, value string }
+	needs    []string
 	// Gate fields (if set, this is a gate not a regular task)
-	gate         *gateConfig
+	gate *gateConfig
 	// Cross-platform verification mode
-	verify       string
+	verify string
+}
+
+// Review represents a non-deterministic review node in the execution graph.
+type Review struct {
+	pipeline      *Pipeline
+	name          string
+	primitive     string
+	agent         string
+	inputs        []string
+	context       []string
+	outputs       []string
+	dependsOn     []string
+	deterministic bool
 }
 
 // Task creates a new task with the given name.
@@ -559,10 +574,8 @@ func (p *Pipeline) Task(name string) *Task {
 	if name == "" {
 		log.Panic().Msg("task name cannot be empty")
 	}
-	for _, existing := range p.tasks {
-		if existing.name == name {
-			log.Panic().Str("task", name).Msg("task already exists")
-		}
+	if p.hasNode(name) {
+		log.Panic().Str("task", name).Msg("task/review already exists")
 	}
 	t := &Task{
 		pipeline: p,
@@ -576,16 +589,36 @@ func (p *Pipeline) Task(name string) *Task {
 	return t
 }
 
+// Review creates a non-deterministic review node.
+func (p *Pipeline) Review(name string) *Review {
+	if name == "" {
+		log.Panic().Msg("review name cannot be empty")
+	}
+	if p.hasNode(name) {
+		log.Panic().Str("review", name).Msg("task/review already exists")
+	}
+	r := &Review{
+		pipeline:      p,
+		name:          name,
+		inputs:        make([]string, 0),
+		context:       make([]string, 0),
+		outputs:       make([]string, 0),
+		dependsOn:     make([]string, 0),
+		deterministic: false,
+	}
+	log.Debug().Str("review", name).Msg("registered review")
+	p.reviews = append(p.reviews, r)
+	return r
+}
+
 // Gate creates an approval gate that pauses the pipeline until approved.
 // A gate is a special task with no command that waits for an approval signal.
 func (p *Pipeline) Gate(name string) *Task {
 	if name == "" {
 		log.Panic().Msg("gate name cannot be empty")
 	}
-	for _, existing := range p.tasks {
-		if existing.name == name {
-			log.Panic().Str("gate", name).Msg("task/gate already exists with this name")
-		}
+	if p.hasNode(name) {
+		log.Panic().Str("gate", name).Msg("task/gate/review already exists with this name")
 	}
 	t := &Task{
 		pipeline: p,
@@ -601,6 +634,20 @@ func (p *Pipeline) Gate(name string) *Task {
 	log.Debug().Str("gate", name).Msg("registered gate")
 	p.tasks = append(p.tasks, t)
 	return t
+}
+
+func (p *Pipeline) hasNode(name string) bool {
+	for _, existing := range p.tasks {
+		if existing.name == name {
+			return true
+		}
+	}
+	for _, existing := range p.reviews {
+		if existing.name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // GateStrategy sets the approval strategy for this gate task.
@@ -698,6 +745,95 @@ func (t *Task) Run(cmd string) *Task {
 	}
 	t.command = cmd
 	return t
+}
+
+// Name returns the review node's name for use in dependencies.
+func (r *Review) Name() string {
+	return r.name
+}
+
+// Primitive sets the review primitive identifier.
+func (r *Review) Primitive(name string) *Review {
+	if name == "" {
+		log.Panic().Str("review", r.name).Msg("primitive cannot be empty")
+	}
+	r.primitive = name
+	return r
+}
+
+// Agent sets the agent identifier that should eventually fulfill this review.
+func (r *Review) Agent(name string) *Review {
+	if name == "" {
+		log.Panic().Str("review", r.name).Msg("agent cannot be empty")
+	}
+	r.agent = name
+	return r
+}
+
+// Diff records a diff reference as review input.
+func (r *Review) Diff(ref string) *Review {
+	if ref == "" {
+		log.Panic().Str("review", r.name).Msg("diff reference cannot be empty")
+	}
+	r.inputs = append(r.inputs, ref)
+	return r
+}
+
+// Input records an arbitrary review input reference.
+func (r *Review) Input(ref string) *Review {
+	if ref == "" {
+		log.Panic().Str("review", r.name).Msg("input reference cannot be empty")
+	}
+	r.inputs = append(r.inputs, ref)
+	return r
+}
+
+// Context records files that a future review executor may read.
+func (r *Review) Context(paths ...string) *Review {
+	for _, path := range paths {
+		if path == "" {
+			log.Panic().Str("review", r.name).Msg("context path cannot be empty")
+		}
+		r.context = append(r.context, path)
+	}
+	return r
+}
+
+// Outputs records structured output paths produced by this review node.
+func (r *Review) Outputs(paths ...string) *Review {
+	for _, path := range paths {
+		if path == "" {
+			log.Panic().Str("review", r.name).Msg("output path cannot be empty")
+		}
+		r.outputs = append(r.outputs, path)
+	}
+	return r
+}
+
+// After sets dependencies for this review node.
+func (r *Review) After(nodes ...string) *Review {
+	for _, node := range nodes {
+		if node == "" {
+			continue
+		}
+		found := false
+		for _, existing := range r.dependsOn {
+			if existing == node {
+				found = true
+				break
+			}
+		}
+		if !found {
+			r.dependsOn = append(r.dependsOn, node)
+		}
+	}
+	return r
+}
+
+// Deterministic overrides the default non-deterministic review metadata.
+func (r *Review) Deterministic(value bool) *Review {
+	r.deterministic = value
+	return r
 }
 
 // Container sets the container image for this task.
@@ -879,7 +1015,7 @@ func (t *Task) After(tasks ...string) *Task {
 // The condition is evaluated at runtime based on CI context variables:
 //   - branch == 'main' - run only on main branch
 //   - branch != 'main' - run on all branches except main
-//   - tag != '' - run only when a tag is present
+//   - tag != ” - run only when a tag is present
 //   - event == 'push' - run only on push events
 //   - ci == true - run only in CI environment
 func (t *Task) When(condition string) *Task {
@@ -1425,19 +1561,22 @@ func (p *Pipeline) detectCycle() []string {
 	for _, t := range p.tasks {
 		deps[t.name] = t.dependsOn
 	}
+	for _, r := range p.reviews {
+		deps[r.name] = r.dependsOn
+	}
 
 	color := make(map[string]int)
 	parent := make(map[string]string)
 
-	// Initialize all tasks as white (unvisited)
-	for _, t := range p.tasks {
-		color[t.name] = white
+	// Initialize all nodes as white (unvisited)
+	for name := range deps {
+		color[name] = white
 	}
 
 	// DFS from each unvisited node
-	for _, t := range p.tasks {
-		if color[t.name] == white {
-			if cycle := p.dfsDetectCycle(t.name, deps, color, parent); cycle != nil {
+	for name := range deps {
+		if color[name] == white {
+			if cycle := p.dfsDetectCycle(name, deps, color, parent); cycle != nil {
 				return cycle
 			}
 		}
@@ -1701,6 +1840,17 @@ func (p *Pipeline) topologicalSort() []*Task {
 	return sorted
 }
 
+func (p *Pipeline) nodeNames() map[string]bool {
+	names := make(map[string]bool)
+	for _, t := range p.tasks {
+		names[t.name] = true
+	}
+	for _, r := range p.reviews {
+		names[r.name] = true
+	}
+	return names
+}
+
 // =============================================================================
 // EMIT
 // =============================================================================
@@ -1722,10 +1872,7 @@ func (p *Pipeline) Emit() {
 // EmitTo writes the pipeline JSON to the given writer.
 func (p *Pipeline) EmitTo(w io.Writer) error {
 	// Validate
-	taskNames := make(map[string]bool)
-	for _, t := range p.tasks {
-		taskNames[t.name] = true
-	}
+	taskNames := p.nodeNames()
 	for _, t := range p.tasks {
 		if t.command == "" && t.gate == nil {
 			log.Error().Str("task", t.name).Msg("task has no command")
@@ -1739,6 +1886,18 @@ func (p *Pipeline) EmitTo(w io.Writer) error {
 					return fmt.Errorf("task %q depends on unknown task %q (did you mean %q?)", t.name, dep, suggestion)
 				}
 				return fmt.Errorf("task %q depends on unknown task %q", t.name, dep)
+			}
+		}
+	}
+	for _, r := range p.reviews {
+		for _, dep := range r.dependsOn {
+			if !taskNames[dep] {
+				log.Error().Str("review", r.name).Str("dependency", dep).Msg("unknown dependency")
+				suggestion := suggestTaskName(dep, taskNames)
+				if suggestion != "" {
+					return fmt.Errorf("review %q depends on unknown node %q (did you mean %q?)", r.name, dep, suggestion)
+				}
+				return fmt.Errorf("review %q depends on unknown node %q", r.name, dep)
 			}
 		}
 	}
@@ -1834,35 +1993,40 @@ func (p *Pipeline) EmitTo(w io.Writer) error {
 	}
 
 	type jsonTask struct {
-		Name       string              `json:"name"`
-		Command    string              `json:"command,omitempty"`
-		Container  string              `json:"container,omitempty"`
-		Workdir    string              `json:"workdir,omitempty"`
-		Env        map[string]string   `json:"env,omitempty"`
-		Mounts     []jsonMount         `json:"mounts,omitempty"`
-		Inputs     []string            `json:"inputs,omitempty"`       // v1-style file patterns
-		TaskInputs []jsonTaskInput     `json:"task_inputs,omitempty"`  // v2-style inputs from other tasks
-		Outputs    map[string]string   `json:"outputs,omitempty"`
-		DependsOn  []string            `json:"depends_on,omitempty"`
-		When       string              `json:"when,omitempty"`
-		Secrets    []string            `json:"secrets,omitempty"`
-		SecretRefs []jsonSecretRef     `json:"secret_refs,omitempty"`  // v2-style typed secrets
-		Matrix     map[string][]string `json:"matrix,omitempty"`
-		Services   []jsonService       `json:"services,omitempty"`
-		Retry      int                 `json:"retry,omitempty"`
-		Timeout    int                 `json:"timeout,omitempty"`
-		Target     string              `json:"target,omitempty"`       // Per-task target override
-		K8s        *jsonK8sOptions     `json:"k8s,omitempty"`          // K8s-specific options
-		Requires   []string            `json:"requires,omitempty"`     // Required node labels
+		Name          string              `json:"name"`
+		Kind          string              `json:"kind,omitempty"`
+		Command       string              `json:"command,omitempty"`
+		Container     string              `json:"container,omitempty"`
+		Workdir       string              `json:"workdir,omitempty"`
+		Env           map[string]string   `json:"env,omitempty"`
+		Mounts        []jsonMount         `json:"mounts,omitempty"`
+		Inputs        []string            `json:"inputs,omitempty"`      // v1-style file patterns
+		TaskInputs    []jsonTaskInput     `json:"task_inputs,omitempty"` // v2-style inputs from other tasks
+		Outputs       any                 `json:"outputs,omitempty"`
+		DependsOn     []string            `json:"depends_on,omitempty"`
+		Primitive     string              `json:"primitive,omitempty"`
+		Agent         string              `json:"agent,omitempty"`
+		Context       []string            `json:"context,omitempty"`
+		Deterministic *bool               `json:"deterministic,omitempty"`
+		When          string              `json:"when,omitempty"`
+		Secrets       []string            `json:"secrets,omitempty"`
+		SecretRefs    []jsonSecretRef     `json:"secret_refs,omitempty"` // v2-style typed secrets
+		Matrix        map[string][]string `json:"matrix,omitempty"`
+		Services      []jsonService       `json:"services,omitempty"`
+		Retry         int                 `json:"retry,omitempty"`
+		Timeout       int                 `json:"timeout,omitempty"`
+		Target        string              `json:"target,omitempty"`   // Per-task target override
+		K8s           *jsonK8sOptions     `json:"k8s,omitempty"`      // K8s-specific options
+		Requires      []string            `json:"requires,omitempty"` // Required node labels
 		// Capability-based dependencies
-		Provides   []jsonProvide       `json:"provides,omitempty"`
-		Needs      []string            `json:"needs,omitempty"`
+		Provides []jsonProvide `json:"provides,omitempty"`
+		Needs    []string      `json:"needs,omitempty"`
 		// AI-native fields
-		Semantic   *jsonSemantic       `json:"semantic,omitempty"`
-		AiHooks    *jsonAiHooks        `json:"ai_hooks,omitempty"`
+		Semantic *jsonSemantic `json:"semantic,omitempty"`
+		AiHooks  *jsonAiHooks  `json:"ai_hooks,omitempty"`
 		// Gate (approval point)
-		Gate       *jsonGate           `json:"gate,omitempty"`
-		Verify     string              `json:"verify,omitempty"`
+		Gate   *jsonGate `json:"gate,omitempty"`
+		Verify string    `json:"verify,omitempty"`
 	}
 
 	type jsonResource struct {
@@ -1921,8 +2085,8 @@ func (p *Pipeline) EmitTo(w io.Writer) error {
 	}
 
 	// Build tasks
-	tasks := make([]jsonTask, len(p.tasks))
-	for i, t := range p.tasks {
+	tasks := make([]jsonTask, 0, len(p.tasks)+len(p.reviews))
+	for _, t := range p.tasks {
 		var mounts []jsonMount
 		if len(t.mounts) > 0 {
 			mounts = make([]jsonMount, len(t.mounts))
@@ -1986,24 +2150,24 @@ func (p *Pipeline) EmitTo(w io.Writer) error {
 			when = t.whenCond.expr
 		}
 
-		tasks[i] = jsonTask{
+		tasks = append(tasks, jsonTask{
 			Name:       t.name,
 			Command:    t.command,
 			Container:  t.container,
 			Workdir:    t.workdir,
 			Env:        env,
 			Mounts:     mounts,
-			Inputs:     t.inputs,      // v1-style file patterns
-			TaskInputs: taskInputs,    // v2-style inputs from other tasks
+			Inputs:     t.inputs,   // v1-style file patterns
+			TaskInputs: taskInputs, // v2-style inputs from other tasks
 			Outputs:    outputs,
 			DependsOn:  t.dependsOn,
 			When:       when,
 			Secrets:    t.secrets,
-			SecretRefs: secretRefs,    // v2-style typed secrets
+			SecretRefs: secretRefs, // v2-style typed secrets
 			Matrix:     t.matrix,
 			Retry:      t.retry,
 			Timeout:    t.timeout,
-			Target:     t.targetName,  // Per-task target override
+			Target:     t.targetName, // Per-task target override
 			Services: func() []jsonService {
 				if len(t.services) == 0 {
 					return nil
@@ -2069,7 +2233,22 @@ func (p *Pipeline) EmitTo(w io.Writer) error {
 				}
 			}(),
 			Verify: t.verify,
-		}
+		})
+	}
+
+	for _, r := range p.reviews {
+		deterministic := r.deterministic
+		tasks = append(tasks, jsonTask{
+			Name:          r.name,
+			Kind:          "review",
+			Primitive:     r.primitive,
+			Agent:         r.agent,
+			Inputs:        r.inputs,
+			Context:       r.context,
+			Outputs:       r.outputs,
+			DependsOn:     r.dependsOn,
+			Deterministic: &deterministic,
+		})
 	}
 
 	out := jsonPipeline{

--- a/sdk/go/sykli_test.go
+++ b/sdk/go/sykli_test.go
@@ -256,6 +256,72 @@ func TestTaskWithNoCommandFails(t *testing.T) {
 	}
 }
 
+func TestReviewNodeEmitsMetadata(t *testing.T) {
+	p := New()
+	p.Task("test").Run("go test ./...")
+	p.Review("review:api-breakage").
+		Primitive("api-breakage").
+		Agent("local").
+		Diff("main...HEAD").
+		Context("README.md", "docs/architecture.md").
+		After("test").
+		Outputs("reviews/api-breakage.local.json")
+
+	result, err := emitJSON(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tasks := result["tasks"].([]interface{})
+	var review map[string]interface{}
+	for _, node := range tasks {
+		task := node.(map[string]interface{})
+		if task["name"] == "review:api-breakage" {
+			review = task
+			break
+		}
+	}
+	if review == nil {
+		t.Fatal("review node not found")
+	}
+
+	if review["kind"] != "review" {
+		t.Errorf("expected kind review, got %v", review["kind"])
+	}
+	if review["primitive"] != "api-breakage" {
+		t.Errorf("expected primitive api-breakage, got %v", review["primitive"])
+	}
+	if review["agent"] != "local" {
+		t.Errorf("expected agent local, got %v", review["agent"])
+	}
+	if review["deterministic"] != false {
+		t.Errorf("expected deterministic=false, got %v", review["deterministic"])
+	}
+	if _, ok := review["command"]; ok {
+		t.Errorf("review node should not emit command")
+	}
+
+	inputs := review["inputs"].([]interface{})
+	if len(inputs) != 1 || inputs[0] != "main...HEAD" {
+		t.Errorf("expected diff input, got %v", inputs)
+	}
+
+	context := review["context"].([]interface{})
+	if len(context) != 2 || context[0] != "README.md" || context[1] != "docs/architecture.md" {
+		t.Errorf("expected context files, got %v", context)
+	}
+
+	outputs := review["outputs"].([]interface{})
+	if len(outputs) != 1 || outputs[0] != "reviews/api-breakage.local.json" {
+		t.Errorf("expected review output path, got %v", outputs)
+	}
+
+	deps := review["depends_on"].([]interface{})
+	if len(deps) != 1 || deps[0] != "test" {
+		t.Errorf("expected dependency on test, got %v", deps)
+	}
+}
+
 func TestUnknownDependencyFails(t *testing.T) {
 	p := New()
 	p.Task("build").Run("go build").After("nonexistent")


### PR DESCRIPTION
## Summary
Adds the first internal model for SYKLI Reviews as non-deterministic graph nodes. This only models review work in the graph; it does not call any provider or implement review execution.

## Scope
- Adds review node metadata to the core graph parser: kind, primitive, agent, context, outputs, dependencies, deterministic flag.
- Lets validation accept commandless review nodes while preserving normal task command validation.
- Exposes review metadata in plan/explain output, including deterministic=false by default.
- Adds Go SDK support via s.Review(...).Primitive(...).Agent(...).Diff(...).Context(...).After(...).Outputs(...).
- Updates README docs to mark SYKLI Reviews experimental and distinguish task nodes from review nodes.

## Verification
- cd core && mix format
- cd core && mix test
- cd core && mix credo
- cd core && mix escript.build
- GOCACHE=/tmp/sykli-go-build-cache go test ./... in sdk/go
- git diff --check
- test/blackbox/run.sh: 137 passed, 11 expected-red, 0 failed