### PR TITLE
Add experimental review-node SDK support

### DIFF
--- a/docs/sdk-schema.md
+++ b/docs/sdk-schema.md
@@ -69,7 +69,7 @@ The full canonical field list, with stability labels:
 | JSON key | Stability | Required? | Notes |
 |---|---|---|---|
 | `name` | stable | yes | unique, non-empty |
-| `kind` | experimental (non-Go SDKs) | no | `"task"` (default) or `"review"`; only Go emits `"review"` |
+| `kind` | experimental | no | `"task"` (default) or `"review"` |
 | `command` | stable | conditional | required unless `gate` is set or `kind == "review"` |
 | `container` | stable | no | triggers v2 |
 | `workdir` | stable | no | |
@@ -108,7 +108,7 @@ Unique within the pipeline, non-empty. The engine rejects empty/whitespace/non-b
 
 ### `kind`
 
-`"task"` (default; SDKs do not emit `kind` in this case) or `"review"`. When `kind == "review"`, `command` is not required and the review-only fields below become meaningful. Today only the Go SDK constructs review nodes (`sdk/go/sykli.go:559-570`, `:2241-2247`); engine support is complete (`graph.ex:420-429`, `parse_review/1`). Cross-SDK parity for review nodes is a future work item — not part of this schema's scope.
+`"task"` (default; SDKs do not emit `kind` in this case) or `"review"`. When `kind == "review"`, `command` is not required and the review-only fields below become meaningful. Review nodes are experimental graph nodes for review/reasoning/check primitives, not shell-command tasks.
 
 ### `command`
 
@@ -242,7 +242,13 @@ When `kind == "review"`, the engine reads four additional fields via `parse_revi
 - `context` — array of context file references.
 - `deterministic` — boolean; engine default `false`.
 
-These are meaningful only when `kind == "review"`. The schema **rejects** them on regular tasks (encoded via `if/then` in the task `allOf`): if `kind` is absent or not `"review"`, none of `primitive`, `agent`, `context`, or `deterministic` may appear. The engine itself is permissive — `parse_review/1` (`graph.ex:420-429`) is simply never entered for non-review tasks, so any review fields would be silently ignored — but the schema treats them as a likely typo. Cross-SDK support is incomplete: only Go currently emits review nodes.
+These are meaningful only when `kind == "review"`. The schema **rejects** them on regular tasks (encoded via `if/then` in the task `allOf`): if `kind` is absent or not `"review"`, none of `primitive`, `agent`, `context`, or `deterministic` may appear. The engine itself is permissive — `parse_review/1` (`graph.ex:420-429`) is simply never entered for non-review tasks, so any review fields would be silently ignored — but the schema treats them as a likely typo.
+
+Review nodes do not have canonical `outputs` behavior yet. SDKs should not emit
+`outputs` for review nodes; review results/structured outputs are intentionally
+left out of the current experimental contract. The schema rejects task execution
+fields on review nodes: `command`, `outputs`, `gate`, `container`, `services`,
+`k8s`, `mounts`, `retry`, and `timeout`.
 
 ## Normalization behavior
 
@@ -352,7 +358,7 @@ introduce a replacement field.
 These are **descriptive, not prescriptive**. The schema documents current behavior; resolving these is Phase 2C / future work.
 
 1. **`version` is advisory only today.** SDKs emit `"1"` or `"2"`; engine ignores. This document defines it as the pipeline wire-format/schema version and describes the migration path to version-aware parsing.
-2. **Review nodes are Go-only.** Engine supports `kind: "review"` and the four review-only fields, but only the Go SDK constructs them. No conformance coverage.
+2. **Review nodes are experimental.** Engine supports `kind: "review"` and the four review-only fields, and SDKs expose minimal review builders. Review outputs are not canonical.
 3. **`verify` and `oidc` are reserved with no SDK emit.** Engine reads them; SDKs have no API. Either implement SDK support or drop from the schema once a decision lands.
 4. **`history_hint` is engine-internal.** SDKs MUST NOT emit. Schema marks `readOnly` for clarity.
 5. **TypeScript K8s interface drift.** `K8sOptions` interface declares 15 fields; only 4 are serialized. The other 11 silently disappear at emit. The schema reflects the wire contract (4 fields); the TypeScript drift is a TS-side issue, not a schema issue.

--- a/schemas/sykli-pipeline.schema.json
+++ b/schemas/sykli-pipeline.schema.json
@@ -73,6 +73,28 @@
               ]
             }
           }
+        },
+        {
+          "description": "Review nodes are graph metadata nodes, not shell-command tasks. The canonical review-node contract rejects task execution fields.",
+          "if": {
+            "properties": { "kind": { "const": "review" } },
+            "required": ["kind"]
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                { "required": ["command"] },
+                { "required": ["outputs"] },
+                { "required": ["gate"] },
+                { "required": ["container"] },
+                { "required": ["services"] },
+                { "required": ["k8s"] },
+                { "required": ["mounts"] },
+                { "required": ["retry"] },
+                { "required": ["timeout"] }
+              ]
+            }
+          }
         }
       ],
       "properties": {
@@ -82,7 +104,7 @@
           "minLength": 1
         },
         "kind": {
-          "description": "Task kind. Default is task. The review kind is currently emitted only by the Go SDK; engine support is complete but cross-SDK coverage is incomplete. Experimental.",
+          "description": "Task kind. Default is task. The review kind is experimental.",
           "enum": ["task", "review"]
         },
         "command": {

--- a/sdk/elixir/lib/sykli/dsl.ex
+++ b/sdk/elixir/lib/sykli/dsl.ex
@@ -76,12 +76,49 @@ defmodule Sykli.DSL do
   end
 
   # ============================================================================
+  # REVIEW MACRO
+  # ============================================================================
+
+  @doc """
+  Defines an experimental review node in the pipeline graph.
+
+      review "review-code" do
+        primitive "lint"
+        agent "claude"
+        context ["lib/**/*.ex"]
+        after_ ["test"]
+        deterministic true
+      end
+  """
+  defmacro review(name, do: block) do
+    quote do
+      Process.put(:sykli_current_task, %Sykli.Task{
+        name: unquote(name),
+        kind: :review
+      })
+
+      unquote(block)
+
+      completed_task = Process.get(:sykli_current_task)
+      tasks = Process.get(:sykli_tasks)
+      Process.put(:sykli_tasks, [completed_task | tasks])
+
+      Logger.debug("registered review", review: unquote(name))
+
+      Process.delete(:sykli_current_task)
+    end
+  end
+
+  # ============================================================================
   # TASK OPTIONS
   # ============================================================================
 
   @doc "Sets the command to run."
   def run(command) when is_binary(command) do
-    update_current_task(fn t -> %{t | command: command} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "run")
+      %{t | command: command}
+    end)
   end
 
   @doc "Sets task dependencies."
@@ -109,6 +146,7 @@ defmodule Sykli.DSL do
   def input_from(from_task, output_name, dest_path)
       when is_binary(from_task) and is_binary(output_name) and is_binary(dest_path) do
     update_current_task(fn t ->
+      reject_review_option!(t, "input_from")
       task_input = %{from_task: from_task, output: output_name, dest: dest_path}
 
       # Add dependency if not already present
@@ -131,17 +169,51 @@ defmodule Sykli.DSL do
 
   @doc "Sets the container image."
   def container(image) when is_binary(image) do
-    update_current_task(fn t -> %{t | container: image} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "container")
+      %{t | container: image}
+    end)
   end
 
   @doc "Sets the working directory inside container."
   def workdir(path) when is_binary(path) do
-    update_current_task(fn t -> %{t | workdir: path} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "workdir")
+      %{t | workdir: path}
+    end)
   end
 
   @doc "Sets input file patterns for caching."
   def inputs(patterns) when is_list(patterns) do
     update_current_task(fn t -> %{t | inputs: patterns} end)
+  end
+
+  @doc "Sets the review primitive identifier."
+  def primitive(name) when is_binary(name) and name != "" do
+    update_current_task(fn t -> %{t | primitive: name} end)
+  end
+
+  def primitive("") do
+    raise ArgumentError, "review primitive cannot be empty"
+  end
+
+  @doc "Sets the review agent identifier."
+  def agent(name) when is_binary(name) and name != "" do
+    update_current_task(fn t -> %{t | agent: name} end)
+  end
+
+  def agent("") do
+    raise ArgumentError, "review agent cannot be empty"
+  end
+
+  @doc "Sets review context paths."
+  def context(paths) when is_list(paths) do
+    update_current_task(fn t -> %{t | context: paths} end)
+  end
+
+  @doc "Sets whether a review is deterministic."
+  def deterministic(value) when is_boolean(value) do
+    update_current_task(fn t -> %{t | deterministic: value} end)
   end
 
   @doc "Sets output paths."
@@ -151,17 +223,26 @@ defmodule Sykli.DSL do
       |> Enum.with_index()
       |> Map.new(fn {path, i} -> {"output_#{i}", path} end)
 
-    update_current_task(fn t -> %{t | outputs: output_map} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "outputs")
+      %{t | outputs: output_map}
+    end)
   end
 
   @doc "Sets a named output."
   def output(name, path) do
-    update_current_task(fn t -> %{t | outputs: Map.put(t.outputs, name, path)} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "output")
+      %{t | outputs: Map.put(t.outputs, name, path)}
+    end)
   end
 
   @doc "Sets an environment variable."
   def env(key, value) when is_binary(key) and key != "" do
-    update_current_task(fn t -> %{t | env: Map.put(t.env, key, value)} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "env")
+      %{t | env: Map.put(t.env, key, value)}
+    end)
   end
 
   def env("", _value) do
@@ -170,7 +251,10 @@ defmodule Sykli.DSL do
 
   @doc "Sets a condition for when this task runs."
   def when_(condition) when is_binary(condition) do
-    update_current_task(fn t -> %{t | condition: condition} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "when_")
+      %{t | condition: condition}
+    end)
   end
 
   @doc """
@@ -188,17 +272,26 @@ defmodule Sykli.DSL do
       end
   """
   def when_cond(%Sykli.Condition{} = condition) do
-    update_current_task(fn t -> %{t | when_cond: condition} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "when_cond")
+      %{t | when_cond: condition}
+    end)
   end
 
   @doc "Declares a required secret."
   def secret(name) when is_binary(name) do
-    update_current_task(fn t -> %{t | secrets: t.secrets ++ [name]} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "secret")
+      %{t | secrets: t.secrets ++ [name]}
+    end)
   end
 
   @doc "Declares multiple required secrets."
   def secrets(names) when is_list(names) do
-    update_current_task(fn t -> %{t | secrets: t.secrets ++ names} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "secrets")
+      %{t | secrets: t.secrets ++ names}
+    end)
   end
 
   @doc """
@@ -216,7 +309,11 @@ defmodule Sykli.DSL do
   """
   def secret_from(name, %Sykli.SecretRef{} = ref) when is_binary(name) do
     secret_ref = %{ref | name: name}
-    update_current_task(fn t -> %{t | secret_refs: t.secret_refs ++ [secret_ref]} end)
+
+    update_current_task(fn t ->
+      reject_review_option!(t, "secret_from")
+      %{t | secret_refs: t.secret_refs ++ [secret_ref]}
+    end)
   end
 
   @doc """
@@ -227,12 +324,18 @@ defmodule Sykli.DSL do
   """
   @deprecated "target/1 no longer affects emitted pipeline JSON; use concrete execution requirement fields instead"
   def target(name) when is_binary(name) do
-    update_current_task(fn t -> t end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "target")
+      t
+    end)
   end
 
   @doc "Adds a matrix dimension."
   def matrix(key, values) when is_binary(key) and is_list(values) do
-    update_current_task(fn t -> %{t | matrix: Map.put(t.matrix, key, values)} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "matrix")
+      %{t | matrix: Map.put(t.matrix, key, values)}
+    end)
   end
 
   @doc """
@@ -253,7 +356,10 @@ defmodule Sykli.DSL do
       end
   """
   def requires(labels) when is_list(labels) do
-    update_current_task(fn t -> %{t | requires: labels} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "requires")
+      %{t | requires: labels}
+    end)
   end
 
   @doc """
@@ -272,18 +378,26 @@ defmodule Sykli.DSL do
       end
   """
   def verify(mode) when mode in ~w(cross_platform always never) do
-    update_current_task(fn t -> %{t | verify: mode} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "verify")
+      %{t | verify: mode}
+    end)
   end
 
   @doc "Adds a service container."
   def service(image, name) do
     svc = %{image: image, name: name}
-    update_current_task(fn t -> %{t | services: t.services ++ [svc]} end)
+
+    update_current_task(fn t ->
+      reject_review_option!(t, "service")
+      %{t | services: t.services ++ [svc]}
+    end)
   end
 
   @doc "Sets retry count."
   def retry(count) when is_integer(count) and count >= 0 do
     update_current_task(fn t ->
+      reject_review_option!(t, "retry")
       Logger.debug("setting retry", task: t.name, retry: count)
       %{t | retry: count}
     end)
@@ -292,6 +406,7 @@ defmodule Sykli.DSL do
   @doc "Sets timeout in seconds."
   def timeout(seconds) when is_integer(seconds) and seconds > 0 do
     update_current_task(fn t ->
+      reject_review_option!(t, "timeout")
       Logger.debug("setting timeout", task: t.name, timeout: seconds)
       %{t | timeout: seconds}
     end)
@@ -316,6 +431,7 @@ defmodule Sykli.DSL do
   """
   def k8s(%Sykli.K8s{} = opts) do
     update_current_task(fn t ->
+      reject_review_option!(t, "k8s")
       Logger.debug("setting k8s options", task: t.name)
       %{t | k8s: opts}
     end)
@@ -324,13 +440,21 @@ defmodule Sykli.DSL do
   @doc "Mounts a directory into the container."
   def mount(resource_name, path) do
     mount = %{resource: resource_name, path: path, type: :directory}
-    update_current_task(fn t -> %{t | mounts: t.mounts ++ [mount]} end)
+
+    update_current_task(fn t ->
+      reject_review_option!(t, "mount")
+      %{t | mounts: t.mounts ++ [mount]}
+    end)
   end
 
   @doc "Mounts a cache volume into the container."
   def mount_cache(cache_name, path) do
     mount = %{resource: cache_name, path: path, type: :cache}
-    update_current_task(fn t -> %{t | mounts: t.mounts ++ [mount]} end)
+
+    update_current_task(fn t ->
+      reject_review_option!(t, "mount_cache")
+      %{t | mounts: t.mounts ++ [mount]}
+    end)
   end
 
   # ============================================================================
@@ -352,6 +476,7 @@ defmodule Sykli.DSL do
   """
   def covers(patterns) when is_list(patterns) do
     update_current_task(fn t ->
+      reject_review_option!(t, "covers")
       semantic = t.semantic || %{covers: [], intent: nil, criticality: nil}
       %{t | semantic: %{semantic | covers: patterns}}
     end)
@@ -371,6 +496,7 @@ defmodule Sykli.DSL do
   """
   def intent(description) when is_binary(description) do
     update_current_task(fn t ->
+      reject_review_option!(t, "intent")
       semantic = t.semantic || %{covers: [], intent: nil, criticality: nil}
       %{t | semantic: %{semantic | intent: description}}
     end)
@@ -407,6 +533,7 @@ defmodule Sykli.DSL do
   """
   def set_criticality(level) when level in [:high, :medium, :low] do
     update_current_task(fn t ->
+      reject_review_option!(t, "set_criticality")
       semantic = t.semantic || %{covers: [], intent: nil, criticality: nil}
       %{t | semantic: %{semantic | criticality: level}}
     end)
@@ -429,6 +556,7 @@ defmodule Sykli.DSL do
   """
   def on_fail(action) when action in [:analyze, :retry, :skip] do
     update_current_task(fn t ->
+      reject_review_option!(t, "on_fail")
       ai_hooks = t.ai_hooks || %{on_fail: nil, select: nil}
       %{t | ai_hooks: %{ai_hooks | on_fail: action}}
     end)
@@ -451,6 +579,7 @@ defmodule Sykli.DSL do
   """
   def select_mode(mode) when mode in [:smart, :always, :manual] do
     update_current_task(fn t ->
+      reject_review_option!(t, "select_mode")
       ai_hooks = t.ai_hooks || %{on_fail: nil, select: nil}
       %{t | ai_hooks: %{ai_hooks | select: mode}}
     end)
@@ -498,6 +627,7 @@ defmodule Sykli.DSL do
   """
   def provides(name, value \\ nil) when is_binary(name) do
     update_current_task(fn t ->
+      reject_review_option!(t, "provides")
       entry = if value, do: %{name: name, value: value}, else: %{name: name}
       %{t | provides: t.provides ++ [entry]}
     end)
@@ -516,7 +646,10 @@ defmodule Sykli.DSL do
       end
   """
   def needs(names) when is_list(names) do
-    update_current_task(fn t -> %{t | needs: t.needs ++ names} end)
+    update_current_task(fn t ->
+      reject_review_option!(t, "needs")
+      %{t | needs: t.needs ++ names}
+    end)
   end
 
   # ============================================================================
@@ -531,6 +664,7 @@ defmodule Sykli.DSL do
   def gate_strategy(strategy)
       when is_binary(strategy) and strategy in ~w(prompt env file webhook) do
     update_current_task(fn t ->
+      reject_review_option!(t, "gate_strategy")
       gate = t.gate || raise "gate_strategy can only be used inside a gate block"
       %{t | gate: %{gate | strategy: strategy}}
     end)
@@ -539,6 +673,7 @@ defmodule Sykli.DSL do
   @doc "Sets the approval prompt message for this gate task."
   def gate_message(message) when is_binary(message) do
     update_current_task(fn t ->
+      reject_review_option!(t, "gate_message")
       gate = t.gate || raise "gate_message can only be used inside a gate block"
       %{t | gate: %{gate | message: message}}
     end)
@@ -547,6 +682,7 @@ defmodule Sykli.DSL do
   @doc "Sets the timeout in seconds for this gate task."
   def gate_timeout(seconds) when is_integer(seconds) and seconds > 0 do
     update_current_task(fn t ->
+      reject_review_option!(t, "gate_timeout")
       gate = t.gate || raise "gate_timeout can only be used inside a gate block"
       %{t | gate: %{gate | timeout: seconds}}
     end)
@@ -555,6 +691,7 @@ defmodule Sykli.DSL do
   @doc "Sets the environment variable to poll for the env strategy."
   def gate_env_var(var) when is_binary(var) do
     update_current_task(fn t ->
+      reject_review_option!(t, "gate_env_var")
       gate = t.gate || raise "gate_env_var can only be used inside a gate block"
       %{t | gate: %{gate | env_var: var}}
     end)
@@ -563,6 +700,7 @@ defmodule Sykli.DSL do
   @doc "Sets the file path to poll for the file strategy."
   def gate_file_path(path) when is_binary(path) do
     update_current_task(fn t ->
+      reject_review_option!(t, "gate_file_path")
       gate = t.gate || raise "gate_file_path can only be used inside a gate block"
       %{t | gate: %{gate | file_path: path}}
     end)
@@ -574,7 +712,11 @@ defmodule Sykli.DSL do
   """
   def mount_cwd do
     mount = %{resource: "src:.", path: "/work", type: :directory}
-    update_current_task(fn t -> %{t | mounts: t.mounts ++ [mount], workdir: "/work"} end)
+
+    update_current_task(fn t ->
+      reject_review_option!(t, "mount_cwd")
+      %{t | mounts: t.mounts ++ [mount], workdir: "/work"}
+    end)
   end
 
   @doc """
@@ -586,7 +728,11 @@ defmodule Sykli.DSL do
     end
 
     mount = %{resource: "src:.", path: container_path, type: :directory}
-    update_current_task(fn t -> %{t | mounts: t.mounts ++ [mount], workdir: container_path} end)
+
+    update_current_task(fn t ->
+      reject_review_option!(t, "mount_cwd_at")
+      %{t | mounts: t.mounts ++ [mount], workdir: container_path}
+    end)
   end
 
   # ============================================================================
@@ -953,4 +1099,10 @@ defmodule Sykli.DSL do
     current = Process.get(:sykli_current_task)
     Process.put(:sykli_current_task, update_fn.(current))
   end
+
+  defp reject_review_option!(%Sykli.Task{kind: :review}, option) do
+    raise "#{option} cannot be used inside a review block"
+  end
+
+  defp reject_review_option!(%Sykli.Task{}, _option), do: :ok
 end

--- a/sdk/elixir/lib/sykli/emitter.ex
+++ b/sdk/elixir/lib/sykli/emitter.ex
@@ -19,11 +19,20 @@ defmodule Sykli.Emitter do
       raise "duplicate task names detected"
     end
 
-    # Check all non-gate tasks have commands
+    # Check all non-gate, non-review tasks have commands
     Enum.each(pipeline.tasks, fn task ->
-      if is_nil(task.gate) and (is_nil(task.command) or task.command == "") do
-        Logger.error("task has no command", task: task.name)
-        raise "task #{inspect(task.name)} has no command"
+      cond do
+        task.kind == :review and (is_nil(task.primitive) or task.primitive == "") ->
+          Logger.error("review has no primitive", review: task.name)
+          raise "review #{inspect(task.name)} has no primitive"
+
+        task.kind != :review and is_nil(task.gate) and
+            (is_nil(task.command) or task.command == "") ->
+          Logger.error("task has no command", task: task.name)
+          raise "task #{inspect(task.name)} has no command"
+
+        true ->
+          :ok
       end
     end)
 
@@ -176,6 +185,27 @@ defmodule Sykli.Emitter do
   end
 
   defp task_to_json(task) do
+    if task.kind == :review do
+      review_to_json(task)
+    else
+      regular_task_to_json(task)
+    end
+  end
+
+  defp review_to_json(task) do
+    %{
+      name: task.name,
+      kind: "review",
+      primitive: task.primitive,
+      deterministic: task.deterministic
+    }
+    |> maybe_put(:agent, task.agent)
+    |> maybe_put(:context, non_empty(task.context))
+    |> maybe_put(:inputs, non_empty(task.inputs))
+    |> maybe_put(:depends_on, non_empty(task.depends_on))
+  end
+
+  defp regular_task_to_json(task) do
     # Use when_cond if set, otherwise use condition string
     condition =
       case task.when_cond do

--- a/sdk/elixir/lib/sykli/task.ex
+++ b/sdk/elixir/lib/sykli/task.ex
@@ -4,7 +4,12 @@ defmodule Sykli.Task do
   """
 
   defstruct name: nil,
+            kind: :task,
             command: nil,
+            primitive: nil,
+            agent: nil,
+            context: [],
+            deterministic: false,
             container: nil,
             workdir: nil,
             env: %{},
@@ -69,7 +74,12 @@ defmodule Sykli.Task do
 
   @type t :: %__MODULE__{
           name: String.t(),
+          kind: :task | :review,
           command: String.t() | nil,
+          primitive: String.t() | nil,
+          agent: String.t() | nil,
+          context: [String.t()],
+          deterministic: boolean(),
           container: String.t() | nil,
           workdir: String.t() | nil,
           env: %{String.t() => String.t()},

--- a/sdk/elixir/test/sykli_test.exs
+++ b/sdk/elixir/test/sykli_test.exs
@@ -111,6 +111,42 @@ defmodule SykliTest do
       task = hd(result.tasks)
       assert length(task.mounts) == 2
     end
+
+    test "review node" do
+      use Sykli
+
+      result =
+        pipeline do
+          task "test" do
+            run("go test ./...")
+          end
+
+          review "review-code" do
+            primitive("lint")
+            agent("claude")
+            context(["src/**/*.go"])
+            after_(["test"])
+            deterministic(true)
+          end
+        end
+
+      json = Sykli.Emitter.to_json(result)
+      decoded = Jason.decode!(json)
+      review = Enum.at(decoded["tasks"], 1)
+
+      assert review == %{
+               "name" => "review-code",
+               "kind" => "review",
+               "primitive" => "lint",
+               "agent" => "claude",
+               "context" => ["src/**/*.go"],
+               "depends_on" => ["test"],
+               "deterministic" => true
+             }
+
+      refute Map.has_key?(review, "command")
+      refute Map.has_key?(review, "outputs")
+    end
   end
 
   describe "validation" do
@@ -138,6 +174,57 @@ defmodule SykliTest do
           end
         end
         |> Sykli.Emitter.validate!()
+      end
+    end
+
+    test "review does not require command" do
+      use Sykli
+
+      pipeline =
+        pipeline do
+          review "review-code" do
+            primitive("lint")
+          end
+        end
+
+      assert Sykli.Emitter.validate!(pipeline) == pipeline
+    end
+
+    test "review requires primitive" do
+      use Sykli
+
+      assert_raise RuntimeError, ~r/has no primitive/, fn ->
+        pipeline do
+          review "review-code" do
+          end
+        end
+        |> Sykli.Emitter.validate!()
+      end
+    end
+
+    test "review rejects task execution options" do
+      use Sykli
+
+      assert_raise RuntimeError, ~r/run cannot be used inside a review block/, fn ->
+        pipeline do
+          review "review-code" do
+            primitive("lint")
+            run("echo nope")
+          end
+        end
+      end
+    end
+
+    test "review rejects task metadata options" do
+      use Sykli
+
+      assert_raise RuntimeError, ~r/env cannot be used inside a review block/, fn ->
+        pipeline do
+          review "review-code" do
+            primitive("lint")
+            env("CI", "true")
+          end
+        end
       end
     end
 

--- a/sdk/go/sykli.go
+++ b/sdk/go/sykli.go
@@ -799,14 +799,11 @@ func (r *Review) Context(paths ...string) *Review {
 	return r
 }
 
-// Outputs records structured output paths produced by this review node.
+// Outputs is deprecated for review nodes and no longer affects emitted JSON.
+//
+// Review outputs are not part of the canonical review-node contract. Keep this
+// method for source compatibility with early experimental users.
 func (r *Review) Outputs(paths ...string) *Review {
-	for _, path := range paths {
-		if path == "" {
-			log.Panic().Str("review", r.name).Msg("output path cannot be empty")
-		}
-		r.outputs = append(r.outputs, path)
-	}
 	return r
 }
 
@@ -1015,7 +1012,7 @@ func (t *Task) After(tasks ...string) *Task {
 // The condition is evaluated at runtime based on CI context variables:
 //   - branch == 'main' - run only on main branch
 //   - branch != 'main' - run on all branches except main
-//   - tag != '' - run only when a tag is present
+//   - tag != ” - run only when a tag is present
 //   - event == 'push' - run only on push events
 //   - ci == true - run only in CI environment
 func (t *Task) When(condition string) *Task {
@@ -1882,6 +1879,10 @@ func (p *Pipeline) EmitTo(w io.Writer) error {
 		}
 	}
 	for _, r := range p.reviews {
+		if r.primitive == "" {
+			log.Error().Str("review", r.name).Msg("review has no primitive")
+			return fmt.Errorf("review %q has no primitive", r.name)
+		}
 		for _, dep := range r.dependsOn {
 			if !taskNames[dep] {
 				log.Error().Str("review", r.name).Str("dependency", dep).Msg("unknown dependency")
@@ -2235,9 +2236,6 @@ func (p *Pipeline) EmitTo(w io.Writer) error {
 			Context:       r.context,
 			DependsOn:     r.dependsOn,
 			Deterministic: &deterministic,
-		}
-		if len(r.outputs) > 0 {
-			jt.Outputs = r.outputs
 		}
 		tasks = append(tasks, jt)
 	}

--- a/sdk/go/sykli_test.go
+++ b/sdk/go/sykli_test.go
@@ -264,8 +264,7 @@ func TestReviewNodeEmitsMetadata(t *testing.T) {
 		Agent("local").
 		Diff("main...HEAD").
 		Context("README.md", "docs/architecture.md").
-		After("test").
-		Outputs("reviews/api-breakage.local.json")
+		After("test")
 
 	result, err := emitJSON(p)
 	if err != nil {
@@ -311,15 +310,61 @@ func TestReviewNodeEmitsMetadata(t *testing.T) {
 		t.Errorf("expected context files, got %v", context)
 	}
 
-	outputs := review["outputs"].([]interface{})
-	if len(outputs) != 1 || outputs[0] != "reviews/api-breakage.local.json" {
-		t.Errorf("expected review output path, got %v", outputs)
+	if _, ok := review["outputs"]; ok {
+		t.Errorf("review node should not emit outputs")
 	}
 
 	deps := review["depends_on"].([]interface{})
 	if len(deps) != 1 || deps[0] != "test" {
 		t.Errorf("expected dependency on test, got %v", deps)
 	}
+}
+
+func TestReviewOutputsIsNoop(t *testing.T) {
+	p := New()
+	p.Review("review").
+		Primitive("lint").
+		Outputs("reviews/lint.json")
+
+	result, err := emitJSON(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	review := result["tasks"].([]interface{})[0].(map[string]interface{})
+	if _, ok := review["outputs"]; ok {
+		t.Errorf("review node should not emit outputs")
+	}
+}
+
+func TestReviewEmptyNamePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for empty review name")
+		}
+	}()
+	p := New()
+	p.Review("")
+}
+
+func TestReviewDuplicateNamePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for duplicate review name")
+		}
+	}()
+	p := New()
+	p.Task("review").Run("echo test")
+	p.Review("review")
+}
+
+func TestReviewEmptyPrimitivePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for empty review primitive")
+		}
+	}()
+	p := New()
+	p.Review("review").Primitive("")
 }
 
 func TestUnknownDependencyFails(t *testing.T) {

--- a/sdk/python/src/sykli/__init__.py
+++ b/sdk/python/src/sykli/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     # Core
     "Pipeline",
     "Task",
+    "Review",
     "TaskGroup",
     # Resources
     "Directory",
@@ -850,6 +851,84 @@ class Task:
 
 
 # =============================================================================
+# REVIEW
+# =============================================================================
+
+
+class Review:
+    """Experimental review node in the pipeline graph."""
+
+    def __init__(self, pipeline: Pipeline, name: str) -> None:
+        self._pipeline = pipeline
+        self._name = name
+        self._primitive: str = ""
+        self._agent: str = ""
+        self._context: list[str] = []
+        self._inputs: list[str] = []
+        self._depends_on: list[str] = []
+        self._deterministic: bool = False
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def primitive(self, name: str) -> Self:
+        if not name:
+            raise ValueError(f"review {self._name!r}: primitive cannot be empty")
+        self._primitive = name
+        return self
+
+    def agent(self, name: str) -> Self:
+        if not name:
+            raise ValueError(f"review {self._name!r}: agent cannot be empty")
+        self._agent = name
+        return self
+
+    def context(self, *paths: str) -> Self:
+        for path in paths:
+            if not path:
+                raise ValueError(f"review {self._name!r}: context path cannot be empty")
+            self._context.append(path)
+        return self
+
+    def inputs(self, *refs: str) -> Self:
+        for ref in refs:
+            if not ref:
+                raise ValueError(f"review {self._name!r}: input reference cannot be empty")
+            self._inputs.append(ref)
+        return self
+
+    def after(self, *tasks: str) -> Self:
+        for task in tasks:
+            if task and task not in self._depends_on:
+                self._depends_on.append(task)
+        return self
+
+    def deterministic(self, value: bool) -> Self:
+        if not isinstance(value, bool):
+            raise ValueError(f"review {self._name!r}: deterministic must be a boolean")
+        self._deterministic = value
+        return self
+
+    def _to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "name": self._name,
+            "kind": "review",
+            "primitive": self._primitive,
+            "deterministic": self._deterministic,
+        }
+        if self._agent:
+            d["agent"] = self._agent
+        if self._context:
+            d["context"] = list(self._context)
+        if self._inputs:
+            d["inputs"] = list(self._inputs)
+        if self._depends_on:
+            d["depends_on"] = list(self._depends_on)
+        return d
+
+
+# =============================================================================
 # PIPELINE
 # =============================================================================
 
@@ -866,7 +945,7 @@ class Pipeline:
     """
 
     def __init__(self, *, k8s_defaults: K8sOptions | None = None) -> None:
-        self._tasks: list[Task] = []
+        self._tasks: list[Task | Review] = []
         self._task_names: set[str] = set()
         self._dirs: list[Directory] = []
         self._caches: list[CacheVolume] = []
@@ -899,6 +978,18 @@ class Pipeline:
         self._task_names.add(name)
         log.debug("registered gate %r", name)
         return t
+
+    def review(self, name: str) -> Review:
+        """Create an experimental review node."""
+        if not name:
+            raise ValueError("review name cannot be empty")
+        if name in self._task_names:
+            raise ValueError(f"task/gate/review {name!r} already exists")
+        r = Review(self, name)
+        self._tasks.append(r)
+        self._task_names.add(name)
+        log.debug("registered review %r", name)
+        return r
 
     # ─────────────────────────────────────────────────────────────────────────
     # RESOURCES
@@ -1013,9 +1104,16 @@ class Pipeline:
 
     def validate(self) -> None:
         """Validate the pipeline. Raises ValidationError on problems."""
-        # Check all non-gate tasks have commands
+        # Check all non-gate, non-review tasks have commands.
         for t in self._tasks:
-            if not t._is_gate and not t._command:
+            if isinstance(t, Review):
+                if not t._primitive:
+                    raise ValidationError(
+                        code="MISSING_COMMAND",
+                        message=f"review {t._name!r} has no primitive",
+                        task=t._name,
+                    )
+            elif not t._is_gate and not t._command:
                 raise ValidationError(
                     code="MISSING_COMMAND",
                     message=f"task {t._name!r} has no command",
@@ -1042,6 +1140,8 @@ class Pipeline:
 
         # K8s validation
         for t in self._tasks:
+            if isinstance(t, Review):
+                continue
             k8s = t._k8s
             if k8s is None and self._k8s_defaults:
                 k8s = self._k8s_defaults
@@ -1091,6 +1191,8 @@ class Pipeline:
             prefix = "  "
             if t._is_gate:
                 kind = f"gate ({t._gate_strategy})"
+            elif isinstance(t, Review):
+                kind = f"review ({t._primitive})"
             else:
                 kind = t._command
             deps = f" (after: {', '.join(t._depends_on)})" if t._depends_on else ""
@@ -1118,6 +1220,8 @@ class Pipeline:
         if self._dirs or self._caches:
             return True
         for t in self._tasks:
+            if isinstance(t, Review):
+                continue
             if t._container or t._mounts:
                 return True
         return False

--- a/sdk/python/tests/test_serialization.py
+++ b/sdk/python/tests/test_serialization.py
@@ -16,6 +16,32 @@ class TestJsonWireFormat:
         task = d["tasks"][0]
         assert task == {"name": "test", "command": "pytest"}
 
+    def test_review_node(self):
+        p = Pipeline()
+        p.task("test").run("go test ./...")
+        (
+            p.review("review-code")
+            .primitive("lint")
+            .agent("claude")
+            .context("src/**/*.go")
+            .after("test")
+            .deterministic(True)
+        )
+
+        d = p.to_dict()
+        review = d["tasks"][1]
+        assert review == {
+            "name": "review-code",
+            "kind": "review",
+            "primitive": "lint",
+            "agent": "claude",
+            "context": ["src/**/*.go"],
+            "depends_on": ["test"],
+            "deterministic": True,
+        }
+        assert "command" not in review
+        assert "outputs" not in review
+
     def test_full_task(self):
         p = Pipeline()
         with pytest.warns(DeprecationWarning, match="Task.target\\(\\) is deprecated"):

--- a/sdk/python/tests/test_validation.py
+++ b/sdk/python/tests/test_validation.py
@@ -104,6 +104,40 @@ class TestDeferredValidation:
         # Should not raise — gates don't need commands
         p.validate()
 
+    def test_review_no_command_ok(self):
+        p = Pipeline()
+        p.review("review-code").primitive("lint")
+        p.validate()
+
+    def test_review_requires_primitive(self):
+        p = Pipeline()
+        p.review("review-code")
+        with pytest.raises(ValidationError) as exc_info:
+            p.validate()
+        assert exc_info.value.code == "MISSING_COMMAND"
+        assert exc_info.value.task == "review-code"
+
+    def test_empty_review_name(self):
+        p = Pipeline()
+        with pytest.raises(ValueError):
+            p.review("")
+
+    def test_duplicate_review_name(self):
+        p = Pipeline()
+        p.task("review-code").run("echo test")
+        with pytest.raises(ValueError):
+            p.review("review-code")
+
+    def test_empty_review_primitive(self):
+        p = Pipeline()
+        with pytest.raises(ValueError):
+            p.review("review-code").primitive("")
+
+    def test_review_deterministic_requires_bool(self):
+        p = Pipeline()
+        with pytest.raises(ValueError):
+            p.review("review-code").deterministic("yes")
+
     def test_unknown_dependency(self):
         p = Pipeline()
         p.task("test").run("pytest").after("lint")

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -457,6 +457,19 @@ pub struct Task<'a> {
     index: usize,
 }
 
+/// An experimental review node in the pipeline graph.
+pub struct Review<'a> {
+    pipeline: &'a mut Pipeline,
+    index: usize,
+}
+
+#[derive(Clone, Default, PartialEq)]
+enum NodeKind {
+    #[default]
+    Task,
+    Review,
+}
+
 /// Represents an input artifact from another task's output.
 #[derive(Clone, Default)]
 struct TaskInput {
@@ -723,8 +736,13 @@ impl std::fmt::Display for Condition {
 
 #[derive(Clone, Default)]
 struct TaskData {
+    kind: NodeKind,
     name: String,
     command: String,
+    primitive: Option<String>,
+    agent: Option<String>,
+    context: Vec<String>,
+    deterministic: bool,
     container: Option<String>,
     workdir: Option<String>,
     env: HashMap<String, String>,
@@ -1560,6 +1578,87 @@ impl<'a> Task<'a> {
     }
 }
 
+impl<'a> Review<'a> {
+    /// Returns the review node's name.
+    pub fn name(&self) -> String {
+        self.pipeline.tasks[self.index].name.clone()
+    }
+
+    /// Sets the review primitive identifier.
+    ///
+    /// # Panics
+    /// Panics if `name` is empty.
+    #[must_use]
+    pub fn primitive(self, name: &str) -> Self {
+        assert!(!name.is_empty(), "review primitive cannot be empty");
+        self.pipeline.tasks[self.index].primitive = Some(name.to_string());
+        self
+    }
+
+    /// Sets the agent identifier for this review node.
+    ///
+    /// # Panics
+    /// Panics if `name` is empty.
+    #[must_use]
+    pub fn agent(self, name: &str) -> Self {
+        assert!(!name.is_empty(), "review agent cannot be empty");
+        self.pipeline.tasks[self.index].agent = Some(name.to_string());
+        self
+    }
+
+    /// Adds context paths for the review.
+    ///
+    /// # Panics
+    /// Panics if any path is empty.
+    #[must_use]
+    pub fn context(self, paths: &[&str]) -> Self {
+        for path in paths {
+            assert!(!path.is_empty(), "review context path cannot be empty");
+        }
+        self.pipeline.tasks[self.index]
+            .context
+            .extend(paths.iter().map(|s| (*s).to_string()));
+        self
+    }
+
+    /// Records review input references.
+    ///
+    /// # Panics
+    /// Panics if any input reference is empty.
+    #[must_use]
+    pub fn inputs(self, refs: &[&str]) -> Self {
+        for reference in refs {
+            assert!(
+                !reference.is_empty(),
+                "review input reference cannot be empty"
+            );
+        }
+        self.pipeline.tasks[self.index]
+            .inputs
+            .extend(refs.iter().map(|s| (*s).to_string()));
+        self
+    }
+
+    /// Sets dependencies for this review node. Duplicates are ignored.
+    #[must_use]
+    pub fn after(self, tasks: &[&str]) -> Self {
+        let task = &mut self.pipeline.tasks[self.index];
+        for name in tasks {
+            if !name.is_empty() && !task.depends_on.iter().any(|dep| dep == name) {
+                task.depends_on.push((*name).to_string());
+            }
+        }
+        self
+    }
+
+    /// Sets whether the review is deterministic.
+    #[must_use]
+    pub fn deterministic(self, value: bool) -> Self {
+        self.pipeline.tasks[self.index].deterministic = value;
+        self
+    }
+}
+
 // =============================================================================
 // EXPLAIN CONTEXT
 // =============================================================================
@@ -1708,6 +1807,28 @@ impl Pipeline {
         });
         let index = self.tasks.len() - 1;
         Task {
+            pipeline: self,
+            index,
+        }
+    }
+
+    /// Creates an experimental review node with the given name.
+    ///
+    /// # Panics
+    /// Panics if `name` is empty or if a node with the same name already exists.
+    pub fn review(&mut self, name: &str) -> Review<'_> {
+        assert!(!name.is_empty(), "review name cannot be empty");
+        assert!(
+            !self.tasks.iter().any(|t| t.name == name),
+            "task/gate/review {name:?} already exists"
+        );
+        self.tasks.push(TaskData {
+            kind: NodeKind::Review,
+            name: name.to_string(),
+            ..Default::default()
+        });
+        let index = self.tasks.len() - 1;
+        Review {
             pipeline: self,
             index,
         }
@@ -2047,7 +2168,14 @@ impl Pipeline {
         // Validate
         let task_names: Vec<_> = self.tasks.iter().map(|t| t.name.as_str()).collect();
         for t in &self.tasks {
-            if t.command.is_empty() && t.gate.is_none() {
+            if t.kind == NodeKind::Review {
+                if t.primitive.as_deref().unwrap_or("").is_empty() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("review {:?} has no primitive", t.name),
+                    ));
+                }
+            } else if t.command.is_empty() && t.gate.is_none() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("task {:?} has no command", t.name),
@@ -2152,7 +2280,36 @@ impl Pipeline {
                 .iter()
                 .map(|t| JsonTask {
                     name: t.name.clone(),
-                    command: if t.command.is_empty() { None } else { Some(t.command.clone()) },
+                    kind: if t.kind == NodeKind::Review {
+                        Some("review".to_string())
+                    } else {
+                        None
+                    },
+                    command: if t.kind == NodeKind::Review || t.command.is_empty() {
+                        None
+                    } else {
+                        Some(t.command.clone())
+                    },
+                    primitive: if t.kind == NodeKind::Review {
+                        t.primitive.clone()
+                    } else {
+                        None
+                    },
+                    agent: if t.kind == NodeKind::Review {
+                        t.agent.clone()
+                    } else {
+                        None
+                    },
+                    context: if t.kind == NodeKind::Review && !t.context.is_empty() {
+                        Some(t.context.clone())
+                    } else {
+                        None
+                    },
+                    deterministic: if t.kind == NodeKind::Review {
+                        Some(t.deterministic)
+                    } else {
+                        None
+                    },
                     container: t.container.clone(),
                     workdir: t.workdir.clone(),
                     env: if t.env.is_empty() {
@@ -2193,7 +2350,7 @@ impl Pipeline {
                                 .collect(),
                         )
                     },
-                    outputs: if t.outputs.is_empty() {
+                    outputs: if t.kind == NodeKind::Review || t.outputs.is_empty() {
                         None
                     } else {
                         Some(t.outputs.clone())
@@ -2298,7 +2455,11 @@ impl Pipeline {
                             None
                         } else {
                             Some(JsonSemantic {
-                                covers: if s.covers.is_empty() { None } else { Some(s.covers.clone()) },
+                                covers: if s.covers.is_empty() {
+                                    None
+                                } else {
+                                    Some(s.covers.clone())
+                                },
                                 intent: s.intent.clone(),
                                 criticality: s.criticality.as_ref().map(|c| match c {
                                     Criticality::High => "high".to_string(),
@@ -2552,7 +2713,17 @@ struct JsonAiHooks {
 struct JsonTask {
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    primitive: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    deterministic: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     container: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2680,6 +2851,74 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&buf).unwrap();
 
         assert_eq!(json["tasks"][1]["depends_on"][0], "test");
+    }
+
+    #[test]
+    fn test_review_node_serialization() {
+        let mut p = Pipeline::new();
+        p.task("test").run("go test ./...");
+        p.review("review-code")
+            .primitive("lint")
+            .agent("claude")
+            .context(&["src/**/*.go"])
+            .after(&["test"])
+            .deterministic(true);
+
+        let mut buf = Vec::new();
+        p.emit_to(&mut buf).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        let review = &json["tasks"][1];
+
+        assert_eq!(review["name"], "review-code");
+        assert_eq!(review["kind"], "review");
+        assert_eq!(review["primitive"], "lint");
+        assert_eq!(review["agent"], "claude");
+        assert_eq!(review["context"][0], "src/**/*.go");
+        assert_eq!(review["depends_on"][0], "test");
+        assert_eq!(review["deterministic"], true);
+        assert!(review.get("command").is_none());
+        assert!(review.get("outputs").is_none());
+    }
+
+    #[test]
+    fn test_review_node_does_not_require_command() {
+        let mut p = Pipeline::new();
+        p.review("review-code").primitive("lint");
+
+        let mut buf = Vec::new();
+        p.emit_to(&mut buf).unwrap();
+    }
+
+    #[test]
+    fn test_review_node_requires_primitive() {
+        let mut p = Pipeline::new();
+        p.review("review-code");
+
+        let mut buf = Vec::new();
+        let err = p.emit_to(&mut buf).unwrap_err();
+        assert!(err.to_string().contains("has no primitive"));
+    }
+
+    #[test]
+    #[should_panic(expected = "review name cannot be empty")]
+    fn test_review_empty_name_panics() {
+        let mut p = Pipeline::new();
+        p.review("");
+    }
+
+    #[test]
+    #[should_panic(expected = "already exists")]
+    fn test_review_duplicate_name_panics() {
+        let mut p = Pipeline::new();
+        p.task("review-code").run("echo test");
+        p.review("review-code");
+    }
+
+    #[test]
+    #[should_panic(expected = "review primitive cannot be empty")]
+    fn test_review_empty_primitive_panics() {
+        let mut p = Pipeline::new();
+        p.review("review-code").primitive("");
     }
 
     #[test]
@@ -3860,13 +4099,11 @@ mod tests {
     #[test]
     fn test_k8s_gpu() {
         let mut p = Pipeline::new();
-        p.task("train")
-            .run("python train.py")
-            .k8s(K8sOptions {
-                memory: Some("32Gi".into()),
-                gpu: Some(2),
-                ..Default::default()
-            });
+        p.task("train").run("python train.py").k8s(K8sOptions {
+            memory: Some("32Gi".into()),
+            gpu: Some(2),
+            ..Default::default()
+        });
 
         let mut buf = Vec::new();
         p.emit_to(&mut buf).unwrap();
@@ -3897,7 +4134,10 @@ mod tests {
         assert_eq!(json["tasks"][0]["k8s"]["memory"], "32Gi");
         assert_eq!(json["tasks"][0]["k8s"]["gpu"], 1);
         // Raw JSON passed through
-        assert!(json["tasks"][0]["k8s"]["raw"].as_str().unwrap().contains("nodeSelector"));
+        assert!(json["tasks"][0]["k8s"]["raw"]
+            .as_str()
+            .unwrap()
+            .contains("nodeSelector"));
     }
 
     #[test]
@@ -3912,7 +4152,10 @@ mod tests {
         p.emit_to(&mut buf).unwrap();
         let json: serde_json::Value = serde_json::from_slice(&buf).unwrap();
 
-        assert!(json["tasks"][0]["k8s"]["raw"].as_str().unwrap().contains("serviceAccount"));
+        assert!(json["tasks"][0]["k8s"]["raw"]
+            .as_str()
+            .unwrap()
+            .contains("serviceAccount"));
     }
 
     #[test]
@@ -4092,7 +4335,9 @@ mod tests {
             .gate_timeout(600)
             .gate_message("Approve deployment to production?")
             .gate_env_var("DEPLOY_APPROVED");
-        p.task("deploy").run("make deploy").after(&["approve-deploy"]);
+        p.task("deploy")
+            .run("make deploy")
+            .after(&["approve-deploy"]);
 
         let mut buf = Vec::new();
         p.emit_to(&mut buf).unwrap();
@@ -4104,7 +4349,10 @@ mod tests {
         // Gate config
         assert_eq!(json["tasks"][1]["gate"]["strategy"], "env");
         assert_eq!(json["tasks"][1]["gate"]["timeout"], 600);
-        assert_eq!(json["tasks"][1]["gate"]["message"], "Approve deployment to production?");
+        assert_eq!(
+            json["tasks"][1]["gate"]["message"],
+            "Approve deployment to production?"
+        );
         assert_eq!(json["tasks"][1]["gate"]["env_var"], "DEPLOY_APPROVED");
         // Non-gate tasks still have commands
         assert_eq!(json["tasks"][0]["command"], "make build");

--- a/sdk/typescript/src/index.test.ts
+++ b/sdk/typescript/src/index.test.ts
@@ -52,6 +52,55 @@ describe('Pipeline', () => {
       const json = p.toJSON();
       expect(json.version).toBe('2');
     });
+
+    it('creates an experimental review node', () => {
+      const p = new Pipeline();
+      p.task('test').run('go test ./...');
+      p.review('review-code')
+        .primitive('lint')
+        .agent('claude')
+        .context('src/**/*.go')
+        .after('test')
+        .deterministic(true);
+
+      const json = p.toJSON();
+      const review = (json.tasks as any[])[1];
+
+      expect(review).toEqual({
+        name: 'review-code',
+        kind: 'review',
+        primitive: 'lint',
+        agent: 'claude',
+        context: ['src/**/*.go'],
+        depends_on: ['test'],
+        deterministic: true,
+      });
+      expect(review.command).toBeUndefined();
+      expect(review.outputs).toBeUndefined();
+    });
+
+    it('does not require commands for review nodes', () => {
+      const p = new Pipeline();
+      p.review('review-code').primitive('lint');
+
+      expect(() => p.toJSON()).not.toThrow();
+    });
+
+    it('rejects empty review names', () => {
+      const p = new Pipeline();
+      expect(() => p.review('')).toThrow(ValidationError);
+    });
+
+    it('rejects duplicate review names', () => {
+      const p = new Pipeline();
+      p.task('review-code').run('echo test');
+      expect(() => p.review('review-code')).toThrow(ValidationError);
+    });
+
+    it('rejects empty review primitives', () => {
+      const p = new Pipeline();
+      expect(() => p.review('review-code').primitive('')).toThrow('primitive cannot be empty');
+    });
   });
 
   describe('conditions', () => {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -774,6 +774,16 @@ export class Task {
     return this._gate !== undefined;
   }
 
+  /** @internal Check if this is a review node */
+  _isReview(): boolean {
+    return false;
+  }
+
+  /** @internal Get review primitive */
+  _getPrimitive(): string | undefined {
+    return undefined;
+  }
+
   // ─────────────────────────────────────────────────────────────────────────────
   // Internal accessors (for Template and Pipeline use)
   // ─────────────────────────────────────────────────────────────────────────────
@@ -955,6 +965,139 @@ export class Task {
 }
 
 // =============================================================================
+// REVIEW
+// =============================================================================
+
+/** Experimental review node in the pipeline graph */
+export class Review {
+  private _primitive?: string;
+  private _agent?: string;
+  private _context: string[] = [];
+  private _inputs: string[] = [];
+  private _dependsOn: string[] = [];
+  private _deterministic = false;
+
+  constructor(
+    private readonly pipeline: Pipeline,
+    public readonly name: string
+  ) {}
+
+  /** Set the review primitive identifier */
+  primitive(name: string): this {
+    if (!name) {
+      throw new Error(`review '${this.name}': primitive cannot be empty`);
+    }
+    this._primitive = name;
+    return this;
+  }
+
+  /** Set the agent identifier for this review */
+  agent(name: string): this {
+    if (!name) {
+      throw new Error(`review '${this.name}': agent cannot be empty`);
+    }
+    this._agent = name;
+    return this;
+  }
+
+  /** Add review context paths */
+  context(...paths: string[]): this {
+    for (const path of paths) {
+      if (!path) {
+        throw new Error(`review '${this.name}': context path cannot be empty`);
+      }
+      this._context.push(path);
+    }
+    return this;
+  }
+
+  /** Add review input references */
+  inputs(...refs: string[]): this {
+    for (const ref of refs) {
+      if (!ref) {
+        throw new Error(`review '${this.name}': input reference cannot be empty`);
+      }
+      this._inputs.push(ref);
+    }
+    return this;
+  }
+
+  /** Set dependencies for this review node */
+  after(...tasks: string[]): this {
+    for (const task of tasks) {
+      if (task && !this._dependsOn.includes(task)) {
+        this._dependsOn.push(task);
+      }
+    }
+    return this;
+  }
+
+  /** Set whether this review is deterministic */
+  deterministic(value: boolean): this {
+    this._deterministic = value;
+    return this;
+  }
+
+  /** @internal Check if this is a gate task */
+  _isGate(): boolean {
+    return false;
+  }
+
+  /** @internal Check if this is a review node */
+  _isReview(): boolean {
+    return true;
+  }
+
+  /** @internal Get dependencies */
+  _getDependsOn(): string[] {
+    return this._dependsOn;
+  }
+
+  /** @internal Get command */
+  _getCommand(): string | undefined {
+    return undefined;
+  }
+
+  /** @internal Get container image */
+  _getContainer(): string | undefined {
+    return undefined;
+  }
+
+  /** @internal Get mounts */
+  _getMounts(): Mount[] {
+    return [];
+  }
+
+  /** @internal Get K8s options */
+  _getK8s(): K8sOptions | undefined {
+    return undefined;
+  }
+
+  /** @internal Set K8s options */
+  _setK8s(_opts: K8sOptions): void {}
+
+  /** @internal Get primitive */
+  _getPrimitive(): string | undefined {
+    return this._primitive;
+  }
+
+  /** Convert to JSON representation (internal) */
+  _toJSON(): Record<string, unknown> {
+    const json: Record<string, unknown> = {
+      name: this.name,
+      kind: 'review',
+      primitive: this._primitive,
+      deterministic: this._deterministic,
+    };
+    if (this._agent) json.agent = this._agent;
+    if (this._context.length > 0) json.context = this._context;
+    if (this._inputs.length > 0) json.inputs = this._inputs;
+    if (this._dependsOn.length > 0) json.depends_on = this._dependsOn;
+    return json;
+  }
+}
+
+// =============================================================================
 // TASK GROUP
 // =============================================================================
 
@@ -1005,7 +1148,7 @@ const enum Color {
 
 /** CI pipeline with tasks and resources */
 export class Pipeline {
-  private tasks: Task[] = [];
+  private tasks: Array<Task | Review> = [];
   private templates: Map<string, Template> = new Map();
   private directories: Directory[] = [];
   private caches: CacheVolume[] = [];
@@ -1028,6 +1171,19 @@ export class Pipeline {
     const task = new Task(this, name);
     this.tasks.push(task);
     return task;
+  }
+
+  /** Create an experimental review node */
+  review(name: string): Review {
+    if (!name || name.trim() === '') {
+      throw new ValidationError('Review name cannot be empty', 'EMPTY_NAME');
+    }
+    if (this.tasks.some((t) => t.name === name)) {
+      throw new ValidationError(`Duplicate task/gate/review name: "${name}"`, 'DUPLICATE_TASK');
+    }
+    const review = new Review(this, name);
+    this.tasks.push(review);
+    return review;
   }
 
   /** Create an approval gate that pauses the pipeline until approved */
@@ -1155,8 +1311,16 @@ export class Pipeline {
       }
       taskNames.add(task.name);
 
-      // Missing command check (gates don't need a command)
-      if (!task._getCommand() && !task._isGate()) {
+      if (task._isReview() && !task._getPrimitive()) {
+        throw new ValidationError(
+          `Review "${task.name}" has no primitive`,
+          'MISSING_COMMAND',
+          'did you forget to call .primitive()?'
+        );
+      }
+
+      // Missing command check (gates and review nodes don't need a command)
+      if (!task._getCommand() && !task._isGate() && !task._isReview()) {
         throw new ValidationError(
           `Task "${task.name}" has no command`,
           'MISSING_COMMAND',
@@ -1479,9 +1643,9 @@ export class Pipeline {
    * Topological sort using Kahn's algorithm.
    * Returns tasks in dependency order for display.
    */
-  private topologicalSort(): Task[] {
+  private topologicalSort(): Array<Task | Review> {
     const inDegree = new Map<string, number>();
-    const taskMap = new Map<string, Task>();
+    const taskMap = new Map<string, Task | Review>();
 
     // Initialize
     for (const task of this.tasks) {
@@ -1504,7 +1668,7 @@ export class Pipeline {
       }
     }
 
-    const sorted: Task[] = [];
+    const sorted: Array<Task | Review> = [];
     while (queue.length > 0) {
       const name = queue.shift()!;
       sorted.push(taskMap.get(name)!);
@@ -1526,7 +1690,7 @@ export class Pipeline {
   /**
    * Get the effective condition string for a task.
    */
-  private getTaskCondition(task: Task): string | undefined {
+  private getTaskCondition(task: Task | Review): string | undefined {
     // Access internal state via JSON output
     const json = task._toJSON();
     return json.when as string | undefined;
@@ -1537,7 +1701,7 @@ export class Pipeline {
    * Returns skip reason or undefined if task would run.
    */
   private wouldSkip(
-    task: Task,
+    task: Task | Review,
     ctx: { branch: string; tag: string; event: string; ci: boolean }
   ): string | undefined {
     const condition = this.getTaskCondition(task);

--- a/tests/conformance/cases/22-review-node.json
+++ b/tests/conformance/cases/22-review-node.json
@@ -1,0 +1,18 @@
+{
+  "version": "1",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./..."
+    },
+    {
+      "name": "review-code",
+      "kind": "review",
+      "primitive": "lint",
+      "agent": "claude",
+      "context": ["src/**/*.go"],
+      "depends_on": ["test"],
+      "deterministic": true
+    }
+  ]
+}

--- a/tests/conformance/fixtures/elixir/22-review-node.exs
+++ b/tests/conformance/fixtures/elixir/22-review-node.exs
@@ -1,0 +1,18 @@
+use Sykli
+
+pipeline do
+  task "test" do
+    run "go test ./..."
+  end
+
+  review "review-code" do
+    primitive "lint"
+    agent "claude"
+    context ["src/**/*.go"]
+    after_ ["test"]
+    deterministic true
+  end
+end
+|> Sykli.Emitter.validate!()
+|> Sykli.Emitter.to_json()
+|> IO.puts()

--- a/tests/conformance/fixtures/go/22-review-node.go
+++ b/tests/conformance/fixtures/go/22-review-node.go
@@ -1,0 +1,17 @@
+package main
+
+import sykli "github.com/yairfalse/sykli/sdk/go"
+
+func main() {
+	p := sykli.New()
+
+	p.Task("test").Run("go test ./...")
+	p.Review("review-code").
+		Primitive("lint").
+		Agent("claude").
+		Context("src/**/*.go").
+		After("test").
+		Deterministic(true)
+
+	p.Emit()
+}

--- a/tests/conformance/fixtures/python/22-review-node.py
+++ b/tests/conformance/fixtures/python/22-review-node.py
@@ -1,0 +1,13 @@
+from sykli import Pipeline
+
+p = Pipeline()
+
+p.task("test").run("go test ./...")
+p.review("review-code") \
+    .primitive("lint") \
+    .agent("claude") \
+    .context("src/**/*.go") \
+    .after("test") \
+    .deterministic(True)
+
+p.emit()

--- a/tests/conformance/fixtures/rust/22-review-node.rs
+++ b/tests/conformance/fixtures/rust/22-review-node.rs
@@ -1,0 +1,15 @@
+use sykli::Pipeline;
+
+fn main() {
+    let mut p = Pipeline::new();
+
+    p.task("test").run("go test ./...");
+    p.review("review-code")
+        .primitive("lint")
+        .agent("claude")
+        .context(&["src/**/*.go"])
+        .after(&["test"])
+        .deterministic(true);
+
+    p.emit();
+}

--- a/tests/conformance/fixtures/typescript/22-review-node.ts
+++ b/tests/conformance/fixtures/typescript/22-review-node.ts
@@ -1,0 +1,13 @@
+import { Pipeline } from '../../../../sdk/typescript/src/index';
+
+const p = new Pipeline();
+
+p.task('test').run('go test ./...');
+p.review('review-code')
+  .primitive('lint')
+  .agent('claude')
+  .context('src/**/*.go')
+  .after('test')
+  .deterministic(true);
+
+p.emit();


### PR DESCRIPTION
## Summary
- add minimal experimental review-node builders/APIs across Go, Rust, TypeScript, Python, and Elixir
- add conformance case 22-review-node plus fixtures for all SDKs
- document review nodes as experimental and keep review outputs out of canonical behavior

## Validation
- python3 -c "import json; json.load(open('schemas/sykli-pipeline.schema.json'))"
- python3 scripts/validate-conformance-schema.py — 22 passed, 0 failed
- env GOCACHE=/private/tmp/sykli-go-build SYKLI_CONFORMANCE_PYTHON=python3.14 tests/conformance/run.sh — 135 passed, 0 failed, 0 skipped
- env GOCACHE=/private/tmp/sykli-go-build SYKLI_CONFORMANCE_PYTHON=python3.14 tests/conformance/run.sh 22-review-node — 5 passed
- env GOCACHE=/private/tmp/sykli-go-build go test ./...
- cargo test --lib
- npx vitest run
- mix test
- PYTHONPATH=src python3.14 -m pytest
- git diff --check
- git diff --name-only core schemas — no output

Note: the conformance harness embedded schema-validation step skipped because python3.14 does not have jsonschema installed. Standalone schema validation passed with local python3.

## Confirmations
- no engine behavior changes
- no schema field changes
- no replacement for target
- no review outputs added to canonical behavior
- no Phase 3 fields added