### PR TITLE
feat(github): Phase 2 — Webhook → Executor → Check Run Lifecycle (ADR-021)

### DIFF
--- a/core/lib/sykli/github/app/fake.ex
+++ b/core/lib/sykli/github/app/fake.ex
@@ -5,8 +5,14 @@ defmodule Sykli.GitHub.App.Fake do
 
   @impl true
   def installation_token(installation_id, opts \\ []) do
-    token = Keyword.get(opts, :token, "fake-installation-token-#{installation_id}")
-    expires_at = Keyword.get(opts, :expires_at, 4_102_444_800)
-    {:ok, token, expires_at}
+    case Keyword.get(opts, :app_response, :default) do
+      :default ->
+        token = Keyword.get(opts, :token, "fake-installation-token-#{installation_id}")
+        expires_at = Keyword.get(opts, :expires_at, 4_102_444_800)
+        {:ok, token, expires_at}
+
+      response ->
+        response
+    end
   end
 end

--- a/core/lib/sykli/github/check_run_formatter.ex
+++ b/core/lib/sykli/github/check_run_formatter.ex
@@ -1,0 +1,73 @@
+defmodule Sykli.GitHub.CheckRunFormatter do
+  @moduledoc "Formats task results for GitHub check runs."
+
+  alias Sykli.Executor.TaskResult
+
+  @max_lines 50
+
+  @spec conclusion(TaskResult.t()) :: String.t()
+  def conclusion(%TaskResult{status: :passed}), do: "success"
+  def conclusion(%TaskResult{status: :failed}), do: "failure"
+  def conclusion(%TaskResult{status: :errored}), do: "failure"
+  def conclusion(%TaskResult{status: :cached}), do: "success"
+  def conclusion(%TaskResult{status: :skipped}), do: "skipped"
+  def conclusion(%TaskResult{status: :blocked}), do: "cancelled"
+
+  @spec format(TaskResult.t()) :: %{title: String.t(), summary: String.t()}
+  def format(%TaskResult{} = result) do
+    %{
+      title: title(result),
+      summary: summary(result)
+    }
+  end
+
+  defp title(%TaskResult{name: name, status: :cached}), do: "#{name}: cached (cache hit)"
+  defp title(%TaskResult{name: name, status: status}), do: "#{name}: #{status}"
+
+  defp summary(%TaskResult{status: :errored} = result) do
+    [
+      "Infrastructure failure while running `#{result.name}`.",
+      "",
+      output_block(result)
+    ]
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  defp summary(%TaskResult{} = result) do
+    [
+      "Task `#{result.name}` finished with status `#{result.status}`.",
+      output_block(result)
+    ]
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n\n")
+  end
+
+  defp output_block(%TaskResult{} = result) do
+    output =
+      [result.output, error_output(result.error)]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join("\n")
+      |> last_lines(@max_lines)
+
+    if output == "" do
+      ""
+    else
+      "```text\n#{output}\n```"
+    end
+  end
+
+  defp error_output(%Sykli.Error{output: output}) when is_binary(output), do: output
+  defp error_output(%Sykli.Error{message: message}) when is_binary(message), do: message
+  defp error_output(nil), do: nil
+  defp error_output(error), do: inspect(error)
+
+  defp last_lines("", _limit), do: ""
+
+  defp last_lines(text, limit) do
+    text
+    |> String.split("\n")
+    |> Enum.take(-limit)
+    |> Enum.join("\n")
+  end
+end

--- a/core/lib/sykli/github/checks.ex
+++ b/core/lib/sykli/github/checks.ex
@@ -1,113 +1,39 @@
 defmodule Sykli.GitHub.Checks do
-  @moduledoc "GitHub Checks API client."
+  @moduledoc "GitHub Checks API facade."
 
-  require Logger
+  @behaviour Sykli.GitHub.Checks.Behaviour
 
-  @api_url "https://api.github.com"
+  @impl true
+  def create_suite(context, token, opts \\ []) do
+    impl =
+      Keyword.get(opts, :impl, Application.get_env(:sykli, :github_checks_impl, __MODULE__.Real))
 
-  def create_suite(%{repo: repo, head_sha: head_sha}, token, opts \\ []) do
-    request(
-      :post,
-      "/repos/#{repo}/check-suites",
-      token,
-      %{head_sha: head_sha},
-      opts,
-      "github.checks.write_failed"
-    )
+    impl.create_suite(context, token, opts)
   end
 
   def create_suite(repo, head_sha, token, opts) when is_binary(repo) and is_binary(head_sha),
     do: create_suite(%{repo: repo, head_sha: head_sha}, token, opts)
 
-  def create_run(%{repo: repo, head_sha: head_sha}, token, opts \\ []) do
-    name = Keyword.get(opts, :name, "sykli")
+  @impl true
+  def create_run(context, token, opts \\ []) do
+    impl =
+      Keyword.get(opts, :impl, Application.get_env(:sykli, :github_checks_impl, __MODULE__.Real))
 
-    request(
-      :post,
-      "/repos/#{repo}/check-runs",
-      token,
-      %{name: name, head_sha: head_sha, status: "queued"},
-      opts,
-      "github.checks.write_failed"
-    )
+    impl.create_run(context, token, opts)
   end
 
   def create_run(repo, head_sha, token, opts) when is_binary(repo) and is_binary(head_sha),
     do: create_run(%{repo: repo, head_sha: head_sha}, token, opts)
 
-  def update_run(%{repo: repo, check_run_id: check_run_id}, token, attrs, opts \\ []) do
-    request(
-      :patch,
-      "/repos/#{repo}/check-runs/#{check_run_id}",
-      token,
-      attrs,
-      opts,
-      "github.checks.write_failed"
-    )
+  @impl true
+  def update_run(context, token, attrs, opts \\ []) do
+    impl =
+      Keyword.get(opts, :impl, Application.get_env(:sykli, :github_checks_impl, __MODULE__.Real))
+
+    impl.update_run(context, token, attrs, opts)
   end
 
   def update_run(repo, check_run_id, attrs, token, opts)
       when is_binary(repo) and is_integer(check_run_id),
       do: update_run(%{repo: repo, check_run_id: check_run_id}, token, attrs, opts)
-
-  defp request(method, path, token, payload, opts, error_code) do
-    client =
-      Keyword.get(
-        opts,
-        :http_client,
-        Application.get_env(:sykli, :github_http_client, Sykli.GitHub.HTTPClient.Real)
-      )
-
-    api_url = Keyword.get(opts, :api_url, Application.get_env(:sykli, :github_api_url, @api_url))
-    url = api_url <> path
-    body = Jason.encode!(payload)
-
-    headers = [
-      {~c"Authorization", String.to_charlist("Bearer #{token}")},
-      {~c"Accept", ~c"application/vnd.github+json"},
-      {~c"X-GitHub-Api-Version", ~c"2022-11-28"},
-      {~c"User-Agent", ~c"sykli/0.6"},
-      {~c"Content-Type", ~c"application/json"}
-    ]
-
-    case client.request(method, url, headers, body) do
-      {:ok, code, response} when code in 200..299 ->
-        decode_response(response)
-
-      {:ok, code, response} ->
-        Logger.warning("[GitHub Checks] request failed", code: code, path: path)
-        {:error, github_error(error_code, "GitHub Checks API request failed", {code, response})}
-
-      {:error, reason} ->
-        {:error, github_error(error_code, "GitHub Checks API request failed", reason)}
-    end
-  end
-
-  defp decode_response(""), do: {:ok, %{}}
-
-  defp decode_response(body) do
-    case Jason.decode(body) do
-      {:ok, data} ->
-        {:ok, data}
-
-      {:error, reason} ->
-        {:error,
-         github_error(
-           "github.checks.bad_response",
-           "GitHub Checks API response was invalid",
-           reason
-         )}
-    end
-  end
-
-  defp github_error(code, message, cause) do
-    %Sykli.Error{
-      code: code,
-      type: :runtime,
-      message: message,
-      step: :run,
-      cause: cause,
-      hints: []
-    }
-  end
 end

--- a/core/lib/sykli/github/checks/behaviour.ex
+++ b/core/lib/sykli/github/checks/behaviour.ex
@@ -1,0 +1,9 @@
+defmodule Sykli.GitHub.Checks.Behaviour do
+  @moduledoc "Behaviour for GitHub Checks API clients."
+
+  @callback create_suite(map(), String.t(), keyword()) ::
+              {:ok, map()} | {:error, Sykli.Error.t()}
+  @callback create_run(map(), String.t(), keyword()) :: {:ok, map()} | {:error, Sykli.Error.t()}
+  @callback update_run(map(), String.t(), map(), keyword()) ::
+              {:ok, map()} | {:error, Sykli.Error.t()}
+end

--- a/core/lib/sykli/github/checks/fake.ex
+++ b/core/lib/sykli/github/checks/fake.ex
@@ -1,0 +1,42 @@
+defmodule Sykli.GitHub.Checks.Fake do
+  @moduledoc "Fake GitHub Checks client for tests."
+
+  @behaviour Sykli.GitHub.Checks.Behaviour
+
+  @impl true
+  def create_suite(context, token, opts \\ []) do
+    notify(opts, {:github_checks_create_suite, context, token})
+    response(opts, :create_suite_response, {:ok, %{"id" => 10_001}})
+  end
+
+  @impl true
+  def create_run(context, token, opts \\ []) do
+    notify(opts, {:github_checks_create_run, context, token, Keyword.get(opts, :name)})
+
+    case response(opts, :create_run_response, :default) do
+      :default ->
+        name = Keyword.get(opts, :name, "sykli")
+        {:ok, %{"id" => run_id_for(name), "name" => name}}
+
+      other ->
+        other
+    end
+  end
+
+  @impl true
+  def update_run(context, token, attrs, opts \\ []) do
+    notify(opts, {:github_checks_update_run, context, token, attrs})
+    response(opts, :update_run_response, {:ok, %{"id" => context.check_run_id}})
+  end
+
+  defp run_id_for(name), do: 20_000 + :erlang.phash2(name, 10_000)
+
+  defp response(opts, key, default), do: Keyword.get(opts, key, default)
+
+  defp notify(opts, message) do
+    case Keyword.get(opts, :test_pid) do
+      pid when is_pid(pid) -> send(pid, message)
+      _ -> :ok
+    end
+  end
+end

--- a/core/lib/sykli/github/checks/real.ex
+++ b/core/lib/sykli/github/checks/real.ex
@@ -1,0 +1,108 @@
+defmodule Sykli.GitHub.Checks.Real do
+  @moduledoc "GitHub Checks API client."
+
+  @behaviour Sykli.GitHub.Checks.Behaviour
+
+  require Logger
+
+  @api_url "https://api.github.com"
+
+  @impl true
+  def create_suite(%{repo: repo, head_sha: head_sha}, token, opts \\ []) do
+    request(
+      :post,
+      "/repos/#{repo}/check-suites",
+      token,
+      %{head_sha: head_sha},
+      opts,
+      "github.checks.write_failed"
+    )
+  end
+
+  @impl true
+  def create_run(%{repo: repo, head_sha: head_sha}, token, opts \\ []) do
+    name = Keyword.get(opts, :name, "sykli")
+
+    request(
+      :post,
+      "/repos/#{repo}/check-runs",
+      token,
+      %{name: name, head_sha: head_sha, status: "queued"},
+      opts,
+      "github.checks.write_failed"
+    )
+  end
+
+  @impl true
+  def update_run(%{repo: repo, check_run_id: check_run_id}, token, attrs, opts \\ []) do
+    request(
+      :patch,
+      "/repos/#{repo}/check-runs/#{check_run_id}",
+      token,
+      attrs,
+      opts,
+      "github.checks.write_failed"
+    )
+  end
+
+  defp request(method, path, token, payload, opts, error_code) do
+    client =
+      Keyword.get(
+        opts,
+        :http_client,
+        Application.get_env(:sykli, :github_http_client, Sykli.GitHub.HTTPClient.Real)
+      )
+
+    api_url = Keyword.get(opts, :api_url, Application.get_env(:sykli, :github_api_url, @api_url))
+    url = api_url <> path
+    body = Jason.encode!(payload)
+
+    headers = [
+      {~c"Authorization", String.to_charlist("Bearer #{token}")},
+      {~c"Accept", ~c"application/vnd.github+json"},
+      {~c"X-GitHub-Api-Version", ~c"2022-11-28"},
+      {~c"User-Agent", ~c"sykli/0.6"},
+      {~c"Content-Type", ~c"application/json"}
+    ]
+
+    case client.request(method, url, headers, body) do
+      {:ok, code, response} when code in 200..299 ->
+        decode_response(response)
+
+      {:ok, code, response} ->
+        Logger.warning("[GitHub Checks] request failed", code: code, path: path)
+        {:error, github_error(error_code, "GitHub Checks API request failed", {code, response})}
+
+      {:error, reason} ->
+        {:error, github_error(error_code, "GitHub Checks API request failed", reason)}
+    end
+  end
+
+  defp decode_response(""), do: {:ok, %{}}
+
+  defp decode_response(body) do
+    case Jason.decode(body) do
+      {:ok, data} ->
+        {:ok, data}
+
+      {:error, reason} ->
+        {:error,
+         github_error(
+           "github.checks.bad_response",
+           "GitHub Checks API response was invalid",
+           reason
+         )}
+    end
+  end
+
+  defp github_error(code, message, cause) do
+    %Sykli.Error{
+      code: code,
+      type: :runtime,
+      message: message,
+      step: :run,
+      cause: cause,
+      hints: []
+    }
+  end
+end

--- a/core/lib/sykli/github/dispatcher.ex
+++ b/core/lib/sykli/github/dispatcher.ex
@@ -17,7 +17,10 @@ defmodule Sykli.GitHub.Dispatcher do
         :ok
 
       {:error, %Sykli.Error{} = error} = result ->
-        Deliveries.evict(delivery_id)
+        if retryable_dispatch_error?(error) do
+          Deliveries.evict(delivery_id)
+        end
+
         Logger.warning("[GitHub Dispatcher] dispatch failed", code: error.code)
         result
     end
@@ -372,6 +375,14 @@ defmodule Sykli.GitHub.Dispatcher do
 
   defp checks_client(opts), do: Keyword.get(opts, :checks_client, Sykli.GitHub.Checks)
   defp source_client(opts), do: Keyword.get(opts, :source_client, Sykli.GitHub.Source)
+
+  defp retryable_dispatch_error?(%Sykli.Error{code: code}) do
+    code not in [
+      "github.app.missing_config",
+      "github.app.private_key_not_found",
+      "github.app.jwt_failed"
+    ]
+  end
 
   defp dispatch_error(code, message, cause \\ nil) do
     %Sykli.Error{

--- a/core/lib/sykli/github/dispatcher.ex
+++ b/core/lib/sykli/github/dispatcher.ex
@@ -1,0 +1,386 @@
+defmodule Sykli.GitHub.Dispatcher do
+  @moduledoc "Dispatches accepted GitHub webhooks into executor runs."
+
+  require Logger
+
+  alias Sykli.GitHub.CheckRunFormatter
+  alias Sykli.GitHub.Webhook.Deliveries
+  alias Sykli.Occurrence.PubSub, as: OccPubSub
+
+  @spec dispatch(map(), keyword()) :: :ok | {:error, Sykli.Error.t()}
+  def dispatch(%{delivery_id: delivery_id} = event, opts \\ []) do
+    run_id = Map.get(event, :run_id) || "github:#{delivery_id}"
+    event = Map.put(event, :run_id, run_id)
+
+    case do_dispatch(event, opts) do
+      :ok ->
+        :ok
+
+      {:error, %Sykli.Error{} = error} = result ->
+        Deliveries.evict(delivery_id)
+        Logger.warning("[GitHub Dispatcher] dispatch failed", code: error.code)
+        result
+    end
+  end
+
+  defp do_dispatch(event, opts) do
+    run_id = event.run_id
+
+    OccPubSub.github_run_dispatched(run_id, %{
+      event: event.event,
+      delivery_id: event.delivery_id,
+      repo: event.repo,
+      head_sha: event.head_sha
+    })
+
+    with {:ok, token, _expires_at} <-
+           app_client(opts).installation_token(event.installation_id, opts),
+         {:ok, suite} <- create_suite(event, token, opts) do
+      dispatch_after_suite(event, token, suite, opts)
+    else
+      {:error, %Sykli.Error{} = error} ->
+        {:error, error}
+
+      {:error, reason} ->
+        {:error, dispatch_error("github.dispatch.failed", "GitHub dispatch failed", reason)}
+    end
+  end
+
+  defp dispatch_after_suite(event, token, suite, opts) do
+    run_id = event.run_id
+
+    with {:ok, source_path} <- acquire_source(event, token, opts),
+         {:ok, results} <- dispatch_from_source(event, token, source_path, opts) do
+      OccPubSub.github_check_suite_concluded(run_id, %{
+        repo: event.repo,
+        head_sha: event.head_sha,
+        check_suite_id: suite["id"],
+        conclusion: conclusion(results)
+      })
+
+      :ok
+    else
+      {:error, %Sykli.Error{} = error} ->
+        maybe_emit_source_failed(run_id, event, error)
+        create_setup_failure(event, token, error, opts)
+
+        OccPubSub.github_check_suite_concluded(run_id, %{
+          repo: event.repo,
+          head_sha: event.head_sha,
+          check_suite_id: suite["id"],
+          conclusion: "failure"
+        })
+
+        {:error, error}
+
+      {:error, reason} ->
+        error = dispatch_error("github.dispatch.failed", "GitHub dispatch failed", reason)
+        maybe_emit_source_failed(run_id, event, error)
+        create_setup_failure(event, token, error, opts)
+
+        OccPubSub.github_check_suite_concluded(run_id, %{
+          repo: event.repo,
+          head_sha: event.head_sha,
+          check_suite_id: suite["id"],
+          conclusion: "failure"
+        })
+
+        {:error, error}
+    end
+  end
+
+  defp dispatch_from_source(event, token, source_path, opts) do
+    with {:ok, graph, tasks} <- load_graph(source_path),
+         {:ok, check_runs} <- create_task_runs(event, token, tasks, opts),
+         :ok <- mark_in_progress(event, token, check_runs, opts),
+         {:ok, results} <- run_executor(tasks, graph, source_path, event.run_id, opts),
+         :ok <- conclude_task_runs(event, token, check_runs, results, opts) do
+      {:ok, results}
+    end
+  after
+    source_client(opts).cleanup(source_path, opts)
+  end
+
+  defp create_suite(event, token, opts) do
+    case checks_client(opts).create_suite(
+           %{repo: event.repo, head_sha: event.head_sha},
+           token,
+           opts
+         ) do
+      {:ok, suite} ->
+        OccPubSub.github_check_suite_opened(event.run_id, %{
+          repo: event.repo,
+          head_sha: event.head_sha,
+          check_suite_id: suite["id"]
+        })
+
+        {:ok, suite}
+
+      error ->
+        error
+    end
+  end
+
+  defp acquire_source(event, token, opts) do
+    case source_client(opts).acquire(event, token, opts) do
+      {:ok, path} ->
+        OccPubSub.github_run_source_acquired(event.run_id, %{
+          repo: event.repo,
+          sha: event.head_sha,
+          path: path,
+          bytes: directory_bytes(path)
+        })
+
+        {:ok, path}
+
+      error ->
+        error
+    end
+  end
+
+  defp load_graph(source_path) do
+    with {:ok, sdk_file} <- Sykli.Detector.find(source_path),
+         {:ok, json} <- Sykli.Detector.emit(sdk_file),
+         {:ok, graph} <- Sykli.Graph.parse(json),
+         expanded <- Sykli.Graph.expand_matrix(graph),
+         {:ok, tasks} <- Sykli.Graph.topo_sort(expanded) do
+      {:ok, expanded, tasks}
+    else
+      {:error, :no_sdk_file} ->
+        {:error,
+         dispatch_error(
+           "github.dispatch.no_pipeline",
+           "no sykli pipeline was found in the cloned source"
+         )}
+
+      {:error, reason} ->
+        {:error,
+         dispatch_error("github.dispatch.graph_failed", "failed to build task graph", reason)}
+    end
+  end
+
+  defp create_task_runs(event, token, tasks, opts) do
+    Enum.reduce_while(tasks, {:ok, %{}}, fn task, {:ok, acc} ->
+      case checks_client(opts).create_run(
+             %{repo: event.repo, head_sha: event.head_sha},
+             token,
+             Keyword.put(opts, :name, task.name)
+           ) do
+        {:ok, run} ->
+          check_run_id = run["id"]
+
+          OccPubSub.github_check_run_created(event.run_id, %{
+            task_name: task.name,
+            check_run_id: check_run_id
+          })
+
+          {:cont, {:ok, Map.put(acc, task.name, check_run_id)}}
+
+        {:error, %Sykli.Error{} = error} ->
+          {:halt, {:error, error}}
+      end
+    end)
+  end
+
+  defp mark_in_progress(event, token, check_runs, opts) do
+    check_runs
+    |> Enum.each(fn {task_name, check_run_id} ->
+      transition_check_run(
+        event,
+        token,
+        task_name,
+        check_run_id,
+        "queued",
+        "in_progress",
+        %{
+          status: "in_progress"
+        },
+        opts
+      )
+    end)
+
+    :ok
+  end
+
+  defp run_executor(tasks, graph, source_path, run_id, opts) do
+    exec_opts =
+      opts
+      |> Keyword.put(:workdir, source_path)
+      |> Keyword.put(:run_id, run_id)
+
+    case run_executor_quietly(tasks, graph, exec_opts) do
+      {:ok, results} ->
+        {:ok, results}
+
+      {:error, results} when is_list(results) ->
+        {:ok, results}
+
+      {:error, %Sykli.Error{} = error} ->
+        {:error, error}
+
+      {:error, reason} ->
+        {:error, dispatch_error("github.dispatch.executor_failed", "executor failed", reason)}
+    end
+  end
+
+  defp run_executor_quietly(tasks, graph, opts) do
+    original_group_leader = Process.group_leader()
+
+    {:ok, io} = StringIO.open("")
+    Process.group_leader(self(), io)
+
+    try do
+      Sykli.Executor.run(tasks, graph, opts)
+    after
+      Process.group_leader(self(), original_group_leader)
+      StringIO.close(io)
+    end
+  end
+
+  defp conclude_task_runs(event, token, check_runs, results, opts) do
+    Enum.each(results, fn result ->
+      case Map.fetch(check_runs, result.name) do
+        {:ok, check_run_id} ->
+          formatted = CheckRunFormatter.format(result)
+
+          attrs = %{
+            status: "completed",
+            conclusion: CheckRunFormatter.conclusion(result),
+            output: formatted
+          }
+
+          transition_check_run(
+            event,
+            token,
+            result.name,
+            check_run_id,
+            "in_progress",
+            "completed",
+            attrs,
+            opts
+          )
+
+        :error ->
+          :ok
+      end
+    end)
+
+    :ok
+  end
+
+  defp create_setup_failure(event, token, %Sykli.Error{} = error, opts) do
+    with {:ok, run} <-
+           checks_client(opts).create_run(
+             %{repo: event.repo, head_sha: event.head_sha},
+             token,
+             Keyword.put(opts, :name, "sykli/source")
+           ) do
+      check_run_id = run["id"]
+
+      transition_check_run(
+        event,
+        token,
+        "sykli/source",
+        check_run_id,
+        "queued",
+        "completed",
+        %{
+          status: "completed",
+          conclusion: "failure",
+          output: %{
+            title: "sykli/source: failed",
+            summary: "Sykli could not prepare the webhook run.\n\n```text\n#{error.message}\n```"
+          }
+        },
+        opts
+      )
+    end
+
+    :ok
+  end
+
+  defp transition_check_run(event, token, task_name, check_run_id, from, to, attrs, opts) do
+    case checks_client(opts).update_run(
+           %{repo: event.repo, check_run_id: check_run_id},
+           token,
+           attrs,
+           opts
+         ) do
+      {:ok, _run} ->
+        OccPubSub.github_check_run_transitioned(event.run_id, %{
+          from: from,
+          to: to,
+          task_name: task_name,
+          check_run_id: check_run_id
+        })
+
+      {:error, %Sykli.Error{} = error} ->
+        OccPubSub.github_check_run_transition_failed(event.run_id, %{
+          from: from,
+          to: to,
+          task_name: task_name,
+          check_run_id: check_run_id,
+          error: %{code: error.code, message: error.message}
+        })
+
+        Logger.warning("[GitHub Dispatcher] check run transition failed", code: error.code)
+    end
+  end
+
+  defp conclusion(results) do
+    if Enum.any?(results, &(&1.status in [:failed, :errored, :blocked])) do
+      "failure"
+    else
+      "success"
+    end
+  end
+
+  defp maybe_emit_source_failed(run_id, event, %Sykli.Error{} = error) do
+    if error.code in [
+         "github.source.clone_failed",
+         "github.source.checkout_failed",
+         "github.source.copy_failed"
+       ] do
+      OccPubSub.github_run_source_failed(run_id, %{
+        repo: event.repo,
+        sha: event.head_sha,
+        error: %{code: error.code, message: error.message}
+      })
+    end
+  end
+
+  defp directory_bytes(path) do
+    path
+    |> Path.join("**/*")
+    |> Path.wildcard()
+    |> Enum.filter(&File.regular?/1)
+    |> Enum.reduce(0, fn file, acc ->
+      case File.stat(file) do
+        {:ok, stat} -> acc + stat.size
+        {:error, _} -> acc
+      end
+    end)
+  end
+
+  defp app_client(opts),
+    do:
+      Keyword.get(
+        opts,
+        :app_client,
+        Application.get_env(:sykli, :github_app_impl, Sykli.GitHub.App)
+      )
+
+  defp checks_client(opts), do: Keyword.get(opts, :checks_client, Sykli.GitHub.Checks)
+  defp source_client(opts), do: Keyword.get(opts, :source_client, Sykli.GitHub.Source)
+
+  defp dispatch_error(code, message, cause \\ nil) do
+    %Sykli.Error{
+      code: code,
+      type: :runtime,
+      message: message,
+      step: :run,
+      cause: cause,
+      hints: []
+    }
+  end
+end

--- a/core/lib/sykli/github/http_client/fake.ex
+++ b/core/lib/sykli/github/http_client/fake.ex
@@ -1,0 +1,25 @@
+defmodule Sykli.GitHub.HTTPClient.Fake do
+  @moduledoc "Fake GitHub HTTP client for tests."
+
+  @behaviour Sykli.GitHub.HTTPClient
+
+  @impl true
+  def request(method, url, headers, body) do
+    case Application.get_env(:sykli, :github_http_client_fake_response, {:ok, 200, "{}"}) do
+      {:ok, _code, _response} = ok ->
+        notify({:github_http_request, method, url, headers, body})
+        ok
+
+      {:error, _reason} = error ->
+        notify({:github_http_request, method, url, headers, body})
+        error
+    end
+  end
+
+  defp notify(message) do
+    case Application.get_env(:sykli, :github_http_client_fake_test_pid) do
+      pid when is_pid(pid) -> send(pid, message)
+      _ -> :ok
+    end
+  end
+end

--- a/core/lib/sykli/github/source.ex
+++ b/core/lib/sykli/github/source.ex
@@ -1,0 +1,21 @@
+defmodule Sykli.GitHub.Source do
+  @moduledoc "GitHub source acquisition facade."
+
+  @behaviour Sykli.GitHub.Source.Behaviour
+
+  @impl true
+  def acquire(context, token, opts \\ []) do
+    impl =
+      Keyword.get(opts, :impl, Application.get_env(:sykli, :github_source_impl, __MODULE__.Real))
+
+    impl.acquire(context, token, opts)
+  end
+
+  @impl true
+  def cleanup(path, opts \\ []) do
+    impl =
+      Keyword.get(opts, :impl, Application.get_env(:sykli, :github_source_impl, __MODULE__.Real))
+
+    impl.cleanup(path, opts)
+  end
+end

--- a/core/lib/sykli/github/source/behaviour.ex
+++ b/core/lib/sykli/github/source/behaviour.ex
@@ -1,0 +1,6 @@
+defmodule Sykli.GitHub.Source.Behaviour do
+  @moduledoc "Behaviour for GitHub source acquisition."
+
+  @callback acquire(map(), String.t(), keyword()) :: {:ok, String.t()} | {:error, Sykli.Error.t()}
+  @callback cleanup(String.t(), keyword()) :: :ok
+end

--- a/core/lib/sykli/github/source/fake.ex
+++ b/core/lib/sykli/github/source/fake.ex
@@ -1,0 +1,61 @@
+defmodule Sykli.GitHub.Source.Fake do
+  @moduledoc "Fixture-backed GitHub source acquisition for tests."
+
+  @behaviour Sykli.GitHub.Source.Behaviour
+
+  @base_dir Path.join(System.tmp_dir!(), "sykli-runs")
+
+  @impl true
+  def acquire(context, token, opts \\ []) do
+    notify(opts, {:github_source_acquire, context, token})
+
+    case Keyword.get(opts, :source_response, :default) do
+      :default -> copy_fixture(context, opts)
+      response -> response
+    end
+  end
+
+  @impl true
+  def cleanup(path, opts \\ []) do
+    notify(opts, {:github_source_cleanup, path})
+    Sykli.GitHub.Source.Real.cleanup(path, opts)
+  end
+
+  defp copy_fixture(context, opts) do
+    fixture = Keyword.fetch!(opts, :source_fixture)
+    run_id = Map.get(context, :run_id) || Map.get(context, :delivery_id) || "fake"
+    dest = Path.join([@base_dir, "fake-#{safe_segment(run_id)}", "repo"])
+
+    File.rm_rf!(Path.dirname(dest))
+    File.mkdir_p!(Path.dirname(dest))
+
+    case File.cp_r(fixture, dest) do
+      {:ok, _files} -> {:ok, dest}
+      {:error, reason, file} -> {:error, source_error(file, reason)}
+    end
+  end
+
+  defp safe_segment(value) do
+    value
+    |> to_string()
+    |> String.replace(~r/[^A-Za-z0-9._:-]/, "-")
+  end
+
+  defp source_error(file, reason) do
+    %Sykli.Error{
+      code: "github.source.copy_failed",
+      type: :runtime,
+      message: "failed to copy fixture source",
+      step: :setup,
+      cause: {file, reason},
+      hints: []
+    }
+  end
+
+  defp notify(opts, message) do
+    case Keyword.get(opts, :test_pid) do
+      pid when is_pid(pid) -> send(pid, message)
+      _ -> :ok
+    end
+  end
+end

--- a/core/lib/sykli/github/source/real.ex
+++ b/core/lib/sykli/github/source/real.ex
@@ -16,10 +16,10 @@ defmodule Sykli.GitHub.Source.Real do
     repo_dir = Path.join(root, "repo")
 
     with :ok <- ensure_contained(root),
-         :ok <- File.rm_rf!(root) |> always_ok(),
+         :ok <- remove_tree(root),
          :ok <- File.mkdir_p(root),
-         :ok <- clone(repo, repo_dir, token),
-         :ok <- checkout(repo_dir, sha, token) do
+         :ok <- clone(repo, repo_dir, token, opts),
+         :ok <- checkout(repo, repo_dir, sha, token, opts) do
       {:ok, repo_dir}
     else
       {:error, %Sykli.Error{} = error} ->
@@ -40,8 +40,7 @@ defmodule Sykli.GitHub.Source.Real do
   def cleanup(path, _opts) when is_binary(path) do
     case run_root(path) do
       {:ok, root} ->
-        File.rm_rf!(root)
-        :ok
+        remove_tree(root)
 
       :error ->
         :ok
@@ -50,10 +49,10 @@ defmodule Sykli.GitHub.Source.Real do
 
   def cleanup(_path, _opts), do: :ok
 
-  defp clone(repo, repo_dir, token) do
-    url = auth_url(repo, token)
+  defp clone(repo, repo_dir, token, opts) do
+    url = repo_url(repo)
 
-    case System.cmd("git", ["clone", "--depth", "1", url, repo_dir], stderr_to_stdout: true) do
+    case git(repo, token, ["clone", "--depth", "1", url, repo_dir], opts) do
       {_out, 0} ->
         :ok
 
@@ -67,21 +66,19 @@ defmodule Sykli.GitHub.Source.Real do
     end
   end
 
-  defp checkout(repo_dir, sha, token) do
+  defp checkout(repo, repo_dir, sha, token, opts) do
     case System.cmd("git", ["-C", repo_dir, "checkout", sha], stderr_to_stdout: true) do
       {_out, 0} ->
         :ok
 
       {_out, _code} ->
-        fetch_and_checkout(repo_dir, sha, token)
+        fetch_and_checkout(repo, repo_dir, sha, token, opts)
     end
   end
 
-  defp fetch_and_checkout(repo_dir, sha, token) do
+  defp fetch_and_checkout(repo, repo_dir, sha, token, opts) do
     with {_out, 0} <-
-           System.cmd("git", ["-C", repo_dir, "fetch", "--depth", "1", "origin", sha],
-             stderr_to_stdout: true
-           ),
+           git(repo, token, ["-C", repo_dir, "fetch", "--depth", "1", "origin", sha], opts),
          {_out, 0} <- System.cmd("git", ["-C", repo_dir, "checkout", sha], stderr_to_stdout: true) do
       :ok
     else
@@ -95,8 +92,41 @@ defmodule Sykli.GitHub.Source.Real do
     end
   end
 
-  defp auth_url(repo, token),
-    do: "https://x-access-token:#{URI.encode_www_form(token)}@github.com/#{repo}.git"
+  defp git(repo, token, args, opts) do
+    runner = Keyword.get(opts, :git_runner, &System.cmd/3)
+
+    with_git_auth_config(repo, token, fn auth_config ->
+      runner.("git", args, stderr_to_stdout: true, env: git_auth_env(auth_config))
+    end)
+  end
+
+  defp with_git_auth_config(repo, token, fun) do
+    path =
+      Path.join(System.tmp_dir!(), "sykli-git-auth-#{System.unique_integer([:positive])}.config")
+
+    try do
+      File.write!(path, git_auth_config(repo, token))
+      File.chmod(path, 0o600)
+      fun.(path)
+    after
+      File.rm(path)
+    end
+  end
+
+  defp git_auth_config(repo, token) do
+    """
+    [http "#{repo_url(repo)}"]
+        extraheader = Authorization: Bearer #{token}
+    """
+  end
+
+  defp git_auth_env(auth_config) do
+    [
+      {"GIT_CONFIG_GLOBAL", auth_config}
+    ]
+  end
+
+  defp repo_url(repo), do: "https://github.com/#{repo}.git"
 
   defp run_root(path) do
     expanded = Path.expand(path)
@@ -133,7 +163,12 @@ defmodule Sykli.GitHub.Source.Real do
     |> String.replace(~r/[^A-Za-z0-9._:-]/, "-")
   end
 
-  defp always_ok(_), do: :ok
+  defp remove_tree(path) do
+    case File.rm_rf(path) do
+      {:ok, _files} -> :ok
+      {:error, file, reason} -> {:error, {file, reason}}
+    end
+  end
 
   defp source_error(code, message, cause \\ nil) do
     %Sykli.Error{

--- a/core/lib/sykli/github/source/real.ex
+++ b/core/lib/sykli/github/source/real.ex
@@ -1,0 +1,148 @@
+defmodule Sykli.GitHub.Source.Real do
+  @moduledoc "Git-backed GitHub source acquisition."
+
+  @behaviour Sykli.GitHub.Source.Behaviour
+
+  alias Sykli.Services.SecretMasker
+
+  @base_dir Path.join(System.tmp_dir!(), "sykli-runs")
+
+  @impl true
+  def acquire(%{repo: repo, head_sha: sha} = context, token, opts \\ []) do
+    run_id =
+      Map.get(context, :run_id) || Keyword.get(opts, :run_id) || Map.get(context, :delivery_id)
+
+    root = Path.join(@base_dir, safe_segment(run_id || sha))
+    repo_dir = Path.join(root, "repo")
+
+    with :ok <- ensure_contained(root),
+         :ok <- File.rm_rf!(root) |> always_ok(),
+         :ok <- File.mkdir_p(root),
+         :ok <- clone(repo, repo_dir, token),
+         :ok <- checkout(repo_dir, sha, token) do
+      {:ok, repo_dir}
+    else
+      {:error, %Sykli.Error{} = error} ->
+        cleanup(root, opts)
+        {:error, error}
+
+      {:error, reason} ->
+        cleanup(root, opts)
+
+        {:error,
+         source_error("github.source.clone_failed", "failed to acquire GitHub source", reason)}
+    end
+  end
+
+  @impl true
+  def cleanup(path, opts \\ [])
+
+  def cleanup(path, _opts) when is_binary(path) do
+    case run_root(path) do
+      {:ok, root} ->
+        File.rm_rf!(root)
+        :ok
+
+      :error ->
+        :ok
+    end
+  end
+
+  def cleanup(_path, _opts), do: :ok
+
+  defp clone(repo, repo_dir, token) do
+    url = auth_url(repo, token)
+
+    case System.cmd("git", ["clone", "--depth", "1", url, repo_dir], stderr_to_stdout: true) do
+      {_out, 0} ->
+        :ok
+
+      {out, code} ->
+        {:error,
+         source_error(
+           "github.source.clone_failed",
+           "git clone failed",
+           %{exit_code: code, output: SecretMasker.mask_string(out, [token])}
+         )}
+    end
+  end
+
+  defp checkout(repo_dir, sha, token) do
+    case System.cmd("git", ["-C", repo_dir, "checkout", sha], stderr_to_stdout: true) do
+      {_out, 0} ->
+        :ok
+
+      {_out, _code} ->
+        fetch_and_checkout(repo_dir, sha, token)
+    end
+  end
+
+  defp fetch_and_checkout(repo_dir, sha, token) do
+    with {_out, 0} <-
+           System.cmd("git", ["-C", repo_dir, "fetch", "--depth", "1", "origin", sha],
+             stderr_to_stdout: true
+           ),
+         {_out, 0} <- System.cmd("git", ["-C", repo_dir, "checkout", sha], stderr_to_stdout: true) do
+      :ok
+    else
+      {out, code} ->
+        {:error,
+         source_error(
+           "github.source.checkout_failed",
+           "git checkout failed",
+           %{exit_code: code, output: SecretMasker.mask_string(out, [token])}
+         )}
+    end
+  end
+
+  defp auth_url(repo, token),
+    do: "https://x-access-token:#{URI.encode_www_form(token)}@github.com/#{repo}.git"
+
+  defp run_root(path) do
+    expanded = Path.expand(path)
+    base = Path.expand(@base_dir)
+
+    if expanded == base or String.starts_with?(expanded, base <> "/") do
+      [_empty, rest] = String.split(expanded, base, parts: 2)
+      segment = rest |> String.trim_leading("/") |> String.split("/", parts: 2) |> List.first()
+
+      if segment in [nil, ""] do
+        :error
+      else
+        {:ok, Path.join(base, segment)}
+      end
+    else
+      :error
+    end
+  end
+
+  defp ensure_contained(path) do
+    expanded = Path.expand(path)
+    base = Path.expand(@base_dir)
+
+    if String.starts_with?(expanded, base <> "/") do
+      :ok
+    else
+      {:error, source_error("github.source.path_escape", "source path escaped temp directory")}
+    end
+  end
+
+  defp safe_segment(value) do
+    value
+    |> to_string()
+    |> String.replace(~r/[^A-Za-z0-9._:-]/, "-")
+  end
+
+  defp always_ok(_), do: :ok
+
+  defp source_error(code, message, cause \\ nil) do
+    %Sykli.Error{
+      code: code,
+      type: :runtime,
+      message: message,
+      step: :setup,
+      cause: cause,
+      hints: []
+    }
+  end
+end

--- a/core/lib/sykli/github/webhook/receiver.ex
+++ b/core/lib/sykli/github/webhook/receiver.ex
@@ -62,21 +62,8 @@ defmodule Sykli.GitHub.Webhook.Receiver do
   defp process_accepted(conn, body, opts) do
     with {:ok, payload} <- decode_json(body),
          {:ok, context} <- webhook_context(conn, payload),
-         {:ok, token, _expires_at} <-
-           app_client(opts).installation_token(context.installation_id, opts),
-         {:ok, suite} <-
-           checks_client(opts).create_suite(
-             %{repo: context.repo, head_sha: context.head_sha},
-             token,
-             opts
-           ),
-         {:ok, run} <-
-           checks_client(opts).create_run(
-             %{repo: context.repo, head_sha: context.head_sha},
-             token,
-             Keyword.put(opts, :name, "sykli")
-           ) do
-      broadcast_success(context, suite, run)
+         :ok <- broadcast_received(context),
+         :ok <- start_dispatch(context, opts) do
       {:ok, send_json(conn, 202, %{ok: true, status: "queued"})}
     end
   end
@@ -102,7 +89,7 @@ defmodule Sykli.GitHub.Webhook.Receiver do
     })
   end
 
-  defp read_full_body(conn, opts \\ []) do
+  defp read_full_body(conn, opts) do
     # `max_body_bytes` is overridable via opts so tests can exercise the
     # 413 path without allocating a real 10 MB request body.
     max_bytes = Keyword.get(opts, :max_body_bytes, @max_body_bytes)
@@ -233,7 +220,7 @@ defmodule Sykli.GitHub.Webhook.Receiver do
   defp head_sha(_event, payload),
     do: payload["after"] || get_in(payload, ["pull_request", "head", "sha"])
 
-  defp broadcast_success(context, suite, run) do
+  defp broadcast_received(context) do
     run_id = "github:#{context.delivery_id}"
 
     OccPubSub.github_webhook_received(run_id, %{
@@ -243,23 +230,26 @@ defmodule Sykli.GitHub.Webhook.Receiver do
       head_sha: context.head_sha
     })
 
-    OccPubSub.github_check_suite_opened(run_id, %{
-      repo: context.repo,
-      head_sha: context.head_sha,
-      check_suite_id: suite["id"],
-      check_run_id: run["id"]
-    })
+    :ok
   end
 
-  defp app_client(opts),
-    do:
-      Keyword.get(
-        opts,
-        :app_client,
-        Application.get_env(:sykli, :github_app_impl, Sykli.GitHub.App)
-      )
+  defp start_dispatch(context, opts) do
+    dispatcher = Keyword.get(opts, :dispatcher, Sykli.GitHub.Dispatcher)
+    supervisor = Keyword.get(opts, :task_supervisor, Sykli.TaskSupervisor)
 
-  defp checks_client(opts), do: Keyword.get(opts, :checks_client, Sykli.GitHub.Checks)
+    case Task.Supervisor.start_child(supervisor, fn -> dispatcher.dispatch(context, opts) end) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, reason} ->
+        {:error,
+         webhook_error(
+           "github.webhook.dispatch_failed",
+           "GitHub webhook dispatch could not be started",
+           reason
+         )}
+    end
+  end
 
   defp status_for(%Sykli.Error{code: "github.webhook.bad_signature"}), do: 401
   defp status_for(%Sykli.Error{code: "github.webhook.missing_signature"}), do: 400
@@ -269,6 +259,7 @@ defmodule Sykli.GitHub.Webhook.Receiver do
   defp status_for(%Sykli.Error{code: "github.webhook.invalid_json"}), do: 400
   defp status_for(%Sykli.Error{code: "github.webhook.unsupported_payload"}), do: 400
   defp status_for(%Sykli.Error{code: "github.webhook.body_too_large"}), do: 413
+  defp status_for(%Sykli.Error{code: "github.webhook.dispatch_failed"}), do: 502
   # `body_read_failed` fires when Plug's read_body returns {:error, _} —
   # typically a timeout or transport IO error on the client connection,
   # not a malformed request. 408 (Request Timeout) is more honest than 400.

--- a/core/lib/sykli/occurrence.ex
+++ b/core/lib/sykli/occurrence.ex
@@ -23,6 +23,13 @@ defmodule Sykli.Occurrence do
       ci.gate.resolved     — gate approved/denied/timed out
       ci.github.webhook.received — GitHub webhook accepted
       ci.github.check_suite.opened — GitHub check suite opened
+      ci.github.run.dispatched — GitHub webhook dispatch started
+      ci.github.run.source_acquired — GitHub source clone succeeded
+      ci.github.run.source_failed — GitHub source clone failed
+      ci.github.check_run.created — GitHub check run created
+      ci.github.check_run.transitioned — GitHub check run status changed
+      ci.github.check_run.transition_failed — GitHub check run update failed
+      ci.github.check_suite.concluded — GitHub check suite reached terminal state
 
   ## Enrichment
 
@@ -224,6 +231,69 @@ defmodule Sykli.Occurrence do
   @spec github_check_suite_opened(String.t(), map(), keyword()) :: t()
   def github_check_suite_opened(run_id, data, opts \\ []) do
     new("ci.github.check_suite.opened", run_id, data,
+      severity: :info,
+      opts: opts
+    )
+  end
+
+  @doc "Create a ci.github.run.dispatched occurrence."
+  @spec github_run_dispatched(String.t(), map(), keyword()) :: t()
+  def github_run_dispatched(run_id, data, opts \\ []) do
+    new("ci.github.run.dispatched", run_id, data,
+      severity: :info,
+      opts: opts
+    )
+  end
+
+  @doc "Create a ci.github.run.source_acquired occurrence."
+  @spec github_run_source_acquired(String.t(), map(), keyword()) :: t()
+  def github_run_source_acquired(run_id, data, opts \\ []) do
+    new("ci.github.run.source_acquired", run_id, data,
+      severity: :info,
+      opts: opts
+    )
+  end
+
+  @doc "Create a ci.github.run.source_failed occurrence."
+  @spec github_run_source_failed(String.t(), map(), keyword()) :: t()
+  def github_run_source_failed(run_id, data, opts \\ []) do
+    new("ci.github.run.source_failed", run_id, data,
+      severity: :error,
+      opts: opts
+    )
+  end
+
+  @doc "Create a ci.github.check_run.created occurrence."
+  @spec github_check_run_created(String.t(), map(), keyword()) :: t()
+  def github_check_run_created(run_id, data, opts \\ []) do
+    new("ci.github.check_run.created", run_id, data,
+      severity: :info,
+      opts: opts
+    )
+  end
+
+  @doc "Create a ci.github.check_run.transitioned occurrence."
+  @spec github_check_run_transitioned(String.t(), map(), keyword()) :: t()
+  def github_check_run_transitioned(run_id, data, opts \\ []) do
+    new("ci.github.check_run.transitioned", run_id, data,
+      severity: :info,
+      opts: opts
+    )
+  end
+
+  @doc "Create a ci.github.check_run.transition_failed occurrence."
+  @spec github_check_run_transition_failed(String.t(), map(), keyword()) :: t()
+  def github_check_run_transition_failed(run_id, data, opts \\ []) do
+    new("ci.github.check_run.transition_failed", run_id, data,
+      severity: :warning,
+      opts: opts
+    )
+  end
+
+  @doc "Create a ci.github.check_suite.concluded occurrence."
+  @spec github_check_suite_concluded(String.t(), map(), keyword()) :: t()
+  def github_check_suite_concluded(run_id, data, opts \\ []) do
+    new("ci.github.check_suite.concluded", run_id, data,
       severity: :info,
       opts: opts
     )

--- a/core/lib/sykli/occurrence/pubsub.ex
+++ b/core/lib/sykli/occurrence/pubsub.ex
@@ -32,6 +32,13 @@ defmodule Sykli.Occurrence.PubSub do
       "ci.gate.resolved"   — gate approved/denied/timed out
       "ci.github.webhook.received" — GitHub webhook accepted
       "ci.github.check_suite.opened" — GitHub check suite opened
+      "ci.github.run.dispatched" — GitHub webhook dispatch started
+      "ci.github.run.source_acquired" — GitHub source clone succeeded
+      "ci.github.run.source_failed" — GitHub source clone failed
+      "ci.github.check_run.created" — GitHub check run created
+      "ci.github.check_run.transitioned" — GitHub check run status changed
+      "ci.github.check_run.transition_failed" — GitHub check run update failed
+      "ci.github.check_suite.concluded" — GitHub check suite reached terminal state
   """
 
   alias Sykli.Occurrence
@@ -135,6 +142,55 @@ defmodule Sykli.Occurrence.PubSub do
   @doc "Broadcast a ci.github.check_suite.opened occurrence. Returns the Occurrence."
   def github_check_suite_opened(run_id, data) do
     occ = Occurrence.github_check_suite_opened(run_id, data)
+    broadcast(occ)
+    occ
+  end
+
+  @doc "Broadcast a ci.github.run.dispatched occurrence. Returns the Occurrence."
+  def github_run_dispatched(run_id, data) do
+    occ = Occurrence.github_run_dispatched(run_id, data)
+    broadcast(occ)
+    occ
+  end
+
+  @doc "Broadcast a ci.github.run.source_acquired occurrence. Returns the Occurrence."
+  def github_run_source_acquired(run_id, data) do
+    occ = Occurrence.github_run_source_acquired(run_id, data)
+    broadcast(occ)
+    occ
+  end
+
+  @doc "Broadcast a ci.github.run.source_failed occurrence. Returns the Occurrence."
+  def github_run_source_failed(run_id, data) do
+    occ = Occurrence.github_run_source_failed(run_id, data)
+    broadcast(occ)
+    occ
+  end
+
+  @doc "Broadcast a ci.github.check_run.created occurrence. Returns the Occurrence."
+  def github_check_run_created(run_id, data) do
+    occ = Occurrence.github_check_run_created(run_id, data)
+    broadcast(occ)
+    occ
+  end
+
+  @doc "Broadcast a ci.github.check_run.transitioned occurrence. Returns the Occurrence."
+  def github_check_run_transitioned(run_id, data) do
+    occ = Occurrence.github_check_run_transitioned(run_id, data)
+    broadcast(occ)
+    occ
+  end
+
+  @doc "Broadcast a ci.github.check_run.transition_failed occurrence. Returns the Occurrence."
+  def github_check_run_transition_failed(run_id, data) do
+    occ = Occurrence.github_check_run_transition_failed(run_id, data)
+    broadcast(occ)
+    occ
+  end
+
+  @doc "Broadcast a ci.github.check_suite.concluded occurrence. Returns the Occurrence."
+  def github_check_suite_concluded(run_id, data) do
+    occ = Occurrence.github_check_suite_concluded(run_id, data)
     broadcast(occ)
     occ
   end

--- a/core/priv/test_fixtures/github_source/simple/sykli.exs
+++ b/core/priv/test_fixtures/github_source/simple/sykli.exs
@@ -1,0 +1,1 @@
+IO.puts(~s({"version":"1","tasks":[{"name":"test","command":"echo ok"}]}))

--- a/core/test/sykli/github/check_run_formatter_test.exs
+++ b/core/test/sykli/github/check_run_formatter_test.exs
@@ -1,0 +1,42 @@
+defmodule Sykli.GitHub.CheckRunFormatterTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.Executor.TaskResult
+  alias Sykli.GitHub.CheckRunFormatter
+
+  test "maps Sykli task statuses to GitHub conclusions" do
+    assert conclusion(:passed) == "success"
+    assert conclusion(:failed) == "failure"
+    assert conclusion(:errored) == "failure"
+    assert conclusion(:cached) == "success"
+    assert conclusion(:skipped) == "skipped"
+    assert conclusion(:blocked) == "cancelled"
+  end
+
+  test "formats errored results as infrastructure failures" do
+    result = %TaskResult{
+      name: "setup",
+      status: :errored,
+      duration_ms: 12,
+      error: Sykli.Error.internal("runtime unavailable"),
+      output: nil,
+      command: "setup"
+    }
+
+    formatted = CheckRunFormatter.format(result)
+
+    assert formatted.title == "setup: errored"
+    assert formatted.summary =~ "Infrastructure failure"
+    assert formatted.summary =~ "runtime unavailable"
+  end
+
+  test "cache hit titles are explicit" do
+    result = %TaskResult{name: "deps", status: :cached, duration_ms: 1}
+
+    assert CheckRunFormatter.format(result).title == "deps: cached (cache hit)"
+  end
+
+  defp conclusion(status) do
+    CheckRunFormatter.conclusion(%TaskResult{name: "task", status: status, duration_ms: 1})
+  end
+end

--- a/core/test/sykli/github/dispatcher_test.exs
+++ b/core/test/sykli/github/dispatcher_test.exs
@@ -87,4 +87,24 @@ defmodule Sykli.GitHub.DispatcherTest do
 
     assert :ok = Deliveries.accept(event.delivery_id, 2)
   end
+
+  test "GitHub App config failures do not evict the delivery", %{event: event} do
+    assert :ok = Deliveries.accept(event.delivery_id, 1)
+
+    assert {:error, %Sykli.Error{code: "github.app.missing_config"}} =
+             Dispatcher.dispatch(event,
+               app_client: Sykli.GitHub.App.Fake,
+               app_response:
+                 {:error,
+                  %Sykli.Error{
+                    code: "github.app.missing_config",
+                    type: :runtime,
+                    message: "SYKLI_GITHUB_APP_ID is required",
+                    step: :setup,
+                    hints: []
+                  }}
+             )
+
+    assert {:error, :duplicate_delivery} = Deliveries.accept(event.delivery_id, 2)
+  end
 end

--- a/core/test/sykli/github/dispatcher_test.exs
+++ b/core/test/sykli/github/dispatcher_test.exs
@@ -1,0 +1,90 @@
+defmodule Sykli.GitHub.DispatcherTest do
+  use ExUnit.Case, async: false
+
+  alias Sykli.GitHub.Dispatcher
+  alias Sykli.GitHub.Webhook.Deliveries
+  alias Sykli.Occurrence.PubSub
+
+  @fixture Path.expand("../../../priv/test_fixtures/github_source/simple", __DIR__)
+
+  setup do
+    Deliveries.clear()
+    PubSub.subscribe()
+
+    on_exit(fn ->
+      PubSub.unsubscribe()
+      Deliveries.clear()
+    end)
+
+    event = %{
+      event: "pull_request",
+      delivery_id: "dispatcher-delivery",
+      repo: "false-systems/sykli",
+      installation_id: 123,
+      head_sha: "abc123"
+    }
+
+    {:ok, event: event}
+  end
+
+  test "dispatch creates per-task check runs and transitions them", %{event: event} do
+    assert :ok =
+             Dispatcher.dispatch(event,
+               app_client: Sykli.GitHub.App.Fake,
+               checks_client: Sykli.GitHub.Checks.Fake,
+               source_client: Sykli.GitHub.Source.Fake,
+               source_fixture: @fixture,
+               test_pid: self(),
+               fake_recorder: self()
+             )
+
+    assert_receive {:github_checks_create_suite, %{repo: "false-systems/sykli"},
+                    "fake-installation-token-123"}
+
+    assert_receive {:github_checks_create_run, %{head_sha: "abc123"},
+                    "fake-installation-token-123", "test"}
+
+    assert_receive {:github_checks_update_run, %{check_run_id: _}, "fake-installation-token-123",
+                    %{status: "in_progress"}}
+
+    assert_receive {:github_checks_update_run, %{check_run_id: _}, "fake-installation-token-123",
+                    %{status: "completed", conclusion: "success"}}
+
+    assert_receive %Sykli.Occurrence{type: "ci.github.run.dispatched"}
+    assert_receive %Sykli.Occurrence{type: "ci.github.run.source_acquired"}
+    assert_receive %Sykli.Occurrence{type: "ci.github.check_run.created"}
+    assert_receive %Sykli.Occurrence{type: "ci.github.check_suite.concluded"}
+  end
+
+  test "dispatch failure evicts the delivery for GitHub retry", %{event: event} do
+    assert :ok = Deliveries.accept(event.delivery_id, 1)
+
+    assert {:error, %Sykli.Error{code: "github.source.clone_failed"}} =
+             Dispatcher.dispatch(event,
+               app_client: Sykli.GitHub.App.Fake,
+               checks_client: Sykli.GitHub.Checks.Fake,
+               source_client: Sykli.GitHub.Source.Fake,
+               test_pid: self(),
+               source_response:
+                 {:error,
+                  %Sykli.Error{
+                    code: "github.source.clone_failed",
+                    type: :runtime,
+                    message: "clone failed",
+                    step: :setup,
+                    hints: []
+                  }}
+             )
+
+    assert_receive {:github_checks_create_run, %{head_sha: "abc123"},
+                    "fake-installation-token-123", "sykli/source"}
+
+    assert_receive {:github_checks_update_run, %{check_run_id: _}, "fake-installation-token-123",
+                    %{status: "completed", conclusion: "failure"}}
+
+    assert_receive %Sykli.Occurrence{type: "ci.github.run.source_failed"}
+    assert_receive %Sykli.Occurrence{type: "ci.github.check_suite.concluded"}
+
+    assert :ok = Deliveries.accept(event.delivery_id, 2)
+  end
+end

--- a/core/test/sykli/github/source_test.exs
+++ b/core/test/sykli/github/source_test.exs
@@ -25,7 +25,90 @@ defmodule Sykli.GitHub.SourceTest do
     refute File.exists?(path)
   end
 
+  test "real source uses transient git auth and does not persist the token" do
+    token = "ghs_secret_installation_token"
+    parent = self()
+
+    git_runner = fn "git", args, opts ->
+      send(parent, {:git_invocation, args, opts})
+
+      case args do
+        ["clone", "--depth", "1", url, repo_dir] ->
+          init_repo(repo_dir, url)
+          {"", 0}
+
+        _ ->
+          {"", 0}
+      end
+    end
+
+    assert {:ok, path} =
+             Sykli.GitHub.Source.Real.acquire(
+               %{
+                 repo: "false-systems/sykli",
+                 head_sha: "HEAD",
+                 delivery_id: "token-safe",
+                 run_id: "github:token-safe"
+               },
+               token,
+               git_runner: git_runner
+             )
+
+    config = File.read!(Path.join([path, ".git", "config"]))
+
+    refute String.contains?(config, token)
+    refute String.contains?(config, "x-access-token")
+    assert String.contains?(config, "https://github.com/false-systems/sykli.git")
+
+    assert_receive {:git_invocation, ["clone", "--depth", "1", url, _repo_dir], opts}
+    assert url == "https://github.com/false-systems/sykli.git"
+    refute url =~ token
+    refute inspect(opts) =~ token
+
+    env = Keyword.fetch!(opts, :env)
+    {"GIT_CONFIG_GLOBAL", auth_config} = List.keyfind(env, "GIT_CONFIG_GLOBAL", 0)
+
+    refute inspect(env) =~ token
+    refute File.exists?(auth_config)
+
+    assert :ok = Sykli.GitHub.Source.Real.cleanup(path)
+  end
+
   test "real cleanup refuses paths outside the sykli temp root" do
-    assert :ok = Sykli.GitHub.Source.Real.cleanup("/tmp/not-sykli-source")
+    decoy = Path.join(System.tmp_dir!(), "not-sykli-source-decoy")
+    sentinel = Path.join(decoy, "sentinel")
+
+    File.mkdir_p!(decoy)
+    File.write!(sentinel, "keep")
+
+    assert :ok = Sykli.GitHub.Source.Real.cleanup(decoy)
+    assert File.exists?(sentinel)
+
+    File.rm_rf!(decoy)
+  end
+
+  defp init_repo(repo_dir, remote_url) do
+    File.mkdir_p!(repo_dir)
+    File.write!(Path.join(repo_dir, "sykli.exs"), "[]\n")
+
+    System.cmd("git", ["init", "-b", "main"], cd: repo_dir, stderr_to_stdout: true)
+
+    System.cmd("git", ["config", "user.email", "test@example.com"],
+      cd: repo_dir,
+      stderr_to_stdout: true
+    )
+
+    System.cmd("git", ["config", "user.name", "Source Test"],
+      cd: repo_dir,
+      stderr_to_stdout: true
+    )
+
+    System.cmd("git", ["remote", "add", "origin", remote_url],
+      cd: repo_dir,
+      stderr_to_stdout: true
+    )
+
+    System.cmd("git", ["add", "sykli.exs"], cd: repo_dir, stderr_to_stdout: true)
+    System.cmd("git", ["commit", "-m", "initial"], cd: repo_dir, stderr_to_stdout: true)
   end
 end

--- a/core/test/sykli/github/source_test.exs
+++ b/core/test/sykli/github/source_test.exs
@@ -1,0 +1,31 @@
+defmodule Sykli.GitHub.SourceTest do
+  use ExUnit.Case, async: false
+
+  alias Sykli.GitHub.Source
+
+  @fixture Path.expand("../../../priv/test_fixtures/github_source/simple", __DIR__)
+
+  test "fake source copies a fixture repo and cleans it up" do
+    context = %{
+      repo: "false-systems/sykli",
+      head_sha: "abc123",
+      delivery_id: "source-test",
+      run_id: "github:source-test"
+    }
+
+    assert {:ok, path} =
+             Source.acquire(context, "installation-token",
+               impl: Sykli.GitHub.Source.Fake,
+               source_fixture: @fixture
+             )
+
+    assert File.exists?(Path.join(path, "sykli.exs"))
+
+    assert :ok = Source.cleanup(path, impl: Sykli.GitHub.Source.Fake)
+    refute File.exists?(path)
+  end
+
+  test "real cleanup refuses paths outside the sykli temp root" do
+    assert :ok = Sykli.GitHub.Source.Real.cleanup("/tmp/not-sykli-source")
+  end
+end

--- a/core/test/sykli/github/webhook/receiver_test.exs
+++ b/core/test/sykli/github/webhook/receiver_test.exs
@@ -52,8 +52,8 @@ defmodule Sykli.GitHub.Webhook.ReceiverTest do
       |> Receiver.call(
         webhook_secret: @secret,
         clock: Sykli.GitHub.Clock.Fake,
-        app_client: __MODULE__.App,
-        checks_client: __MODULE__.Checks
+        dispatcher: __MODULE__.Dispatcher,
+        test_pid: self()
       )
 
     assert conn.status == 503
@@ -72,8 +72,8 @@ defmodule Sykli.GitHub.Webhook.ReceiverTest do
       |> Receiver.call(
         webhook_secret: @secret,
         clock: Sykli.GitHub.Clock.Fake,
-        app_client: __MODULE__.App,
-        checks_client: __MODULE__.Checks
+        dispatcher: __MODULE__.Dispatcher,
+        test_pid: self()
       )
 
     assert conn.status == 202
@@ -84,10 +84,7 @@ defmodule Sykli.GitHub.Webhook.ReceiverTest do
       data: %{repo: "false-systems/sykli"}
     }
 
-    assert_receive %Sykli.Occurrence{
-      type: "ci.github.check_suite.opened",
-      data: %{check_suite_id: 101, check_run_id: 202}
-    }
+    assert_receive {:receiver_dispatch, %{repo: "false-systems/sykli", head_sha: "abc123"}}
   end
 
   test "wrong signature is rejected without logging the raw body" do
@@ -149,8 +146,8 @@ defmodule Sykli.GitHub.Webhook.ReceiverTest do
     opts = [
       webhook_secret: @secret,
       clock: Sykli.GitHub.Clock.Fake,
-      app_client: __MODULE__.App,
-      checks_client: __MODULE__.Checks
+      dispatcher: __MODULE__.Dispatcher,
+      test_pid: self()
     ]
 
     first =
@@ -173,17 +170,26 @@ defmodule Sykli.GitHub.Webhook.ReceiverTest do
     assert second.status == 409
   end
 
-  test "upstream Checks API failure evicts the delivery so a retry can succeed" do
+  test "post-accept dispatch failure evicts the delivery so a retry can succeed" do
     :ok = Roles.acquire(:webhook_receiver)
 
     opts_failing = [
       webhook_secret: @secret,
       clock: Sykli.GitHub.Clock.Fake,
-      app_client: __MODULE__.App,
-      checks_client: __MODULE__.FailingChecks
+      dispatcher: __MODULE__.Dispatcher,
+      test_pid: self(),
+      dispatch_result:
+        {:error,
+         %Sykli.Error{
+           code: "github.dispatch.failed",
+           type: :runtime,
+           message: "dispatch failed",
+           step: :run,
+           hints: []
+         }}
     ]
 
-    opts_ok = Keyword.put(opts_failing, :checks_client, __MODULE__.Checks)
+    opts_ok = Keyword.put(opts_failing, :dispatch_result, :ok)
 
     failing =
       :post
@@ -193,15 +199,18 @@ defmodule Sykli.GitHub.Webhook.ReceiverTest do
       |> put_req_header("x-github-event", "pull_request")
       |> Receiver.call(opts_failing)
 
-    assert failing.status == 502
+    assert failing.status == 202
+    assert_receive {:receiver_dispatch, %{delivery_id: "delivery-retry-me"}}
 
     retry =
-      :post
-      |> conn("/webhook", @body)
-      |> put_req_header("x-hub-signature-256", Signature.sign(@secret, @body))
-      |> put_req_header("x-github-delivery", "delivery-retry-me")
-      |> put_req_header("x-github-event", "pull_request")
-      |> Receiver.call(opts_ok)
+      eventually(fn ->
+        :post
+        |> conn("/webhook", @body)
+        |> put_req_header("x-hub-signature-256", Signature.sign(@secret, @body))
+        |> put_req_header("x-github-delivery", "delivery-retry-me")
+        |> put_req_header("x-github-event", "pull_request")
+        |> Receiver.call(opts_ok)
+      end)
 
     assert retry.status == 202
   end
@@ -219,8 +228,8 @@ defmodule Sykli.GitHub.Webhook.ReceiverTest do
       |> Receiver.call(
         webhook_secret: @secret,
         clock: Sykli.GitHub.Clock.Fake,
-        app_client: __MODULE__.App,
-        checks_client: __MODULE__.Checks
+        dispatcher: __MODULE__.Dispatcher,
+        test_pid: self()
       )
 
     unsigned =
@@ -237,28 +246,35 @@ defmodule Sykli.GitHub.Webhook.ReceiverTest do
              "github.webhook.missing_signature"
   end
 
-  defmodule App do
-    def installation_token(123, _opts), do: {:ok, "installation-token", 4_102_444_800}
+  defp eventually(fun, attempts \\ 20)
+
+  defp eventually(fun, attempts) when attempts > 0 do
+    case fun.() do
+      %{status: 409} ->
+        Process.sleep(10)
+        eventually(fun, attempts - 1)
+
+      result ->
+        result
+    end
   end
 
-  defmodule Checks do
-    def create_suite(
-          %{repo: "false-systems/sykli", head_sha: "abc123"},
-          "installation-token",
-          _opts
-        ),
-        do: {:ok, %{"id" => 101}}
+  defp eventually(fun, 0), do: fun.()
 
-    def create_run(
-          %{repo: "false-systems/sykli", head_sha: "abc123"},
-          "installation-token",
-          _opts
-        ),
-        do: {:ok, %{"id" => 202}}
-  end
+  defmodule Dispatcher do
+    def dispatch(context, opts) do
+      if pid = Keyword.get(opts, :test_pid) do
+        send(pid, {:receiver_dispatch, context})
+      end
 
-  defmodule FailingChecks do
-    def create_suite(_repo, _token, _opts), do: {:error, :upstream_5xx}
-    def create_run(_repo, _token, _opts), do: {:error, :upstream_5xx}
+      case Keyword.get(opts, :dispatch_result, :ok) do
+        {:error, _error} = error ->
+          Sykli.GitHub.Webhook.Deliveries.evict(context.delivery_id)
+          error
+
+        :ok ->
+          :ok
+      end
+    end
   end
 end

--- a/docs/github-native.md
+++ b/docs/github-native.md
@@ -1,8 +1,6 @@
 # GitHub-native Sykli
 
-Sykli can receive GitHub webhooks on a node in your own mesh and report queued Checks API state back to GitHub. This keeps execution local-first: GitHub sends events to hardware you control, and Sykli never operates a hosted control plane.
-
-Phase 1 opens a queued check only. It does not dispatch a pipeline yet.
+Sykli can receive GitHub webhooks on a node in your own mesh, run the repository's execution graph locally, and report per-task Checks API state back to GitHub. This keeps execution local-first: GitHub sends events to hardware you control, and Sykli never operates a hosted control plane.
 
 ## 1. Label One Mesh Node
 
@@ -23,6 +21,7 @@ Create a GitHub App in your account or organization:
 - Webhook secret: generate a long random value.
 - Repository permissions:
   - Checks: Read and write
+  - Contents: Read-only
   - Metadata: Read-only
   - Pull requests: Read-only
 - Subscribe to events:
@@ -78,7 +77,11 @@ Expected result:
 2. Sykli verifies `X-Hub-Signature-256`.
 3. Sykli rejects duplicate `X-GitHub-Delivery` IDs.
 4. Sykli exchanges the App JWT for an installation token.
-5. Sykli creates a Check Suite and a placeholder Check Run with status `queued`.
+5. Sykli creates a Check Suite.
+6. Sykli clones the repository at the webhook head SHA with the installation token.
+7. Sykli detects the `sykli.{go,rs,ts,exs,py}` file and builds the task graph.
+8. Sykli creates one Check Run per task at `queued`.
+9. Sykli runs the graph locally and transitions each Check Run through `in_progress` to its terminal conclusion.
 
 You can inspect the queued suite with GitHub CLI:
 
@@ -86,4 +89,26 @@ You can inspect the queued suite with GitHub CLI:
 gh api /repos/OWNER/REPO/check-suites --jq '.check_suites[] | {id, status, head_sha}'
 ```
 
-The queued state is intentional in Phase 1. Pipeline dispatch and check-run lifecycle transitions land in Phase 2.
+Inspect the per-task runs with:
+
+```bash
+gh api /repos/OWNER/REPO/commits/HEAD/check-runs --jq '.check_runs[] | {name, status, conclusion}'
+```
+
+Task failures render the last task output lines in the Check Run summary. Infrastructure failures use the same `failure` conclusion as command failures, but the summary calls out the infrastructure failure explicitly.
+
+## Occurrences
+
+The receiver and dispatcher emit these GitHub-native occurrences:
+
+- `ci.github.webhook.received`
+- `ci.github.run.dispatched`
+- `ci.github.check_suite.opened`
+- `ci.github.run.source_acquired`
+- `ci.github.run.source_failed`
+- `ci.github.check_run.created`
+- `ci.github.check_run.transitioned`
+- `ci.github.check_run.transition_failed`
+- `ci.github.check_suite.concluded`
+
+These are regular Sykli occurrences and can be consumed through the same occurrence stream as local runs.


### PR DESCRIPTION
Summary: closes the GitHub-native loop from accepted webhook to local execution and per-task GitHub check runs.\n\nScope:\n- Adds Source behaviour with Real git clone and Fake fixture-backed source acquisition.\n- Splits GitHub Checks behind Behaviour/Real/Fake and adds HTTPClient.Fake.\n- Adds Dispatcher to acquire source, build the graph, run Executor, and transition per-task check runs.\n- Wires Receiver to return 202 after accepted webhook and dispatch asynchronously under Sykli.TaskSupervisor.\n- Adds Phase 2 GitHub-native occurrence types and check-run formatting.\n- Updates docs/github-native.md for contents:read, per-task runs, and new occurrences.\n\nVerification:\n- cd core && mix test\n- cd core && mix credo\n- cd core && mix escript.build\n- test/blackbox/run.sh: 137 passed, 11 expected-red, 0 failed\n\nScreenshot/API proof:\n- Not attached: this PR uses local fakes and fixture source for the Phase 2 loop. A live PR Checks-tab capture requires an installed GitHub App on an exposed receiver endpoint.