### PR TITLE
fix(github): create task check runs in progress

### DIFF
--- a/core/lib/sykli/github/checks/fake.ex
+++ b/core/lib/sykli/github/checks/fake.ex
@@ -11,7 +11,11 @@ defmodule Sykli.GitHub.Checks.Fake do
 
   @impl true
   def create_run(context, token, opts \\ []) do
-    notify(opts, {:github_checks_create_run, context, token, Keyword.get(opts, :name)})
+    notify(
+      opts,
+      {:github_checks_create_run, context, token, Keyword.get(opts, :name),
+       Keyword.get(opts, :status, "queued")}
+    )
 
     case response(opts, :create_run_response, :default) do
       :default ->

--- a/core/lib/sykli/github/checks/real.ex
+++ b/core/lib/sykli/github/checks/real.ex
@@ -22,12 +22,13 @@ defmodule Sykli.GitHub.Checks.Real do
   @impl true
   def create_run(%{repo: repo, head_sha: head_sha}, token, opts \\ []) do
     name = Keyword.get(opts, :name, "sykli")
+    status = Keyword.get(opts, :status, "queued")
 
     request(
       :post,
       "/repos/#{repo}/check-runs",
       token,
-      %{name: name, head_sha: head_sha, status: "queued"},
+      %{name: name, head_sha: head_sha, status: status},
       opts,
       "github.checks.write_failed"
     )

--- a/core/lib/sykli/github/dispatcher.ex
+++ b/core/lib/sykli/github/dispatcher.ex
@@ -95,7 +95,6 @@ defmodule Sykli.GitHub.Dispatcher do
   defp dispatch_from_source(event, token, source_path, opts) do
     with {:ok, graph, tasks} <- load_graph(source_path),
          {:ok, check_runs} <- create_task_runs(event, token, tasks, opts),
-         :ok <- mark_in_progress(event, token, check_runs, opts),
          {:ok, results} <- run_executor(tasks, graph, source_path, event.run_id, opts),
          :ok <- conclude_task_runs(event, token, check_runs, results, opts) do
       {:ok, results}
@@ -167,7 +166,9 @@ defmodule Sykli.GitHub.Dispatcher do
       case checks_client(opts).create_run(
              %{repo: event.repo, head_sha: event.head_sha},
              token,
-             Keyword.put(opts, :name, task.name)
+             opts
+             |> Keyword.put(:name, task.name)
+             |> Keyword.put(:status, "in_progress")
            ) do
         {:ok, run} ->
           check_run_id = run["id"]
@@ -183,26 +184,6 @@ defmodule Sykli.GitHub.Dispatcher do
           {:halt, {:error, error}}
       end
     end)
-  end
-
-  defp mark_in_progress(event, token, check_runs, opts) do
-    check_runs
-    |> Enum.each(fn {task_name, check_run_id} ->
-      transition_check_run(
-        event,
-        token,
-        task_name,
-        check_run_id,
-        "queued",
-        "in_progress",
-        %{
-          status: "in_progress"
-        },
-        opts
-      )
-    end)
-
-    :ok
   end
 
   defp run_executor(tasks, graph, source_path, run_id, opts) do

--- a/core/test/sykli/github/checks_test.exs
+++ b/core/test/sykli/github/checks_test.exs
@@ -20,12 +20,13 @@ defmodule Sykli.GitHub.ChecksTest do
     assert Jason.decode!(body) == %{"head_sha" => "abc123"}
   end
 
-  test "create_run creates queued placeholder check run" do
+  test "create_run creates check run with requested status" do
     assert {:ok, %{"id" => 202}} =
              Checks.create_run(%{repo: "false-systems/sykli", head_sha: "abc123"}, "token",
                http_client: __MODULE__.HTTP,
                api_url: "https://api.github.test",
-               name: "sykli"
+               name: "sykli",
+               status: "in_progress"
              )
 
     [{:post, url, body}] = Application.get_env(:sykli, :github_http_requests)
@@ -34,7 +35,7 @@ defmodule Sykli.GitHub.ChecksTest do
     assert Jason.decode!(body) == %{
              "head_sha" => "abc123",
              "name" => "sykli",
-             "status" => "queued"
+             "status" => "in_progress"
            }
   end
 

--- a/core/test/sykli/github/dispatcher_test.exs
+++ b/core/test/sykli/github/dispatcher_test.exs
@@ -42,13 +42,13 @@ defmodule Sykli.GitHub.DispatcherTest do
                     "fake-installation-token-123"}
 
     assert_receive {:github_checks_create_run, %{head_sha: "abc123"},
-                    "fake-installation-token-123", "test"}
-
-    assert_receive {:github_checks_update_run, %{check_run_id: _}, "fake-installation-token-123",
-                    %{status: "in_progress"}}
+                    "fake-installation-token-123", "test", "in_progress"}
 
     assert_receive {:github_checks_update_run, %{check_run_id: _}, "fake-installation-token-123",
                     %{status: "completed", conclusion: "success"}}
+
+    refute_received {:github_checks_update_run, %{check_run_id: _}, "fake-installation-token-123",
+                     %{status: "in_progress"}}
 
     assert_receive %Sykli.Occurrence{type: "ci.github.run.dispatched"}
     assert_receive %Sykli.Occurrence{type: "ci.github.run.source_acquired"}
@@ -77,7 +77,7 @@ defmodule Sykli.GitHub.DispatcherTest do
              )
 
     assert_receive {:github_checks_create_run, %{head_sha: "abc123"},
-                    "fake-installation-token-123", "sykli/source"}
+                    "fake-installation-token-123", "sykli/source", "queued"}
 
     assert_receive {:github_checks_update_run, %{check_run_id: _}, "fake-installation-token-123",
                     %{status: "completed", conclusion: "failure"}}


### PR DESCRIPTION
Summary:
- Creates per-task GitHub Check Runs directly with status in_progress.
- Removes the queued -> in_progress PATCH transition from the dispatcher.
- Keeps setup-failure check runs queued -> completed, since those are not task runs.
- Updates Checks.Real to honor opts[:status] and updates Fake/test assertions.

Closes #155.
Closes #157.

Validation:
- cd core && mix format
- cd core && env -u SYKLI_LABELS mix test test/sykli/github/dispatcher_test.exs test/sykli/github/checks_test.exs
