### PR TITLE
fix(github): clean dispatcher workspace after crashes

### DIFF
--- a/core/lib/sykli/github/dispatcher.ex
+++ b/core/lib/sykli/github/dispatcher.ex
@@ -93,15 +93,43 @@ defmodule Sykli.GitHub.Dispatcher do
   end
 
   defp dispatch_from_source(event, token, source_path, opts) do
-    with {:ok, graph, tasks} <- load_graph(source_path),
-         {:ok, check_runs} <- create_task_runs(event, token, tasks, opts),
-         :ok <- mark_in_progress(event, token, check_runs, opts),
-         {:ok, results} <- run_executor(tasks, graph, source_path, event.run_id, opts),
-         :ok <- conclude_task_runs(event, token, check_runs, results, opts) do
-      {:ok, results}
+    with_workspace_janitor(source_path, opts, fn ->
+      maybe_after_source_acquired(source_path, opts)
+
+      with {:ok, graph, tasks} <- load_graph(source_path),
+           {:ok, check_runs} <- create_task_runs(event, token, tasks, opts),
+           :ok <- mark_in_progress(event, token, check_runs, opts),
+           {:ok, results} <- run_executor(tasks, graph, source_path, event.run_id, opts),
+           :ok <- conclude_task_runs(event, token, check_runs, results, opts) do
+        {:ok, results}
+      end
+    end)
+  end
+
+  defp with_workspace_janitor(source_path, opts, fun) do
+    case workspace_janitor(opts).start(self(), source_path, opts) do
+      {:ok, janitor} ->
+        try do
+          fun.()
+        after
+          workspace_janitor(opts).cleanup(janitor)
+        end
+
+      {:error, reason} ->
+        {:error,
+         dispatch_error(
+           "github.dispatch.workspace_janitor_failed",
+           "failed to monitor source workspace cleanup",
+           reason
+         )}
     end
-  after
-    source_client(opts).cleanup(source_path, opts)
+  end
+
+  defp maybe_after_source_acquired(source_path, opts) do
+    case Keyword.get(opts, :after_source_acquired) do
+      callback when is_function(callback, 1) -> callback.(source_path)
+      _ -> :ok
+    end
   end
 
   defp create_suite(event, token, opts) do
@@ -375,6 +403,9 @@ defmodule Sykli.GitHub.Dispatcher do
 
   defp checks_client(opts), do: Keyword.get(opts, :checks_client, Sykli.GitHub.Checks)
   defp source_client(opts), do: Keyword.get(opts, :source_client, Sykli.GitHub.Source)
+
+  defp workspace_janitor(opts),
+    do: Keyword.get(opts, :workspace_janitor, Sykli.GitHub.WorkspaceJanitor)
 
   defp retryable_dispatch_error?(%Sykli.Error{code: code}) do
     code not in [

--- a/core/lib/sykli/github/workspace_janitor.ex
+++ b/core/lib/sykli/github/workspace_janitor.ex
@@ -1,0 +1,51 @@
+defmodule Sykli.GitHub.WorkspaceJanitor do
+  @moduledoc "Cleans GitHub source workspaces when their owner process exits."
+
+  require Logger
+
+  @cleanup_timeout_ms 5_000
+
+  @spec start(pid(), String.t(), keyword()) :: {:ok, pid()} | {:error, term()}
+  def start(owner, path, opts \\ []) when is_pid(owner) and is_binary(path) do
+    Task.start(fn ->
+      ref = Process.monitor(owner)
+      loop(owner, ref, path, opts)
+    end)
+  end
+
+  @spec cleanup(pid()) :: :ok
+  def cleanup(pid) when is_pid(pid) do
+    ref = make_ref()
+    send(pid, {:cleanup, self(), ref})
+
+    receive do
+      {^ref, :ok} -> :ok
+    after
+      @cleanup_timeout_ms -> :ok
+    end
+  end
+
+  def cleanup(_pid), do: :ok
+
+  defp loop(owner, monitor_ref, path, opts) do
+    receive do
+      {:cleanup, caller, reply_ref} ->
+        Process.demonitor(monitor_ref, [:flush])
+        do_cleanup(path, opts)
+        send(caller, {reply_ref, :ok})
+
+      {:DOWN, ^monitor_ref, :process, ^owner, _reason} ->
+        do_cleanup(path, opts)
+    end
+  end
+
+  defp do_cleanup(path, opts) do
+    source_client(opts).cleanup(path, opts)
+  rescue
+    error ->
+      Logger.warning("[GitHub WorkspaceJanitor] cleanup failed", error: inspect(error))
+      :ok
+  end
+
+  defp source_client(opts), do: Keyword.get(opts, :source_client, Sykli.GitHub.Source)
+end

--- a/core/test/sykli/github/dispatcher_test.exs
+++ b/core/test/sykli/github/dispatcher_test.exs
@@ -107,4 +107,51 @@ defmodule Sykli.GitHub.DispatcherTest do
 
     assert {:error, :duplicate_delivery} = Deliveries.accept(event.delivery_id, 2)
   end
+
+  test "dispatch cleans up the source workspace when the dispatcher process is killed", %{
+    event: event
+  } do
+    parent = self()
+    event = %{event | delivery_id: "dispatcher-crash-cleanup"}
+
+    dispatcher =
+      spawn(fn ->
+        Dispatcher.dispatch(event,
+          app_client: Sykli.GitHub.App.Fake,
+          checks_client: Sykli.GitHub.Checks.Fake,
+          source_client: Sykli.GitHub.Source.Fake,
+          source_fixture: @fixture,
+          after_source_acquired: fn source_path ->
+            send(parent, {:source_acquired, self(), source_path})
+
+            receive do
+              :continue -> :ok
+            end
+          end
+        )
+      end)
+
+    assert_receive {:source_acquired, ^dispatcher, source_path}
+    assert File.exists?(source_path)
+
+    Process.exit(dispatcher, :kill)
+
+    assert_eventually(fn ->
+      refute File.exists?(source_path)
+    end)
+  end
+
+  defp assert_eventually(fun, attempts_left \\ 50)
+
+  defp assert_eventually(fun, attempts_left) when attempts_left > 0 do
+    try do
+      fun.()
+    rescue
+      ExUnit.AssertionError ->
+        Process.sleep(20)
+        assert_eventually(fun, attempts_left - 1)
+    end
+  end
+
+  defp assert_eventually(fun, 0), do: fun.()
 end


### PR DESCRIPTION
## Summary
- add a monitor-backed workspace janitor for GitHub dispatcher source directories
- keep normal-path cleanup synchronous while preserving cleanup after dispatcher kill/crash
- add a regression test that kills the dispatcher after source acquisition and asserts the workspace is removed

Closes #149

## Validation
- cd core && mix format
- cd core && env -u SYKLI_LABELS mix test test/sykli/github/dispatcher_test.exs
- cd core && mix credo
- cd core && env -u SYKLI_LABELS mix test
- cd core && mix escript.build