### PR TITLE
fix(github): avoid walking source tree for size

### DIFF
--- a/core/lib/sykli/github/dispatcher.ex
+++ b/core/lib/sykli/github/dispatcher.ex
@@ -131,7 +131,7 @@ defmodule Sykli.GitHub.Dispatcher do
           repo: event.repo,
           sha: event.head_sha,
           path: path,
-          bytes: directory_bytes(path)
+          bytes: directory_bytes(path, opts)
         })
 
         {:ok, path}
@@ -352,17 +352,28 @@ defmodule Sykli.GitHub.Dispatcher do
     end
   end
 
-  defp directory_bytes(path) do
-    path
-    |> Path.join("**/*")
-    |> Path.wildcard()
-    |> Enum.filter(&File.regular?/1)
-    |> Enum.reduce(0, fn file, acc ->
-      case File.stat(file) do
-        {:ok, stat} -> acc + stat.size
-        {:error, _} -> acc
-      end
-    end)
+  defp directory_bytes(path, opts) do
+    du_runner = Keyword.get(opts, :du_runner, &System.cmd/3)
+
+    case du_runner.("du", ["-sk", path], stderr_to_stdout: true) do
+      {output, 0} ->
+        output
+        |> String.split()
+        |> List.first()
+        |> parse_kibibytes()
+
+      _other ->
+        nil
+    end
+  end
+
+  defp parse_kibibytes(nil), do: nil
+
+  defp parse_kibibytes(value) do
+    case Integer.parse(value) do
+      {kib, ""} -> kib * 1024
+      _other -> nil
+    end
   end
 
   defp app_client(opts),

--- a/core/test/sykli/github/dispatcher_test.exs
+++ b/core/test/sykli/github/dispatcher_test.exs
@@ -51,9 +51,43 @@ defmodule Sykli.GitHub.DispatcherTest do
                     %{status: "completed", conclusion: "success"}}
 
     assert_receive %Sykli.Occurrence{type: "ci.github.run.dispatched"}
-    assert_receive %Sykli.Occurrence{type: "ci.github.run.source_acquired"}
+
+    assert_receive %Sykli.Occurrence{
+      type: "ci.github.run.source_acquired",
+      data: %{bytes: bytes}
+    }
+
+    assert is_integer(bytes)
     assert_receive %Sykli.Occurrence{type: "ci.github.check_run.created"}
     assert_receive %Sykli.Occurrence{type: "ci.github.check_suite.concluded"}
+  end
+
+  test "source_acquired bytes uses du instead of walking the tree", %{event: event} do
+    parent = self()
+
+    du_runner = fn "du", ["-sk", path], opts ->
+      send(parent, {:du_runner_called, path, opts})
+      {"7\t#{path}\n", 0}
+    end
+
+    assert :ok =
+             Dispatcher.dispatch(event,
+               app_client: Sykli.GitHub.App.Fake,
+               checks_client: Sykli.GitHub.Checks.Fake,
+               source_client: Sykli.GitHub.Source.Fake,
+               source_fixture: @fixture,
+               test_pid: self(),
+               fake_recorder: self(),
+               du_runner: du_runner
+             )
+
+    assert_receive {:du_runner_called, path, [stderr_to_stdout: true]}
+    assert String.ends_with?(path, "/repo")
+
+    assert_receive %Sykli.Occurrence{
+      type: "ci.github.run.source_acquired",
+      data: %{bytes: 7168}
+    }
   end
 
   test "dispatch failure evicts the delivery for GitHub retry", %{event: event} do


### PR DESCRIPTION
Summary:
- Replaces the per-file Path.wildcard/File.stat source-size walk with a single du -sk call.
- Returns nil for bytes if du fails or emits unparsable output.
- Adds dispatcher coverage that verifies the du runner is used and bytes are converted from KiB to bytes.

Closes #156.

Validation:
- cd core && mix format
- cd core && env -u SYKLI_LABELS mix test test/sykli/github/dispatcher_test.exs
