### PR TITLE
fix(github): clean up dispatcher nits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **GitHub webhook error responses now distinguish missing vs. bad signature.** Missing `X-Hub-Signature-256` returns 400 `github.webhook.missing_signature`; an invalid signature still returns 401 `github.webhook.bad_signature`. Operators can now tell a stripped-header proxy bug apart from a forgery attempt.
 - **GitHub webhook catch-all is now 502 `github.webhook.upstream_failure`** for raw upstream errors (was 400 `github.webhook.invalid`). GitHub does not retry 400s, so the previous response misclassified transient upstream failures as permanent client errors and silently dropped them.
+- **GitHub check-suite occurrence conclusions now follow per-task Checks API conclusions.** Blocked-only suites report `cancelled`, all-skipped suites report `skipped`, and mixed failed/blocked suites still report `failure`.
 - **`Sykli.Mesh.Roles` moduledoc** clarified to make the local-only ETS semantics explicit. The "mesh" name was misleading — the registry is per-node single-holder enforcement, not cluster-coordinated. Multi-node deployments must ensure only one node carries a given role label.
 
 ## [0.6.0] - 2026-04-29

--- a/core/lib/sykli/github/dispatcher.ex
+++ b/core/lib/sykli/github/dispatcher.ex
@@ -58,7 +58,7 @@ defmodule Sykli.GitHub.Dispatcher do
         repo: event.repo,
         head_sha: event.head_sha,
         check_suite_id: suite["id"],
-        conclusion: conclusion(results)
+        conclusion: suite_conclusion(results)
       })
 
       :ok
@@ -330,7 +330,11 @@ defmodule Sykli.GitHub.Dispatcher do
     end
   end
 
-  defp conclusion(results) do
+  @doc false
+  @spec suite_conclusion([Sykli.Executor.TaskResult.t()]) :: String.t()
+  def suite_conclusion([]), do: "success"
+
+  def suite_conclusion(results) do
     conclusions = Enum.map(results, &CheckRunFormatter.conclusion/1)
 
     cond do

--- a/core/lib/sykli/github/dispatcher.ex
+++ b/core/lib/sykli/github/dispatcher.ex
@@ -101,7 +101,7 @@ defmodule Sykli.GitHub.Dispatcher do
       {:ok, results}
     end
   after
-    source_client(opts).cleanup(source_path, opts)
+    Sykli.GitHub.Source.cleanup(source_path, opts)
   end
 
   defp create_suite(event, token, opts) do
@@ -125,7 +125,7 @@ defmodule Sykli.GitHub.Dispatcher do
   end
 
   defp acquire_source(event, token, opts) do
-    case source_client(opts).acquire(event, token, opts) do
+    case Sykli.GitHub.Source.acquire(event, token, opts) do
       {:ok, path} ->
         OccPubSub.github_run_source_acquired(event.run_id, %{
           repo: event.repo,
@@ -331,10 +331,13 @@ defmodule Sykli.GitHub.Dispatcher do
   end
 
   defp conclusion(results) do
-    if Enum.any?(results, &(&1.status in [:failed, :errored, :blocked])) do
-      "failure"
-    else
-      "success"
+    conclusions = Enum.map(results, &CheckRunFormatter.conclusion/1)
+
+    cond do
+      Enum.any?(conclusions, &(&1 == "failure")) -> "failure"
+      Enum.any?(conclusions, &(&1 == "cancelled")) -> "cancelled"
+      Enum.all?(conclusions, &(&1 == "skipped")) -> "skipped"
+      true -> "success"
     end
   end
 
@@ -374,7 +377,6 @@ defmodule Sykli.GitHub.Dispatcher do
       )
 
   defp checks_client(opts), do: Keyword.get(opts, :checks_client, Sykli.GitHub.Checks)
-  defp source_client(opts), do: Keyword.get(opts, :source_client, Sykli.GitHub.Source)
 
   defp retryable_dispatch_error?(%Sykli.Error{code: code}) do
     code not in [

--- a/core/lib/sykli/github/source.ex
+++ b/core/lib/sykli/github/source.ex
@@ -5,17 +5,19 @@ defmodule Sykli.GitHub.Source do
 
   @impl true
   def acquire(context, token, opts \\ []) do
-    impl =
-      Keyword.get(opts, :impl, Application.get_env(:sykli, :github_source_impl, __MODULE__.Real))
-
-    impl.acquire(context, token, opts)
+    source_impl(opts).acquire(context, token, opts)
   end
 
   @impl true
   def cleanup(path, opts \\ []) do
-    impl =
-      Keyword.get(opts, :impl, Application.get_env(:sykli, :github_source_impl, __MODULE__.Real))
+    source_impl(opts).cleanup(path, opts)
+  end
 
-    impl.cleanup(path, opts)
+  defp source_impl(opts) do
+    Keyword.get(
+      opts,
+      :source_impl,
+      Keyword.get(opts, :impl, Application.get_env(:sykli, :github_source_impl, __MODULE__.Real))
+    )
   end
 end

--- a/core/lib/sykli/github/source/fake.ex
+++ b/core/lib/sykli/github/source/fake.ex
@@ -38,7 +38,7 @@ defmodule Sykli.GitHub.Source.Fake do
   defp safe_segment(value) do
     value
     |> to_string()
-    |> String.replace(~r/[^A-Za-z0-9._:-]/, "-")
+    |> String.replace(~r/[^A-Za-z0-9._-]/, "-")
   end
 
   defp source_error(file, reason) do

--- a/core/lib/sykli/github/source/real.ex
+++ b/core/lib/sykli/github/source/real.ex
@@ -160,7 +160,7 @@ defmodule Sykli.GitHub.Source.Real do
   defp safe_segment(value) do
     value
     |> to_string()
-    |> String.replace(~r/[^A-Za-z0-9._:-]/, "-")
+    |> String.replace(~r/[^A-Za-z0-9._-]/, "-")
   end
 
   defp remove_tree(path) do

--- a/core/test/sykli/github/dispatcher_test.exs
+++ b/core/test/sykli/github/dispatcher_test.exs
@@ -32,7 +32,7 @@ defmodule Sykli.GitHub.DispatcherTest do
              Dispatcher.dispatch(event,
                app_client: Sykli.GitHub.App.Fake,
                checks_client: Sykli.GitHub.Checks.Fake,
-               source_client: Sykli.GitHub.Source.Fake,
+               impl: Sykli.GitHub.Source.Fake,
                source_fixture: @fixture,
                test_pid: self(),
                fake_recorder: self()
@@ -63,7 +63,7 @@ defmodule Sykli.GitHub.DispatcherTest do
              Dispatcher.dispatch(event,
                app_client: Sykli.GitHub.App.Fake,
                checks_client: Sykli.GitHub.Checks.Fake,
-               source_client: Sykli.GitHub.Source.Fake,
+               impl: Sykli.GitHub.Source.Fake,
                test_pid: self(),
                source_response:
                  {:error,

--- a/core/test/sykli/github/dispatcher_test.exs
+++ b/core/test/sykli/github/dispatcher_test.exs
@@ -4,6 +4,7 @@ defmodule Sykli.GitHub.DispatcherTest do
   alias Sykli.GitHub.Dispatcher
   alias Sykli.GitHub.Webhook.Deliveries
   alias Sykli.Occurrence.PubSub
+  alias Sykli.Executor.TaskResult
 
   @fixture Path.expand("../../../priv/test_fixtures/github_source/simple", __DIR__)
 
@@ -32,7 +33,7 @@ defmodule Sykli.GitHub.DispatcherTest do
              Dispatcher.dispatch(event,
                app_client: Sykli.GitHub.App.Fake,
                checks_client: Sykli.GitHub.Checks.Fake,
-               impl: Sykli.GitHub.Source.Fake,
+               source_impl: Sykli.GitHub.Source.Fake,
                source_fixture: @fixture,
                test_pid: self(),
                fake_recorder: self()
@@ -63,7 +64,7 @@ defmodule Sykli.GitHub.DispatcherTest do
              Dispatcher.dispatch(event,
                app_client: Sykli.GitHub.App.Fake,
                checks_client: Sykli.GitHub.Checks.Fake,
-               impl: Sykli.GitHub.Source.Fake,
+               source_impl: Sykli.GitHub.Source.Fake,
                test_pid: self(),
                source_response:
                  {:error,
@@ -106,5 +107,28 @@ defmodule Sykli.GitHub.DispatcherTest do
              )
 
     assert {:error, :duplicate_delivery} = Deliveries.accept(event.delivery_id, 2)
+  end
+
+  test "suite conclusion follows per-task check-run conclusions" do
+    assert Dispatcher.suite_conclusion([]) == "success"
+
+    assert Dispatcher.suite_conclusion([
+             task_result("test", :skipped),
+             task_result("lint", :skipped)
+           ]) == "skipped"
+
+    assert Dispatcher.suite_conclusion([
+             task_result("test", :passed),
+             task_result("deploy", :blocked)
+           ]) == "cancelled"
+
+    assert Dispatcher.suite_conclusion([
+             task_result("test", :failed),
+             task_result("deploy", :blocked)
+           ]) == "failure"
+  end
+
+  defp task_result(name, status) do
+    %TaskResult{name: name, status: status, duration_ms: 1}
   end
 end

--- a/core/test/sykli/github/source_test.exs
+++ b/core/test/sykli/github/source_test.exs
@@ -20,6 +20,7 @@ defmodule Sykli.GitHub.SourceTest do
              )
 
     assert File.exists?(Path.join(path, "sykli.exs"))
+    refute String.contains?(path, ":")
 
     assert :ok = Source.cleanup(path, impl: Sykli.GitHub.Source.Fake)
     refute File.exists?(path)
@@ -56,6 +57,7 @@ defmodule Sykli.GitHub.SourceTest do
 
     config = File.read!(Path.join([path, ".git", "config"]))
 
+    refute String.contains?(path, ":")
     refute String.contains?(config, token)
     refute String.contains?(config, "x-access-token")
     assert String.contains?(config, "https://github.com/false-systems/sykli.git")
@@ -75,16 +77,17 @@ defmodule Sykli.GitHub.SourceTest do
   end
 
   test "real cleanup refuses paths outside the sykli temp root" do
-    decoy = Path.join(System.tmp_dir!(), "not-sykli-source-decoy")
+    decoy =
+      Path.join(System.tmp_dir!(), "not-sykli-source-decoy-#{System.unique_integer([:positive])}")
+
     sentinel = Path.join(decoy, "sentinel")
 
     File.mkdir_p!(decoy)
     File.write!(sentinel, "keep")
+    on_exit(fn -> File.rm_rf!(decoy) end)
 
     assert :ok = Sykli.GitHub.Source.Real.cleanup(decoy)
     assert File.exists?(sentinel)
-
-    File.rm_rf!(decoy)
   end
 
   defp init_repo(repo_dir, remote_url) do

--- a/core/test/sykli/github/source_test.exs
+++ b/core/test/sykli/github/source_test.exs
@@ -15,14 +15,14 @@ defmodule Sykli.GitHub.SourceTest do
 
     assert {:ok, path} =
              Source.acquire(context, "installation-token",
-               impl: Sykli.GitHub.Source.Fake,
+               source_impl: Sykli.GitHub.Source.Fake,
                source_fixture: @fixture
              )
 
     assert File.exists?(Path.join(path, "sykli.exs"))
     refute String.contains?(path, ":")
 
-    assert :ok = Source.cleanup(path, impl: Sykli.GitHub.Source.Fake)
+    assert :ok = Source.cleanup(path, source_impl: Sykli.GitHub.Source.Fake)
     refute File.exists?(path)
   end
 

--- a/core/test/sykli/github/webhook/receiver_test.exs
+++ b/core/test/sykli/github/webhook/receiver_test.exs
@@ -202,15 +202,15 @@ defmodule Sykli.GitHub.Webhook.ReceiverTest do
     assert failing.status == 202
     assert_receive {:receiver_dispatch, %{delivery_id: "delivery-retry-me"}}
 
+    assert_receive {:receiver_dispatch_completed, "delivery-retry-me"}
+
     retry =
-      eventually(fn ->
-        :post
-        |> conn("/webhook", @body)
-        |> put_req_header("x-hub-signature-256", Signature.sign(@secret, @body))
-        |> put_req_header("x-github-delivery", "delivery-retry-me")
-        |> put_req_header("x-github-event", "pull_request")
-        |> Receiver.call(opts_ok)
-      end)
+      :post
+      |> conn("/webhook", @body)
+      |> put_req_header("x-hub-signature-256", Signature.sign(@secret, @body))
+      |> put_req_header("x-github-delivery", "delivery-retry-me")
+      |> put_req_header("x-github-event", "pull_request")
+      |> Receiver.call(opts_ok)
 
     assert retry.status == 202
   end
@@ -246,35 +246,27 @@ defmodule Sykli.GitHub.Webhook.ReceiverTest do
              "github.webhook.missing_signature"
   end
 
-  defp eventually(fun, attempts \\ 20)
-
-  defp eventually(fun, attempts) when attempts > 0 do
-    case fun.() do
-      %{status: 409} ->
-        Process.sleep(10)
-        eventually(fun, attempts - 1)
-
-      result ->
-        result
-    end
-  end
-
-  defp eventually(fun, 0), do: fun.()
-
   defmodule Dispatcher do
     def dispatch(context, opts) do
       if pid = Keyword.get(opts, :test_pid) do
         send(pid, {:receiver_dispatch, context})
       end
 
-      case Keyword.get(opts, :dispatch_result, :ok) do
-        {:error, _error} = error ->
-          Sykli.GitHub.Webhook.Deliveries.evict(context.delivery_id)
-          error
+      result =
+        case Keyword.get(opts, :dispatch_result, :ok) do
+          {:error, _error} = error ->
+            Sykli.GitHub.Webhook.Deliveries.evict(context.delivery_id)
+            error
 
-        :ok ->
-          :ok
+          :ok ->
+            :ok
+        end
+
+      if pid = Keyword.get(opts, :test_pid) do
+        send(pid, {:receiver_dispatch_completed, context.delivery_id})
       end
+
+      result
     end
   end
 end


### PR DESCRIPTION
## Summary
- unify GitHub source injection through the Source facade using the existing :impl option
- make source workspace path segments avoid ':' for better portability
- derive suite occurrence conclusions from CheckRunFormatter's per-task conclusion mapping
- strengthen source cleanup path-containment test
- replace fragile receiver retry polling with an explicit dispatch-completed signal in the test double

Closes #158

## Validation
- cd core && mix format
- cd core && env -u SYKLI_LABELS mix test test/sykli/github/dispatcher_test.exs test/sykli/github/source_test.exs test/sykli/github/webhook/receiver_test.exs
- cd core && mix credo
- cd core && mix escript.build

Full suite note:
- cd core && env -u SYKLI_LABELS mix test hit the existing StreamData TooManyDuplicatesError flake in Sykli.Mesh.Transport.Sim.EventQueueTest; no other failures were reported.