### PR TITLE
feat: add task_type as semantic contract field

### DIFF
--- a/core/lib/sykli/graph.ex
+++ b/core/lib/sykli/graph.ex
@@ -373,15 +373,15 @@ defmodule Sykli.Graph do
   end
 
   def format_error({:task_type_on_review, task_name}) do
-    "Review node '#{task_name}' cannot declare task_type"
+    "Error: Review node '#{task_name}' cannot declare task_type"
   end
 
   def format_error({:task_type_requires_version_3, task_name, version, _task_type}) do
-    "Task '#{task_name}' declares task_type but pipeline version is #{inspect(version)}, not \"3\""
+    "Error: Task '#{task_name}' declares task_type but pipeline version is #{inspect(version)}, not \"3\""
   end
 
   def format_error({:unknown_task_type, task_name, task_type}) do
-    "Task '#{task_name}' declares unknown task_type #{inspect(task_type)}"
+    "Error: Task '#{task_name}' declares unknown task_type #{inspect(task_type)}"
   end
 
   def format_error(reason), do: inspect(reason)

--- a/core/lib/sykli/graph.ex
+++ b/core/lib/sykli/graph.ex
@@ -71,6 +71,7 @@ defmodule Sykli.Graph do
     defstruct [
       :name,
       :kind,
+      :task_type,
       :command,
       :inputs,
       :outputs,
@@ -142,6 +143,10 @@ defmodule Sykli.Graph do
     @spec kind(t()) :: :task | :review
     def kind(%__MODULE__{kind: :review}), do: :review
     def kind(_), do: :task
+
+    @doc "Returns the executable task semantic class."
+    @spec task_type(t()) :: String.t() | nil
+    def task_type(%__MODULE__{task_type: task_type}), do: task_type
 
     @doc "Returns the task command."
     @spec command(t()) :: String.t()
@@ -347,8 +352,10 @@ defmodule Sykli.Graph do
 
   def parse(json) do
     case Jason.decode(json) do
-      {:ok, %{"tasks" => tasks}} ->
-        case map_ok(tasks, &parse_task/1) do
+      {:ok, %{"tasks" => tasks} = data} ->
+        version = Map.get(data, "version", "1")
+
+        case map_ok(tasks, &parse_task(&1, version)) do
           {:ok, parsed_tasks} ->
             parsed = Map.new(parsed_tasks, fn task -> {task.name, task} end)
             {:ok, parsed}
@@ -365,16 +372,32 @@ defmodule Sykli.Graph do
     end
   end
 
-  defp parse_task(map) do
+  def format_error({:task_type_on_review, task_name}) do
+    "Review node '#{task_name}' cannot declare task_type"
+  end
+
+  def format_error({:task_type_requires_version_3, task_name, version, _task_type}) do
+    "Task '#{task_name}' declares task_type but pipeline version is #{inspect(version)}, not \"3\""
+  end
+
+  def format_error({:unknown_task_type, task_name, task_type}) do
+    "Task '#{task_name}' declares unknown task_type #{inspect(task_type)}"
+  end
+
+  def format_error(reason), do: inspect(reason)
+
+  defp parse_task(map, version) do
     task_name = map["name"]
     kind = parse_kind(map["kind"])
 
-    with {:ok, services} <- parse_services(map["services"], task_name),
+    with {:ok, task_type} <- parse_task_type(map["task_type"], kind, version, task_name),
+         {:ok, services} <- parse_services(map["services"], task_name),
          {:ok, mounts} <- parse_mounts(map["mounts"], task_name) do
       {:ok,
        %Task{
          name: task_name,
          kind: kind,
+         task_type: task_type,
          command: map["command"],
          inputs: map["inputs"] || [],
          outputs: normalize_outputs(map["outputs"], kind),
@@ -416,6 +439,24 @@ defmodule Sykli.Graph do
   defp parse_kind("review"), do: :review
   defp parse_kind(:review), do: :review
   defp parse_kind(_), do: :task
+
+  defp parse_task_type(nil, _kind, _version, _task_name), do: {:ok, nil}
+
+  defp parse_task_type(_task_type, :review, _version, task_name) do
+    {:error, {:task_type_on_review, task_name}}
+  end
+
+  defp parse_task_type(task_type, _kind, version, task_name) when version != "3" do
+    {:error, {:task_type_requires_version_3, task_name, version, task_type}}
+  end
+
+  defp parse_task_type(task_type, _kind, "3", task_name) do
+    if Sykli.TaskType.valid?(task_type) do
+      {:ok, task_type}
+    else
+      {:error, {:unknown_task_type, task_name, task_type}}
+    end
+  end
 
   defp parse_review(map, :review) do
     %Review{

--- a/core/lib/sykli/mcp/tools.ex
+++ b/core/lib/sykli/mcp/tools.ex
@@ -500,5 +500,11 @@ defmodule Sykli.MCP.Tools do
   defp format_error({:typescript_failed, msg}), do: "TypeScript SDK failed: #{msg}"
   defp format_error({:python_failed, msg}), do: "Python SDK failed: #{msg}"
   defp format_error({:missing_tool, tool, hint}), do: "Missing #{tool}: #{hint}"
+  defp format_error({:task_type_on_review, _} = reason), do: Sykli.Graph.format_error(reason)
+
+  defp format_error({:task_type_requires_version_3, _, _, _} = reason),
+    do: Sykli.Graph.format_error(reason)
+
+  defp format_error({:unknown_task_type, _, _} = reason), do: Sykli.Graph.format_error(reason)
   defp format_error(reason), do: inspect(reason)
 end

--- a/core/lib/sykli/task_type.ex
+++ b/core/lib/sykli/task_type.ex
@@ -1,0 +1,13 @@
+defmodule Sykli.TaskType do
+  @moduledoc """
+  Shared task_type vocabulary for the semantic pipeline contract.
+  """
+
+  @values ~w(build test lint format scan package publish deploy migrate generate verify cleanup)
+
+  @spec all() :: [String.t()]
+  def all, do: @values
+
+  @spec valid?(term()) :: boolean()
+  def valid?(value), do: value in @values
+end

--- a/core/lib/sykli/validate.ex
+++ b/core/lib/sykli/validate.ex
@@ -82,6 +82,7 @@ defmodule Sykli.Validate do
 
   defp validate_data(data) do
     tasks = data["tasks"] || []
+    version = Map.get(data, "version", "1")
 
     task_names =
       tasks
@@ -95,6 +96,7 @@ defmodule Sykli.Validate do
       |> check_self_deps(tasks)
       |> check_missing_deps(tasks, task_names)
       |> check_missing_commands(tasks)
+      |> check_task_types(tasks, version)
       |> check_cycles(tasks)
 
     warnings =
@@ -252,7 +254,54 @@ defmodule Sykli.Validate do
     end)
   end
 
+  defp check_task_types(errors, tasks, version) do
+    tasks
+    |> Enum.filter(fn t -> valid_name?(t["name"]) and Map.has_key?(t, "task_type") end)
+    |> Enum.reduce(errors, fn t, acc ->
+      name = t["name"]
+      task_type = t["task_type"]
+
+      cond do
+        t["kind"] == "review" ->
+          [
+            %{
+              type: :task_type_on_review,
+              task: name,
+              message: "Review node '#{name}' cannot declare task_type"
+            }
+            | acc
+          ]
+
+        version != "3" ->
+          [
+            %{
+              type: :task_type_requires_version_3,
+              task: name,
+              message: "Task '#{name}' declares task_type but pipeline version is not 3"
+            }
+            | acc
+          ]
+
+        not Sykli.TaskType.valid?(task_type) ->
+          [
+            %{
+              type: :unknown_task_type,
+              task: name,
+              message: "Task '#{name}' declares unknown task_type '#{task_type}'"
+            }
+            | acc
+          ]
+
+        true ->
+          acc
+      end
+    end)
+  end
+
   defp format_error(%{type: :missing_command, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :task_type_on_review, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :task_type_requires_version_3, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :unknown_task_type, message: msg}), do: "Error: #{msg}"
   defp format_error(%{type: :cycle, message: msg}), do: "Error: #{msg}"
   defp format_error(%{type: :missing_dependency, message: msg}), do: "Error: #{msg}"
   defp format_error(%{type: :duplicate_task, message: msg}), do: "Error: #{msg}"

--- a/core/test/core_test.exs
+++ b/core/test/core_test.exs
@@ -38,13 +38,13 @@ defmodule SykliTest do
 
   test "formats task_type parse errors" do
     assert Sykli.Graph.format_error({:task_type_on_review, "review-code"}) ==
-             "Review node 'review-code' cannot declare task_type"
+             "Error: Review node 'review-code' cannot declare task_type"
 
     assert Sykli.Graph.format_error({:task_type_requires_version_3, "test", "2", "test"}) ==
-             ~s(Task 'test' declares task_type but pipeline version is "2", not "3")
+             ~s(Error: Task 'test' declares task_type but pipeline version is "2", not "3")
 
     assert Sykli.Graph.format_error({:unknown_task_type, "thing", "custom"}) ==
-             ~s(Task 'thing' declares unknown task_type "custom")
+             ~s(Error: Task 'thing' declares unknown task_type "custom")
   end
 
   test "parses review nodes with metadata" do

--- a/core/test/core_test.exs
+++ b/core/test/core_test.exs
@@ -7,6 +7,46 @@ defmodule SykliTest do
     assert Map.has_key?(graph, "test")
   end
 
+  test "parses task_type on version 3 executable tasks" do
+    json =
+      ~s({"version":"3","tasks":[{"name":"test","command":"go test ./...","task_type":"test"}]})
+
+    assert {:ok, graph} = Sykli.Graph.parse(json)
+    task = Map.fetch!(graph, "test")
+    assert Sykli.Graph.Task.task_type(task) == "test"
+  end
+
+  test "rejects task_type before version 3" do
+    json =
+      ~s({"version":"2","tasks":[{"name":"test","command":"go test ./...","task_type":"test"}]})
+
+    assert {:error, {:task_type_requires_version_3, "test", "2", "test"}} =
+             Sykli.Graph.parse(json)
+  end
+
+  test "rejects unknown task_type" do
+    json = ~s({"version":"3","tasks":[{"name":"thing","command":"echo hi","task_type":"custom"}]})
+    assert {:error, {:unknown_task_type, "thing", "custom"}} = Sykli.Graph.parse(json)
+  end
+
+  test "rejects task_type on review nodes" do
+    json =
+      ~s({"version":"3","tasks":[{"name":"review-code","kind":"review","primitive":"lint","task_type":"lint"}]})
+
+    assert {:error, {:task_type_on_review, "review-code"}} = Sykli.Graph.parse(json)
+  end
+
+  test "formats task_type parse errors" do
+    assert Sykli.Graph.format_error({:task_type_on_review, "review-code"}) ==
+             "Review node 'review-code' cannot declare task_type"
+
+    assert Sykli.Graph.format_error({:task_type_requires_version_3, "test", "2", "test"}) ==
+             ~s(Task 'test' declares task_type but pipeline version is "2", not "3")
+
+    assert Sykli.Graph.format_error({:unknown_task_type, "thing", "custom"}) ==
+             ~s(Task 'thing' declares unknown task_type "custom")
+  end
+
   test "parses review nodes with metadata" do
     json =
       ~s({"tasks":[{"name":"test","command":"go test ./..."},{"name":"review:api-breakage","kind":"review","primitive":"api-breakage","agent":"local","inputs":["main...HEAD"],"context":["README.md","docs/architecture.md"],"outputs":["reviews/api-breakage.local.json"],"depends_on":["test"],"deterministic":false}]})

--- a/core/test/sykli/validate_test.exs
+++ b/core/test/sykli/validate_test.exs
@@ -229,6 +229,47 @@ defmodule Sykli.ValidateTest do
     end
   end
 
+  describe "validate_json/1 -- task_type" do
+    test "accepts task_type in version 3" do
+      json =
+        ~s({"version":"3","tasks":[{"name":"test","command":"go test ./...","task_type":"test"}]})
+
+      result = Validate.validate_json(json)
+
+      assert result.valid == true
+    end
+
+    test "rejects task_type before version 3" do
+      json =
+        ~s({"version":"2","tasks":[{"name":"test","command":"go test ./...","task_type":"test"}]})
+
+      result = Validate.validate_json(json)
+
+      assert result.valid == false
+      assert Enum.any?(result.errors, &(&1.type == :task_type_requires_version_3))
+    end
+
+    test "rejects unknown task_type" do
+      json =
+        ~s({"version":"3","tasks":[{"name":"thing","command":"echo hi","task_type":"custom"}]})
+
+      result = Validate.validate_json(json)
+
+      assert result.valid == false
+      assert Enum.any?(result.errors, &(&1.type == :unknown_task_type))
+    end
+
+    test "rejects task_type on review nodes" do
+      json =
+        ~s({"version":"3","tasks":[{"name":"review-code","kind":"review","primitive":"lint","task_type":"lint"}]})
+
+      result = Validate.validate_json(json)
+
+      assert result.valid == false
+      assert Enum.any?(result.errors, &(&1.type == :task_type_on_review))
+    end
+  end
+
   describe "format_errors/1" do
     test "formats errors for CLI output" do
       result = %Validate.Result{

--- a/docs/agent-contract-semantics.md
+++ b/docs/agent-contract-semantics.md
@@ -1,0 +1,577 @@
+# Agent-Native Contract Semantics
+
+## Status
+
+This is a design document for Phase 3. It defines future semantic contract
+fields for the Sykli pipeline contract.
+
+This document does not change the current wire format by itself. It is
+normative for future Phase 3 implementation PRs: examples are illustrative, but
+rules and definitions are binding.
+
+JSON remains the canonical wire format. The JSON Schema remains the canonical
+machine contract.
+
+## Thesis
+
+Phase 3 moves Sykli from "describes how to run a graph" to "describes what the
+graph means."
+
+Commands are implementation. They are still necessary for executable tasks, but
+they are a poor semantic interface for agents. A shell command can imply a test,
+a build, a deploy, a migration, or a publish operation, but agents should not
+need to reverse-engineer that meaning from command strings.
+
+The contract should describe intent, expectations, and boundaries. Typed
+semantic fields let agents and tools reason about execution without parsing
+shell command strings to understand what kind of work a node performs.
+
+## Existing concepts and separation of meaning
+
+Sykli currently has graph node kinds:
+
+- `kind` = graph node kind.
+- Current values are `task` and `review`.
+- `task` is executable.
+- `review` is non-executable.
+
+Future Phase 3 fields must preserve this separation:
+
+- `task_type` = semantic class of an executable task.
+- `task_type` applies only to `kind: "task"`.
+- `task_type` must not appear on review nodes.
+- `primitive` = semantic class of a review node.
+- `primitive` applies only to `kind: "review"`.
+
+Do not duplicate meaning across `kind`, `task_type`, and `primitive`.
+
+Examples:
+
+- A lint command that runs as a process is `kind: "task"` with
+  `task_type: "lint"`.
+- A lint review performed by an agent/reasoning primitive is `kind: "review"`
+  with `primitive: "lint"`.
+- A review node must not also declare `task_type: "lint"`.
+
+## Strictness model
+
+### 1. Schema validation is mandatory and authoritative
+
+The canonical JSON Schema defines allowed fields, types, enum values, and
+applicability constraints. SDKs and the engine should reject malformed pipeline
+documents.
+
+Examples:
+
+- Unknown `task_type` = schema error.
+- `task_type` on a review node = schema error.
+- Review node with `command` = schema error.
+
+### 2. Semantic linting is advisory
+
+Sykli may provide warnings for suspicious, incomplete, or weak declarations.
+These warnings are not parse errors.
+
+Examples:
+
+- `deploy` without a declared infrastructure effect = linter warning, not
+  schema error.
+- `migrate` without a declared database or persistent-state effect = linter
+  warning, not schema error.
+
+### 3. Runtime enforcement is out of scope
+
+Sykli validates declarations. Sykli may lint declarations. Sykli does not
+enforce declared runtime behavior.
+
+Sykli does not sandbox syscalls, network access, filesystem writes, external
+API calls, or database writes. Sykli does not verify at runtime that declared
+capabilities or effects match observed process behavior.
+
+Declarations are contract metadata for agents, auditors, reviewers, and
+downstream tools. They are descriptive, not punitive.
+
+This boundary is internal to Sykli:
+
+- Sykli describes and runs graphs of work.
+- A contract layer is not a policy engine.
+- Runtime enforcement would require sandbox/isolation behavior Sykli does not
+  own.
+- Enforced declarations tend to rot into defensive over-declaration.
+
+Descriptive declarations are less likely to degrade into defensive
+over-declaration because a missing declaration does not kill execution.
+
+Example:
+
+- A task declaring no `network` capability but using the network at runtime is
+  out of scope for Sykli enforcement.
+
+## Versioning rule
+
+The existing top-level `version` is the pipeline wire-format/schema version.
+Phase 3 must not introduce a second `contract_version`.
+
+Adding typed semantic fields is a schema evolution event. The first typed
+semantic field, `task_type`, requires `version: "3"`.
+
+The version meanings are:
+
+- `version: "1"` = baseline task graph format.
+- `version: "2"` = resource-aware format.
+- `version: "3"` = semantic contract format, beginning with `task_type`.
+
+The first `version: "3"` implementation must not add other Phase 3 fields just
+because the version becomes `"3"`.
+
+Do not make `version` decorative again.
+
+## Semantic layers
+
+### Layer 1 - Classification: `task_type`
+
+Purpose: classify the semantic purpose of an executable task.
+
+Rules:
+
+- Optional.
+- Applies only to `kind: "task"`.
+- Rejected on `kind: "review"`.
+- Does not change execution behavior.
+- Helps agents reason without parsing `command`.
+- Should be a closed enum.
+- Do not include `custom` in the first implementation.
+- No free-form marketing tags.
+
+The initial enum is exactly these 12 values. Each value has a normative
+definition:
+
+- `build`: Produces compiled or generated artifacts from source inputs.
+- `test`: Executes assertions whose pass/fail result verifies code, artifact,
+  or system behavior.
+- `lint`: Checks source, configuration, or metadata against style, convention,
+  or static correctness rules without intentionally rewriting it.
+- `format`: Rewrites source, configuration, or metadata into a canonical
+  format.
+- `scan`: Analyzes source, dependencies, artifacts, or images for findings such
+  as security, license, dependency, or quality issues.
+- `package`: Assembles existing build outputs into a distributable artifact.
+- `publish`: Uploads, registers, or exposes an artifact outside the local
+  execution environment.
+- `deploy`: Changes a runtime environment to use a new artifact,
+  configuration, or version.
+- `migrate`: Changes persisted state, data shape, or schema.
+- `generate`: Produces source, configuration, or artifacts from templates,
+  schemas, models, or other inputs.
+- `verify`: Checks that an existing invariant holds without primarily
+  producing artifacts or changing runtime state.
+- `cleanup`: Removes temporary/generated resources or restores local execution
+  state.
+
+Boundary notes:
+
+- `test` vs `verify`: use `test` when the task executes assertions for code,
+  artifact, or system behavior; use `verify` when checking an existing
+  invariant without primarily exercising a test suite.
+- `lint` vs `scan`: use `lint` for style, convention, or static correctness;
+  use `scan` for findings-oriented analysis such as security, license,
+  dependency, or quality reports.
+- `format` vs `lint`: use `format` when the task intentionally rewrites files;
+  use `lint` when it checks and reports without intentionally rewriting.
+- `build` vs `package`: use `build` when producing artifacts from source; use
+  `package` when assembling existing outputs into a distributable artifact.
+- `package` vs `publish`: use `package` for local artifact assembly; use
+  `publish` when uploading, registering, or exposing the artifact outside the
+  local execution environment.
+- `deploy` vs `migrate`: use `deploy` when changing a runtime environment to
+  use a new artifact, configuration, or version; use `migrate` when changing
+  persisted state, data shape, or schema.
+
+### Layer 2 - Verification: `success_criteria`
+
+Purpose: describe how success is known beyond process exit.
+
+Rules:
+
+- Optional.
+- Default success remains exit code 0.
+- Criteria array is conjunctive: all criteria must pass.
+- Do not introduce OR semantics initially.
+- `success_criteria` is descriptive at first.
+- Some criteria may become engine-checkable later.
+- Do not make outputs automatically imply success.
+
+Declared `outputs` are artifact expectations, not success criteria by
+themselves.
+
+Example:
+
+If `outputs: { "binary": "dist/app" }` is declared, that does not
+automatically mean `dist/app` is checked as a success condition. If the author
+wants that check, they must declare `success_criteria`.
+
+Initial criterion types:
+
+- `exit_code`
+- `file_exists`
+- `file_non_empty`
+
+Future possibilities, not part of the first implementation:
+
+- `json_path`
+- `regex_match`
+- `coverage_threshold`
+- `junit_report_valid`
+
+### Layer 3 - Boundaries: `capabilities` and `effects`
+
+Purpose: separate what a task expects to access from what it may change.
+
+Definitions:
+
+- `capabilities` = what the task expects to use or access.
+- `effects` = what the task may change in the world.
+
+These are descriptive declarations, not permissions. A missing capability does
+not cause Sykli to kill the task at runtime. A declared effect does not grant
+permission.
+
+Possible capability enum:
+
+- `network`
+- `secret_read`
+- `filesystem_write`
+- `container_runtime`
+- `package_registry_access`
+- `cloud_api_access`
+
+Possible effect enum:
+
+- `filesystem_write_outside_outputs`
+- `artifact_publish`
+- `external_api_call`
+- `database_write`
+- `infrastructure_change`
+- `persistent_state_change`
+- `irreversible_change`
+
+Why split them:
+
+- Sandbox/planning question: "Can this task run in this environment?" maps to
+  `capabilities`.
+- Risk/audit question: "What can this task change?" maps to `effects`.
+
+Linter examples:
+
+- `deploy` without `infrastructure_change` may warn.
+- `migrate` without `database_write` or `persistent_state_change` may warn.
+- Broad capabilities with no corresponding effects may warn.
+
+### Layer 4 - Data contracts: typed inputs and outputs
+
+Existing `inputs` and `outputs` keep their current meanings. Phase 3 must use
+additive evolution for richer semantics. Do not redefine `inputs` or `outputs`
+in place.
+
+Possible future fields:
+
+- `input_contract`
+- `output_contract`
+
+Additive fields may supersede current fields over time, but existing fields are
+not silently reinterpreted.
+
+Structured input/output design is intentionally later than `task_type` and
+`success_criteria`. It touches the artifact model and must be handled
+carefully.
+
+### Layer 5 - Planning expectations
+
+Possible future field:
+
+- `expected`
+
+Purpose: describe expected duration, resource usage, and planning hints.
+
+Examples:
+
+- `duration_seconds`
+- `memory_mb`
+- `cpu_millis`
+- `disk_mb`
+- `network`
+- `cost_hint`
+
+Planning expectations are useful for planning and anomaly detection, but they
+are not part of the first implementation.
+
+### Layer 6 - Determinism and reproducibility
+
+Review nodes already have `deterministic`. Executable tasks may later need
+deterministic/reproducibility semantics.
+
+Do not overload review-node `deterministic`. A possible future shape might live
+under an execution/semantic properties object. Do not implement this in the
+first Phase 3 slice.
+
+### Layer 7 - Failure semantics
+
+Existing `ai_hooks` remains an agent behavior hint layer. Typed semantic fields
+describe the task. `ai_hooks` describes how an agent should interact with or
+respond to the task.
+
+Do not move semantic meaning into `ai_hooks`.
+
+`ai_hooks.on_fail` is not a replacement for typed failure semantics. Failure
+semantics may be designed later, but not in the first Phase 3 slice.
+
+## SDK typing model
+
+Typed contract = JSON Schema + SDK-level validation + engine validation where
+needed.
+
+Each SDK should implement typing idiomatically:
+
+- Rust: enums / typed structs.
+- TypeScript: string union types.
+- Python: `Literal` / dataclass or runtime validation.
+- Go: typed constants + validation.
+- Elixir: `@type` specs + guards/validators.
+
+Wire format remains JSON strings and objects.
+
+Example:
+
+- Rust may expose `TaskType::Test`.
+- TypeScript may expose `"test"` as a union literal.
+- Elixir may accept `:test`.
+- All emit `"task_type": "test"`.
+
+## Phase 3B Decision: `task_type`
+
+Phase 3B implements the first agent-native semantic field: `task_type`.
+
+### Version decision
+
+`task_type` requires pipeline `version: "3"`.
+
+Rationale:
+
+- `version` is the pipeline wire-format/schema version.
+- Adding typed semantic fields is a schema evolution event.
+- If `task_type` is added under `version: "2"`, `version` becomes decorative
+  again.
+- `version: "3"` marks the first agent-native semantic schema expansion.
+
+Version meanings:
+
+- `version: "1"` = baseline task graph format.
+- `version: "2"` = resource-aware format.
+- `version: "3"` = semantic contract format, beginning with `task_type`.
+
+The first implementation must not add `success_criteria`, `capabilities`,
+`effects`, typed input/output contracts, or other Phase 3 fields just because
+the version becomes `"3"`.
+
+### Initial enum decision
+
+The initial `task_type` enum is exactly:
+
+- `build`
+- `test`
+- `lint`
+- `format`
+- `scan`
+- `package`
+- `publish`
+- `deploy`
+- `migrate`
+- `generate`
+- `verify`
+- `cleanup`
+
+No `custom` value is included in the first implementation.
+
+Normative definitions:
+
+- `build`: Produces compiled or generated artifacts from source inputs.
+- `test`: Executes assertions whose pass/fail result verifies code, artifact,
+  or system behavior.
+- `lint`: Checks source, configuration, or metadata against style, convention,
+  or static correctness rules without intentionally rewriting it.
+- `format`: Rewrites source, configuration, or metadata into a canonical
+  format.
+- `scan`: Analyzes source, dependencies, artifacts, or images for findings such
+  as security, license, dependency, or quality issues.
+- `package`: Assembles existing build outputs into a distributable artifact.
+- `publish`: Uploads, registers, or exposes an artifact outside the local
+  execution environment.
+- `deploy`: Changes a runtime environment to use a new artifact,
+  configuration, or version.
+- `migrate`: Changes persisted state, data shape, or schema.
+- `generate`: Produces source, configuration, or artifacts from templates,
+  schemas, models, or other inputs.
+- `verify`: Checks that an existing invariant holds without primarily
+  producing artifacts or changing runtime state.
+- `cleanup`: Removes temporary/generated resources or restores local execution
+  state.
+
+Boundary notes:
+
+- `test` vs `verify`: use `test` when the task executes assertions for code,
+  artifact, or system behavior; use `verify` when checking an existing
+  invariant without primarily exercising a test suite.
+- `lint` vs `scan`: use `lint` for style, convention, or static correctness;
+  use `scan` for findings-oriented analysis such as security, license,
+  dependency, or quality reports.
+- `format` vs `lint`: use `format` when the task intentionally rewrites files;
+  use `lint` when it checks and reports without intentionally rewriting.
+- `build` vs `package`: use `build` when producing artifacts from source; use
+  `package` when assembling existing outputs into a distributable artifact.
+- `package` vs `publish`: use `package` for local artifact assembly; use
+  `publish` when uploading, registering, or exposing the artifact outside the
+  local execution environment.
+- `deploy` vs `migrate`: use `deploy` when changing a runtime environment to
+  use a new artifact, configuration, or version; use `migrate` when changing
+  persisted state, data shape, or schema.
+
+### Applicability decision
+
+`task_type` applies only to executable tasks.
+
+Rules:
+
+- `task_type` must not appear on `kind: "review"` nodes.
+- Review nodes continue to use `primitive`.
+- `task_type` does not change execution behavior.
+- `task_type` is semantic metadata for agents, tooling, schema validation, and
+  future linting.
+
+Schema behavior for Phase 3B:
+
+- Accept `task_type` only when `version: "3"`.
+- Reject unknown `task_type` values.
+- Reject `task_type` on review nodes.
+
+### SDK API decision
+
+In the first implementation, SDKs expose explicit `task_type` APIs. SDKs do not
+infer `task_type` from arbitrary command strings.
+
+Rationale:
+
+- Inferring from command strings recreates the problem Phase 3 is trying to
+  solve.
+- Explicit declaration keeps the contract honest.
+- Preset inference can be safe only where the preset itself has a known
+  semantic purpose.
+
+Likely SDK shapes:
+
+- Go: `.TaskType(sykli.TaskTypeTest)` or equivalent typed constant.
+- Rust: `.task_type(TaskType::Test)`.
+- TypeScript: `.taskType("test")` with a string union type.
+- Python: `.task_type("test")` with runtime validation / `Literal` typing if
+  appropriate.
+- Elixir: `task_type :test` with guards/validators.
+
+### Preset decision
+
+Presets do not emit `task_type` automatically in the first implementation.
+
+The first implementation should add explicit API support only. Presets may be
+updated in a later PR after basic `task_type` conformance is stable.
+
+Rationale:
+
+- Presets are many and language-specific.
+- Updating presets immediately increases blast radius.
+- Explicit API first gives a clear contract.
+
+### Conformance decision
+
+Phase 3B adds positive and negative validation coverage.
+
+Positive conformance case:
+
+- `23-task-type.json`
+- `version: "3"`
+- One or more executable tasks with `task_type`.
+- At least two `task_type` values, for example `test` and `build`.
+- No review node.
+
+Negative coverage:
+
+- Review node with `task_type` must fail schema validation.
+- Unknown `task_type` must fail schema validation.
+- `version: "2"` with `task_type` must fail schema validation.
+
+Negative cases should be covered by schema validation fixtures and SDK unit
+tests. Conformance negative cases may be added if the harness has a clear way
+to represent expected schema-validation failures without mixing them with SDK
+emission parity.
+
+### Engine/parser validation decision
+
+Phase 3B enforces `task_type` version gating, enum validation, and review-node
+rejection through JSON Schema and through minimal engine/parser validation.
+
+## Phase 3 implementation sequence
+
+### Phase 3A - this document
+
+Design only. No schema, SDK, engine, or conformance changes.
+
+### Phase 3B - `task_type`
+
+First additive semantic field. It requires `version: "3"` and uses the exact
+12-value enum defined in this document.
+
+Must include:
+
+- Schema change.
+- SDK support across all five SDKs.
+- Conformance positive and negative cases.
+- Rejection on review nodes.
+- Enum validation.
+
+### Phase 3C - `success_criteria`
+
+Add typed verification semantics.
+
+Must include:
+
+- AND semantics.
+- No implicit output success.
+- First criterion types only.
+
+### Phase 3D - `capabilities` / `effects`
+
+Add descriptive boundary metadata. Must remain non-enforcing.
+
+### Phase 3E - typed input/output contracts
+
+Additive design only. Do not mutate existing `inputs`/`outputs` meanings.
+
+## Non-goals
+
+- Runtime enforcement.
+- Sandbox/policy engine behavior.
+- Compact agent projection format.
+- JSON replacement.
+- Reintroducing `target`.
+- Free-form semantic tags.
+- `custom` task type in the first implementation.
+- Model-specific review semantics.
+- Task-type-specific schema conditionals in the first implementation.
+- Rich artifact ontology in the first implementation.
+
+## Resolved Phase 3B parser decision
+
+Direct parser callers can supply JSON that has not passed through schema
+validation, so Phase 3B duplicates the three critical `task_type` checks in the
+engine/parser:
+
+- Reject `task_type` on review nodes.
+- Reject unknown `task_type` values.
+- Reject `task_type` unless the top-level version is `"3"`.

--- a/docs/sdk-schema.md
+++ b/docs/sdk-schema.md
@@ -7,9 +7,10 @@ This document describes the **current** Sykli pipeline JSON contract. It is grou
 - The engine parser (`core/lib/sykli/graph.ex`) and per-field modules (`core/lib/sykli/graph/task/*.ex`).
 - Engine validation (`core/lib/sykli/validate.ex`).
 - The five SDK emitters (`sdk/{go,rust,typescript,elixir,python}/`).
-- The 21 conformance fixtures (`tests/conformance/cases/*.json`).
+- The 23 conformance fixtures (`tests/conformance/cases/*.json`).
 
-It is **not** a future design document. The agent-native semantic fields proposed in `docs/sdk-audit.md` §10 (Phase 3) — `task_type`, structured `inputs`, structured `outputs`, `success_criteria`, `side_effects`, `expected` — are intentionally out of scope.
+The agent-native semantic model is defined in `docs/agent-contract-semantics.md`.
+This document describes only the current wire contract.
 
 The companion machine-readable schema is `schemas/sykli-pipeline.schema.json` (JSON Schema draft 2020-12).
 Conformance case fixtures are validated against it by `scripts/validate-conformance-schema.py`, which runs at the start of `tests/conformance/run.sh`.
@@ -30,7 +31,7 @@ The engine is currently **more permissive** than the schema in three known ways:
 
 ```jsonc
 {
-  "version": "1" | "2",
+  "version": "1" | "2" | "3",
   "tasks":   [ ... task objects ... ],
   "resources": { ... }   // optional
 }
@@ -38,13 +39,14 @@ The engine is currently **more permissive** than the schema in three known ways:
 
 ### `version`
 
-- **Type:** string enum `"1"` | `"2"`.
-- **Required by canonical schema; ignored by current engine.**
+- **Type:** string enum `"1"` | `"2"` | `"3"`.
+- **Required by canonical schema.**
 - **Meaning:** pipeline wire-format/schema version. It is not an execution capability selector and not an SDK, engine, runtime, or JSON Schema draft version.
 - `"1"` is the baseline task graph format.
 - `"2"` is the resource-aware format: resources, mounts, caches, containers, and related execution-environment metadata.
-- SDKs auto-detect: `"2"` if any task has `container` set, or any task has non-empty `mounts`, or the pipeline has any directory or cache resources; `"1"` otherwise.
-- **Current behavior:** advisory / permissive. The engine parser does not branch on this value (no `Map.get(map, "version", _)` anywhere in `graph.ex`).
+- `"3"` is the semantic contract format, beginning with `task_type`.
+- SDKs auto-detect: `"3"` if any executable task has `task_type`; otherwise `"2"` if any task has `container` set, or any task has non-empty `mounts`, or the pipeline has any directory or cache resources; `"1"` otherwise.
+- **Current behavior:** version-aware for `task_type`. The schema and engine validation reject `task_type` unless `version == "3"`. Other version-aware parser behavior is still intentionally narrow.
 - **Intended future behavior:** the engine should accept known supported versions and reject unknown future versions unless an explicit compatibility mode exists. It should never silently reinterpret a newer document as an older version.
 
 ### `tasks`
@@ -71,6 +73,7 @@ The full canonical field list, with stability labels:
 | `name` | stable | yes | unique, non-empty |
 | `kind` | experimental | no | `"task"` (default) or `"review"` |
 | `command` | stable | conditional | required unless `gate` is set or `kind == "review"` |
+| `task_type` | stable, v3-only | no | executable-task semantic class |
 | `container` | stable | no | triggers v2 |
 | `workdir` | stable | no | |
 | `env` | stable | no | object of string values |
@@ -113,6 +116,36 @@ Unique within the pipeline, non-empty. The engine rejects empty/whitespace/non-b
 ### `command`
 
 Shell command to execute. Required for regular tasks. Gates and review tasks have no command. The engine raises `missing_command` (`validate.ex:230-253`) for any non-gate, non-review task without a command. The schema does not encode this conditional rule — it would require nested `if/then/else` constructs that obscure the more common case. Treat the rule as documented engine behavior.
+
+### `task_type`
+
+Agent-native semantic class of an executable task. This field helps agents and
+tooling understand what a task does without parsing `command`.
+
+Rules:
+
+- Requires top-level `version: "3"`.
+- Applies only to executable tasks (`kind` omitted or `kind == "task"`).
+- Rejected on `kind == "review"` nodes.
+- Optional.
+- Does not change execution behavior.
+- Does not replace review-node `primitive`.
+- Must be one of the closed enum values below. There is no `custom` value.
+
+Allowed values:
+
+- `build`
+- `test`
+- `lint`
+- `format`
+- `scan`
+- `package`
+- `publish`
+- `deploy`
+- `migrate`
+- `generate`
+- `verify`
+- `cleanup`
 
 ### `container`, `workdir`, `env`
 
@@ -248,7 +281,7 @@ Review nodes do not have canonical `outputs` behavior yet. SDKs should not emit
 `outputs` for review nodes; review results/structured outputs are intentionally
 left out of the current experimental contract. The schema rejects task execution
 fields on review nodes: `command`, `outputs`, `gate`, `container`, `services`,
-`k8s`, `mounts`, `retry`, and `timeout`.
+`k8s`, `mounts`, `retry`, `timeout`, and `task_type`.
 
 ## Normalization behavior
 
@@ -285,15 +318,14 @@ tooling, and the engine parser.
 
 It is **not** an execution capability version. It does not mean "run with v1
 features" or "run with v2 features" at execution time, and the current engine
-does not use it to choose parser or executor behavior. It is also not the
+uses it only for narrow `task_type` validation. It is also not the
 version of a particular SDK package, engine release, runtime, or JSON Schema
 draft.
 
-Current behavior is advisory and permissive: SDKs emit `version`, the canonical
-schema requires `"1"` or `"2"`, and the engine ignores the value. This means
-`version` is useful today as SDK/schema contract metadata, but it is not yet an
-engine-enforced compatibility boundary. See the [`version` field](#version)
-above for the per-value definitions of `"1"` and `"2"`.
+Current behavior is partially version-aware: SDKs emit `version`, the canonical
+schema requires `"1"`, `"2"`, or `"3"`, and the engine rejects `task_type` unless
+the top-level version is `"3"`. See the [`version` field](#version) above for
+the per-value definitions.
 
 Future engine behavior should become version-aware in a later implementation
 phase:
@@ -357,7 +389,7 @@ introduce a replacement field.
 
 These are **descriptive, not prescriptive**. The schema documents current behavior; resolving these is Phase 2C / future work.
 
-1. **`version` is advisory only today.** SDKs emit `"1"` or `"2"`; engine ignores. This document defines it as the pipeline wire-format/schema version and describes the migration path to version-aware parsing.
+1. **Version-aware behavior is still narrow.** SDKs emit `"1"`, `"2"`, or `"3"`; engine validation now checks `task_type` compatibility with `version: "3"`, but broader unknown-version rejection is still future work.
 2. **Review nodes are experimental.** Engine supports `kind: "review"` and the four review-only fields, and SDKs expose minimal review builders. Review outputs are not canonical.
 3. **`verify` and `oidc` are reserved with no SDK emit.** Engine reads them; SDKs have no API. Either implement SDK support or drop from the schema once a decision lands.
 4. **`history_hint` is engine-internal.** SDKs MUST NOT emit. Schema marks `readOnly` for clarity.
@@ -369,7 +401,6 @@ These are **descriptive, not prescriptive**. The schema documents current behavi
 
 The following Phase 3 fields are **not** included in this schema:
 
-- `task_type` (closed enum classifying compute / validation / reasoning tasks)
 - Structured `inputs` (typed: `files | env | secret | artifact`)
 - Structured `outputs` (typed: `file | report | artifact` with format)
 - `success_criteria` (first-class assertions beyond exit code)

--- a/schemas/sykli-pipeline.schema.json
+++ b/schemas/sykli-pipeline.schema.json
@@ -6,10 +6,28 @@
   "type": "object",
   "required": ["version", "tasks"],
   "additionalProperties": false,
+  "allOf": [
+    {
+      "description": "`task_type` is the first agent-native semantic field and requires pipeline version 3.",
+      "if": {
+        "properties": { "version": { "not": { "const": "3" } } },
+        "required": ["version"]
+      },
+      "then": {
+        "properties": {
+          "tasks": {
+            "items": {
+              "not": { "required": ["task_type"] }
+            }
+          }
+        }
+      }
+    }
+  ],
   "properties": {
     "version": {
-      "description": "Pipeline schema version. Currently advisory — the engine does not branch on this value. SDKs auto-detect: '2' if any container, mount, dir, or cache resource is used; '1' otherwise.",
-      "enum": ["1", "2"]
+      "description": "Pipeline wire-format/schema version. SDKs auto-detect: '3' if any executable task uses task_type; otherwise '2' if any container, mount, dir, or cache resource is used; '1' otherwise.",
+      "enum": ["1", "2", "3"]
     },
     "tasks": {
       "description": "List of task objects. May be empty.",
@@ -91,7 +109,8 @@
                 { "required": ["k8s"] },
                 { "required": ["mounts"] },
                 { "required": ["retry"] },
-                { "required": ["timeout"] }
+                { "required": ["timeout"] },
+                { "required": ["task_type"] }
               ]
             }
           }
@@ -110,6 +129,23 @@
         "command": {
           "description": "Shell command to execute. Required for regular (non-gate, non-review) tasks; the engine raises `missing_command` otherwise (validate.ex:230-253). Gates and review tasks have no command.",
           "type": "string"
+        },
+        "task_type": {
+          "description": "Agent-native semantic class of an executable task. Requires top-level version == \"3\". Rejected on review nodes.",
+          "enum": [
+            "build",
+            "test",
+            "lint",
+            "format",
+            "scan",
+            "package",
+            "publish",
+            "deploy",
+            "migrate",
+            "generate",
+            "verify",
+            "cleanup"
+          ]
         },
         "container": {
           "description": "Container image (e.g., `golang:1.21`). Triggers v2 emission.",
@@ -371,7 +407,7 @@
           "readOnly": true
         },
         "primitive": {
-          "description": "Review-only. Identifier of the review primitive (e.g., `lint`, `security-scan`). Meaningful only when `kind == \"review\"`. Currently emitted only by the Go SDK; experimental.",
+          "description": "Review-only. Identifier of the review primitive (e.g., `lint`, `security-scan`). Meaningful only when `kind == \"review\"`. Experimental.",
           "type": "string"
         },
         "agent": {

--- a/sdk/elixir/lib/sykli/dsl.ex
+++ b/sdk/elixir/lib/sykli/dsl.ex
@@ -122,29 +122,15 @@ defmodule Sykli.DSL do
   end
 
   @doc "Sets the semantic class of this executable task."
-  def task_type(type)
-      when type in [
-             :build,
-             :test,
-             :lint,
-             :format,
-             :scan,
-             :package,
-             :publish,
-             :deploy,
-             :migrate,
-             :generate,
-             :verify,
-             :cleanup
-           ] do
-    update_current_task(fn t ->
-      reject_review_option!(t, "task_type")
-      %{t | task_type: type}
-    end)
-  end
-
   def task_type(type) do
-    raise ArgumentError, "invalid task_type #{inspect(type)}"
+    if Sykli.Task.valid_task_type?(type) do
+      update_current_task(fn t ->
+        reject_review_option!(t, "task_type")
+        %{t | task_type: type}
+      end)
+    else
+      raise ArgumentError, "invalid task_type #{inspect(type)}"
+    end
   end
 
   @doc "Sets task dependencies."

--- a/sdk/elixir/lib/sykli/dsl.ex
+++ b/sdk/elixir/lib/sykli/dsl.ex
@@ -121,6 +121,32 @@ defmodule Sykli.DSL do
     end)
   end
 
+  @doc "Sets the semantic class of this executable task."
+  def task_type(type)
+      when type in [
+             :build,
+             :test,
+             :lint,
+             :format,
+             :scan,
+             :package,
+             :publish,
+             :deploy,
+             :migrate,
+             :generate,
+             :verify,
+             :cleanup
+           ] do
+    update_current_task(fn t ->
+      reject_review_option!(t, "task_type")
+      %{t | task_type: type}
+    end)
+  end
+
+  def task_type(type) do
+    raise ArgumentError, "invalid task_type #{inspect(type)}"
+  end
+
   @doc "Sets task dependencies."
   def after_(deps) when is_list(deps) do
     update_current_task(fn t -> %{t | depends_on: t.depends_on ++ deps} end)

--- a/sdk/elixir/lib/sykli/emitter.ex
+++ b/sdk/elixir/lib/sykli/emitter.ex
@@ -5,21 +5,6 @@ defmodule Sykli.Emitter do
 
   require Logger
 
-  @task_types [
-    :build,
-    :test,
-    :lint,
-    :format,
-    :scan,
-    :package,
-    :publish,
-    :deploy,
-    :migrate,
-    :generate,
-    :verify,
-    :cleanup
-  ]
-
   # ============================================================================
   # VALIDATION
   # ============================================================================
@@ -41,7 +26,8 @@ defmodule Sykli.Emitter do
           Logger.error("review cannot declare task_type", review: task.name)
           raise "review #{inspect(task.name)} cannot declare task_type"
 
-        task.kind != :review and not is_nil(task.task_type) and task.task_type not in @task_types ->
+        task.kind != :review and not is_nil(task.task_type) and
+            not Sykli.Task.valid_task_type?(task.task_type) ->
           Logger.error("invalid task_type", task: task.name, task_type: inspect(task.task_type))
           raise "task #{inspect(task.name)} has invalid task_type #{inspect(task.task_type)}"
 

--- a/sdk/elixir/lib/sykli/emitter.ex
+++ b/sdk/elixir/lib/sykli/emitter.ex
@@ -5,6 +5,21 @@ defmodule Sykli.Emitter do
 
   require Logger
 
+  @task_types [
+    :build,
+    :test,
+    :lint,
+    :format,
+    :scan,
+    :package,
+    :publish,
+    :deploy,
+    :migrate,
+    :generate,
+    :verify,
+    :cleanup
+  ]
+
   # ============================================================================
   # VALIDATION
   # ============================================================================
@@ -22,6 +37,14 @@ defmodule Sykli.Emitter do
     # Check all non-gate, non-review tasks have commands
     Enum.each(pipeline.tasks, fn task ->
       cond do
+        task.kind == :review and not is_nil(task.task_type) ->
+          Logger.error("review cannot declare task_type", review: task.name)
+          raise "review #{inspect(task.name)} cannot declare task_type"
+
+        task.kind != :review and not is_nil(task.task_type) and task.task_type not in @task_types ->
+          Logger.error("invalid task_type", task: task.name, task_type: inspect(task.task_type))
+          raise "task #{inspect(task.name)} has invalid task_type #{inspect(task.task_type)}"
+
         task.kind == :review and (is_nil(task.primitive) or task.primitive == "") ->
           Logger.error("review has no primitive", review: task.name)
           raise "review #{inspect(task.name)} has no primitive"
@@ -165,7 +188,14 @@ defmodule Sykli.Emitter do
           t.container != nil or length(t.mounts) > 0
         end)
 
-    version = if has_v2_features, do: "2", else: "1"
+    has_v3_features = Enum.any?(pipeline.tasks, &(!is_nil(&1.task_type)))
+
+    version =
+      cond do
+        has_v3_features -> "3"
+        has_v2_features -> "2"
+        true -> "1"
+      end
 
     Logger.debug("emitting pipeline", version: version, tasks: length(pipeline.tasks))
 
@@ -214,6 +244,7 @@ defmodule Sykli.Emitter do
       end
 
     %{name: task.name}
+    |> maybe_put(:task_type, if(task.task_type, do: Atom.to_string(task.task_type), else: nil))
     |> maybe_put(:command, task.command)
     |> maybe_put(:container, task.container)
     |> maybe_put(:workdir, task.workdir)

--- a/sdk/elixir/lib/sykli/task.ex
+++ b/sdk/elixir/lib/sykli/task.ex
@@ -3,6 +3,21 @@ defmodule Sykli.Task do
   Represents a single task in a pipeline.
   """
 
+  @task_types [
+    :build,
+    :test,
+    :lint,
+    :format,
+    :scan,
+    :package,
+    :publish,
+    :deploy,
+    :migrate,
+    :generate,
+    :verify,
+    :cleanup
+  ]
+
   defstruct name: nil,
             kind: :task,
             task_type: nil,
@@ -124,4 +139,10 @@ defmodule Sykli.Task do
   def new(name) when is_binary(name) do
     %__MODULE__{name: name}
   end
+
+  @doc "Returns the allowed task_type values."
+  def task_types, do: @task_types
+
+  @doc "Returns true when the value is an allowed task_type."
+  def valid_task_type?(type), do: type in @task_types
 end

--- a/sdk/elixir/lib/sykli/task.ex
+++ b/sdk/elixir/lib/sykli/task.ex
@@ -5,6 +5,7 @@ defmodule Sykli.Task do
 
   defstruct name: nil,
             kind: :task,
+            task_type: nil,
             command: nil,
             primitive: nil,
             agent: nil,
@@ -60,6 +61,19 @@ defmodule Sykli.Task do
   @type criticality :: :high | :medium | :low
   @type on_fail_action :: :analyze | :retry | :skip
   @type select_mode :: :smart | :always | :manual
+  @type task_type ::
+          :build
+          | :test
+          | :lint
+          | :format
+          | :scan
+          | :package
+          | :publish
+          | :deploy
+          | :migrate
+          | :generate
+          | :verify
+          | :cleanup
 
   @type semantic :: %{
           covers: [String.t()],
@@ -75,6 +89,7 @@ defmodule Sykli.Task do
   @type t :: %__MODULE__{
           name: String.t(),
           kind: :task | :review,
+          task_type: task_type() | nil,
           command: String.t() | nil,
           primitive: String.t() | nil,
           agent: String.t() | nil,

--- a/sdk/elixir/test/sykli_test.exs
+++ b/sdk/elixir/test/sykli_test.exs
@@ -147,6 +147,47 @@ defmodule SykliTest do
       refute Map.has_key?(review, "command")
       refute Map.has_key?(review, "outputs")
     end
+
+    test "task_type emits version 3" do
+      use Sykli
+
+      result =
+        pipeline do
+          task "build" do
+            run("go build ./...")
+            task_type(:build)
+          end
+
+          task "test" do
+            run("go test ./...")
+            task_type(:test)
+            after_(["build"])
+          end
+        end
+
+      json = Sykli.Emitter.to_json(result)
+      decoded = Jason.decode!(json)
+
+      assert decoded["version"] == "3"
+      assert Enum.at(decoded["tasks"], 0)["task_type"] == "build"
+      assert Enum.at(decoded["tasks"], 1)["task_type"] == "test"
+    end
+
+    test "task_type with v2 features still emits version 3" do
+      use Sykli
+
+      result =
+        pipeline do
+          task "test" do
+            run("go test ./...")
+            task_type(:test)
+            container("golang:1.22")
+          end
+        end
+
+      decoded = result |> Sykli.Emitter.to_json() |> Jason.decode!()
+      assert decoded["version"] == "3"
+    end
   end
 
   describe "validation" do
@@ -188,6 +229,32 @@ defmodule SykliTest do
         end
 
       assert Sykli.Emitter.validate!(pipeline) == pipeline
+    end
+
+    test "rejects invalid task_type" do
+      use Sykli
+
+      assert_raise ArgumentError, ~r/invalid task_type/, fn ->
+        pipeline do
+          task "test" do
+            task_type(:custom)
+            run("go test ./...")
+          end
+        end
+      end
+    end
+
+    test "rejects task_type inside review" do
+      use Sykli
+
+      assert_raise RuntimeError, ~r/task_type cannot be used inside a review block/, fn ->
+        pipeline do
+          review "review-code" do
+            primitive("lint")
+            task_type(:lint)
+          end
+        end
+      end
     end
 
     test "review requires primitive" do

--- a/sdk/go/sykli.go
+++ b/sdk/go/sykli.go
@@ -93,19 +93,24 @@ const (
 	TaskTypeCleanup  TaskType = "cleanup"
 )
 
-var validTaskTypes = map[TaskType]bool{
-	TaskTypeBuild:    true,
-	TaskTypeTest:     true,
-	TaskTypeLint:     true,
-	TaskTypeFormat:   true,
-	TaskTypeScan:     true,
-	TaskTypePackage:  true,
-	TaskTypePublish:  true,
-	TaskTypeDeploy:   true,
-	TaskTypeMigrate:  true,
-	TaskTypeGenerate: true,
-	TaskTypeVerify:   true,
-	TaskTypeCleanup:  true,
+func validTaskType(taskType TaskType) bool {
+	switch taskType {
+	case TaskTypeBuild,
+		TaskTypeTest,
+		TaskTypeLint,
+		TaskTypeFormat,
+		TaskTypeScan,
+		TaskTypePackage,
+		TaskTypePublish,
+		TaskTypeDeploy,
+		TaskTypeMigrate,
+		TaskTypeGenerate,
+		TaskTypeVerify,
+		TaskTypeCleanup:
+		return true
+	default:
+		return false
+	}
 }
 
 // PipelineOption configures a Pipeline.
@@ -783,7 +788,7 @@ func (t *Task) Run(cmd string) *Task {
 
 // TaskType sets the semantic class of this executable task.
 func (t *Task) TaskType(taskType TaskType) *Task {
-	if !validTaskTypes[taskType] {
+	if !validTaskType(taskType) {
 		log.Panic().Str("task", t.name).Str("task_type", string(taskType)).Msg("invalid task_type")
 	}
 	t.taskType = taskType
@@ -1966,6 +1971,9 @@ func (p *Pipeline) EmitTo(w io.Writer) error {
 		}
 		if t.container != "" || len(t.mounts) > 0 {
 			hasV2Features = true
+		}
+		if hasV2Features && hasV3Features {
+			break
 		}
 	}
 	if hasV3Features {

--- a/sdk/go/sykli.go
+++ b/sdk/go/sykli.go
@@ -75,6 +75,39 @@ type Pipeline struct {
 	k8sDefaults *K8sOptions // Pipeline-level K8s defaults
 }
 
+// TaskType is the semantic class of an executable task.
+type TaskType string
+
+const (
+	TaskTypeBuild    TaskType = "build"
+	TaskTypeTest     TaskType = "test"
+	TaskTypeLint     TaskType = "lint"
+	TaskTypeFormat   TaskType = "format"
+	TaskTypeScan     TaskType = "scan"
+	TaskTypePackage  TaskType = "package"
+	TaskTypePublish  TaskType = "publish"
+	TaskTypeDeploy   TaskType = "deploy"
+	TaskTypeMigrate  TaskType = "migrate"
+	TaskTypeGenerate TaskType = "generate"
+	TaskTypeVerify   TaskType = "verify"
+	TaskTypeCleanup  TaskType = "cleanup"
+)
+
+var validTaskTypes = map[TaskType]bool{
+	TaskTypeBuild:    true,
+	TaskTypeTest:     true,
+	TaskTypeLint:     true,
+	TaskTypeFormat:   true,
+	TaskTypeScan:     true,
+	TaskTypePackage:  true,
+	TaskTypePublish:  true,
+	TaskTypeDeploy:   true,
+	TaskTypeMigrate:  true,
+	TaskTypeGenerate: true,
+	TaskTypeVerify:   true,
+	TaskTypeCleanup:  true,
+}
+
 // PipelineOption configures a Pipeline.
 type PipelineOption func(*Pipeline)
 
@@ -523,6 +556,7 @@ type gateConfig struct {
 type Task struct {
 	pipeline   *Pipeline
 	name       string
+	taskType   TaskType
 	command    string
 	container  string
 	workdir    string
@@ -744,6 +778,15 @@ func (t *Task) Run(cmd string) *Task {
 		log.Panic().Str("task", t.name).Msg("command cannot be empty")
 	}
 	t.command = cmd
+	return t
+}
+
+// TaskType sets the semantic class of this executable task.
+func (t *Task) TaskType(taskType TaskType) *Task {
+	if !validTaskTypes[taskType] {
+		log.Panic().Str("task", t.name).Str("task_type", string(taskType)).Msg("invalid task_type")
+	}
+	t.taskType = taskType
 	return t
 }
 
@@ -1916,13 +1959,18 @@ func (p *Pipeline) EmitTo(w io.Writer) error {
 	// Detect version based on usage
 	version := "1"
 	hasV2Features := len(p.dirs) > 0 || len(p.caches) > 0
+	hasV3Features := false
 	for _, t := range p.tasks {
+		if t.taskType != "" {
+			hasV3Features = true
+		}
 		if t.container != "" || len(t.mounts) > 0 {
 			hasV2Features = true
-			break
 		}
 	}
-	if hasV2Features {
+	if hasV3Features {
+		version = "3"
+	} else if hasV2Features {
 		version = "2"
 	}
 
@@ -1988,6 +2036,7 @@ func (p *Pipeline) EmitTo(w io.Writer) error {
 	type jsonTask struct {
 		Name          string              `json:"name"`
 		Kind          string              `json:"kind,omitempty"`
+		TaskType      string              `json:"task_type,omitempty"`
 		Command       string              `json:"command,omitempty"`
 		Container     string              `json:"container,omitempty"`
 		Workdir       string              `json:"workdir,omitempty"`
@@ -2139,6 +2188,7 @@ func (p *Pipeline) EmitTo(w io.Writer) error {
 
 		jt := jsonTask{
 			Name:       t.name,
+			TaskType:   string(t.taskType),
 			Command:    t.command,
 			Container:  t.container,
 			Workdir:    t.workdir,

--- a/sdk/go/sykli_test.go
+++ b/sdk/go/sykli_test.go
@@ -78,6 +78,57 @@ func TestBasicTask(t *testing.T) {
 	}
 }
 
+func TestTaskTypeSerialization(t *testing.T) {
+	p := New()
+	p.Task("build").Run("go build ./...").TaskType(TaskTypeBuild)
+	p.Task("test").Run("go test ./...").TaskType(TaskTypeTest).After("build")
+
+	result, err := emitJSON(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result["version"] != "3" {
+		t.Fatalf("expected version '3', got %v", result["version"])
+	}
+
+	tasks := result["tasks"].([]interface{})
+	build := tasks[0].(map[string]interface{})
+	test := tasks[1].(map[string]interface{})
+
+	if build["task_type"] != "build" {
+		t.Errorf("expected build task_type, got %v", build["task_type"])
+	}
+	if test["task_type"] != "test" {
+		t.Errorf("expected test task_type, got %v", test["task_type"])
+	}
+}
+
+func TestTaskTypeWithV2FeaturesEmitsVersion3(t *testing.T) {
+	p := New()
+	p.Task("test").Run("go test ./...").TaskType(TaskTypeTest).Container("golang:1.22")
+
+	result, err := emitJSON(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result["version"] != "3" {
+		t.Fatalf("expected version '3', got %v", result["version"])
+	}
+}
+
+func TestInvalidTaskTypePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for invalid task_type")
+		}
+	}()
+
+	p := New()
+	p.Task("test").Run("go test ./...").TaskType(TaskType("custom"))
+}
+
 func TestTaskWithInputs(t *testing.T) {
 	p := New()
 	p.Task("test").Run("go test").Inputs("**/*.go", "go.mod")

--- a/sdk/python/src/sykli/__init__.py
+++ b/sdk/python/src/sykli/__init__.py
@@ -47,6 +47,7 @@ from typing import (
     IO,
     Any,
     Callable,
+    get_args,
     Literal,
     NoReturn,
     Self,
@@ -126,20 +127,7 @@ TaskType = Literal[
     "cleanup",
 ]
 
-TASK_TYPES: tuple[str, ...] = (
-    "build",
-    "test",
-    "lint",
-    "format",
-    "scan",
-    "package",
-    "publish",
-    "deploy",
-    "migrate",
-    "generate",
-    "verify",
-    "cleanup",
-)
+TASK_TYPES: tuple[str, ...] = get_args(TaskType)
 
 
 @dataclass(frozen=True)
@@ -420,7 +408,7 @@ class Task:
         self._pipeline = pipeline
         self._name = name
         self._is_gate = is_gate
-        self._task_type: str = ""
+        self._task_type: TaskType | None = None
         self._command: str = ""
         self._container: str = ""
         self._workdir: str = ""
@@ -748,7 +736,7 @@ class Task:
 
         if self._command:
             d["command"] = self._command
-        if self._task_type:
+        if self._task_type is not None:
             d["task_type"] = self._task_type
         if self._container:
             d["container"] = self._container
@@ -1269,7 +1257,7 @@ class Pipeline:
         return False
 
     def _has_v3_features(self) -> bool:
-        return any(isinstance(t, Task) and bool(t._task_type) for t in self._tasks)
+        return any(isinstance(t, Task) and t._task_type is not None for t in self._tasks)
 
     def _build_output(self) -> dict[str, Any]:
         has_v2_features = self._has_v2_features()

--- a/sdk/python/src/sykli/__init__.py
+++ b/sdk/python/src/sykli/__init__.py
@@ -47,6 +47,7 @@ from typing import (
     IO,
     Any,
     Callable,
+    Literal,
     NoReturn,
     Self,
     Sequence,
@@ -77,6 +78,7 @@ __all__ = [
     "from_vault",
     # Types
     "K8sOptions",
+    "TaskType",
     "ValidationError",
     "ExplainContext",
     # Presets
@@ -107,6 +109,37 @@ class SelectMode(str, enum.Enum):
     SMART = "smart"
     ALWAYS = "always"
     MANUAL = "manual"
+
+
+TaskType = Literal[
+    "build",
+    "test",
+    "lint",
+    "format",
+    "scan",
+    "package",
+    "publish",
+    "deploy",
+    "migrate",
+    "generate",
+    "verify",
+    "cleanup",
+]
+
+TASK_TYPES: tuple[str, ...] = (
+    "build",
+    "test",
+    "lint",
+    "format",
+    "scan",
+    "package",
+    "publish",
+    "deploy",
+    "migrate",
+    "generate",
+    "verify",
+    "cleanup",
+)
 
 
 @dataclass(frozen=True)
@@ -387,6 +420,7 @@ class Task:
         self._pipeline = pipeline
         self._name = name
         self._is_gate = is_gate
+        self._task_type: str = ""
         self._command: str = ""
         self._container: str = ""
         self._workdir: str = ""
@@ -437,6 +471,12 @@ class Task:
         if not cmd:
             raise ValueError(f"task {self._name!r}: command cannot be empty")
         self._command = cmd
+        return self
+
+    def task_type(self, task_type: TaskType) -> Self:
+        """Set the semantic class of this executable task."""
+        _validate_enum(task_type, TASK_TYPES, "task_type", self._name)
+        self._task_type = task_type
         return self
 
     def after(self, *tasks: str) -> Self:
@@ -708,6 +748,8 @@ class Task:
 
         if self._command:
             d["command"] = self._command
+        if self._task_type:
+            d["task_type"] = self._task_type
         if self._container:
             d["container"] = self._container
         if self._workdir:
@@ -1226,12 +1268,16 @@ class Pipeline:
                 return True
         return False
 
+    def _has_v3_features(self) -> bool:
+        return any(isinstance(t, Task) and bool(t._task_type) for t in self._tasks)
+
     def _build_output(self) -> dict[str, Any]:
-        version = "2" if self._has_v2_features() else "1"
+        has_v2_features = self._has_v2_features()
+        version = "3" if self._has_v3_features() else "2" if has_v2_features else "1"
         output: dict[str, Any] = {"version": version}
 
         # Resources (v2)
-        if version == "2":
+        if has_v2_features:
             resources: dict[str, Any] = {}
             for d in self._dirs:
                 resources[d.id] = d._to_resource()

--- a/sdk/python/tests/test_serialization.py
+++ b/sdk/python/tests/test_serialization.py
@@ -16,6 +16,22 @@ class TestJsonWireFormat:
         task = d["tasks"][0]
         assert task == {"name": "test", "command": "pytest"}
 
+    def test_task_type_serialization(self):
+        p = Pipeline()
+        p.task("build").run("go build ./...").task_type("build")
+        p.task("test").run("go test ./...").task_type("test").after("build")
+
+        d = p.to_dict()
+        assert d["version"] == "3"
+        assert d["tasks"][0]["task_type"] == "build"
+        assert d["tasks"][1]["task_type"] == "test"
+
+    def test_task_type_with_v2_features_emits_version_3(self):
+        p = Pipeline()
+        p.task("test").run("go test ./...").task_type("test").container("golang:1.22")
+
+        assert p.to_dict()["version"] == "3"
+
     def test_review_node(self):
         p = Pipeline()
         p.task("test").run("go test ./...")
@@ -112,7 +128,7 @@ class TestOmitempty:
             "task_inputs", "outputs", "depends_on", "when",
             "secrets", "secret_refs", "matrix", "services",
             "retry", "timeout", "target", "k8s", "requires",
-            "provides", "needs", "semantic", "ai_hooks", "gate",
+            "provides", "needs", "semantic", "ai_hooks", "gate", "task_type",
         ]
         for field in omitted:
             assert field not in task, f"field {field!r} should be omitted"

--- a/sdk/python/tests/test_validation.py
+++ b/sdk/python/tests/test_validation.py
@@ -71,6 +71,15 @@ class TestFailFastValidation:
         with pytest.raises(ValueError):
             p.task("test").select_mode("random")
 
+    def test_invalid_task_type(self):
+        p = Pipeline()
+        with pytest.raises(ValueError, match="invalid task_type"):
+            p.task("test").task_type("custom")
+
+    def test_review_nodes_do_not_expose_task_type(self):
+        p = Pipeline()
+        assert not hasattr(p.review("review-code"), "task_type")
+
     def test_invalid_gate_strategy(self):
         p = Pipeline()
         with pytest.raises(ValueError):

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -463,6 +463,42 @@ pub struct Review<'a> {
     index: usize,
 }
 
+/// Semantic class of an executable task.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TaskType {
+    Build,
+    Test,
+    Lint,
+    Format,
+    Scan,
+    Package,
+    Publish,
+    Deploy,
+    Migrate,
+    Generate,
+    Verify,
+    Cleanup,
+}
+
+impl TaskType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            TaskType::Build => "build",
+            TaskType::Test => "test",
+            TaskType::Lint => "lint",
+            TaskType::Format => "format",
+            TaskType::Scan => "scan",
+            TaskType::Package => "package",
+            TaskType::Publish => "publish",
+            TaskType::Deploy => "deploy",
+            TaskType::Migrate => "migrate",
+            TaskType::Generate => "generate",
+            TaskType::Verify => "verify",
+            TaskType::Cleanup => "cleanup",
+        }
+    }
+}
+
 #[derive(Clone, Default, PartialEq)]
 enum NodeKind {
     #[default]
@@ -738,6 +774,7 @@ impl std::fmt::Display for Condition {
 struct TaskData {
     kind: NodeKind,
     name: String,
+    task_type: Option<TaskType>,
     command: String,
     primitive: Option<String>,
     agent: Option<String>,
@@ -833,6 +870,13 @@ impl<'a> Task<'a> {
     pub fn run(self, cmd: &str) -> Self {
         assert!(!cmd.is_empty(), "command cannot be empty");
         self.pipeline.tasks[self.index].command = cmd.to_string();
+        self
+    }
+
+    /// Sets the semantic class of this executable task.
+    #[must_use]
+    pub fn task_type(self, task_type: TaskType) -> Self {
+        self.pipeline.tasks[self.index].task_type = Some(task_type);
         self
     }
 
@@ -2233,7 +2277,15 @@ impl Pipeline {
                 .iter()
                 .any(|t| t.container.is_some() || !t.mounts.is_empty());
 
-        let version = if has_v2_features { "2" } else { "1" };
+        let has_v3_features = self.tasks.iter().any(|t| t.task_type.is_some());
+
+        let version = if has_v3_features {
+            "3"
+        } else if has_v2_features {
+            "2"
+        } else {
+            "1"
+        };
 
         // Build output
         let output = JsonPipeline {
@@ -2284,6 +2336,11 @@ impl Pipeline {
                         Some("review".to_string())
                     } else {
                         None
+                    },
+                    task_type: if t.kind == NodeKind::Review {
+                        None
+                    } else {
+                        t.task_type.as_ref().map(|tt| tt.as_str().to_string())
                     },
                     command: if t.kind == NodeKind::Review || t.command.is_empty() {
                         None
@@ -2715,6 +2772,8 @@ struct JsonTask {
     #[serde(skip_serializing_if = "Option::is_none")]
     kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    task_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     primitive: Option<String>,
@@ -2838,6 +2897,44 @@ mod tests {
         assert_eq!(json["version"], "1");
         assert_eq!(json["tasks"][0]["name"], "test");
         assert_eq!(json["tasks"][0]["command"], "cargo test");
+    }
+
+    #[test]
+    fn test_task_type_serialization() {
+        let mut p = Pipeline::new();
+        let _ = p
+            .task("build")
+            .run("go build ./...")
+            .task_type(TaskType::Build);
+        let _ = p
+            .task("test")
+            .run("go test ./...")
+            .task_type(TaskType::Test)
+            .after(&["build"]);
+
+        let mut buf = Vec::new();
+        p.emit_to(&mut buf).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+
+        assert_eq!(json["version"], "3");
+        assert_eq!(json["tasks"][0]["task_type"], "build");
+        assert_eq!(json["tasks"][1]["task_type"], "test");
+    }
+
+    #[test]
+    fn test_task_type_with_v2_features_emits_version_3() {
+        let mut p = Pipeline::new();
+        let _ = p
+            .task("test")
+            .run("go test ./...")
+            .task_type(TaskType::Test)
+            .container("golang:1.22");
+
+        let mut buf = Vec::new();
+        p.emit_to(&mut buf).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+
+        assert_eq!(json["version"], "3");
     }
 
     #[test]

--- a/sdk/typescript/src/index.test.ts
+++ b/sdk/typescript/src/index.test.ts
@@ -53,6 +53,39 @@ describe('Pipeline', () => {
       expect(json.version).toBe('2');
     });
 
+    it('serializes task_type and emits version 3', () => {
+      const p = new Pipeline();
+      p.task('build').run('go build ./...').taskType('build');
+      p.task('test').run('go test ./...').taskType('test').after('build');
+
+      const json = p.toJSON();
+      const tasks = json.tasks as any[];
+
+      expect(json.version).toBe('3');
+      expect(tasks[0].task_type).toBe('build');
+      expect(tasks[1].task_type).toBe('test');
+    });
+
+    it('keeps version 3 when task_type is combined with v2 features', () => {
+      const p = new Pipeline();
+      p.task('test').run('go test ./...').taskType('test').container('golang:1.22');
+
+      const json = p.toJSON();
+      expect(json.version).toBe('3');
+    });
+
+    it('rejects invalid task_type values at runtime', () => {
+      const p = new Pipeline();
+      expect(() => p.task('thing').run('echo hi').taskType('custom' as any)).toThrow(
+        "invalid task_type 'custom'"
+      );
+    });
+
+    it('does not expose taskType on review nodes', () => {
+      const p = new Pipeline();
+      expect((p.review('review-code') as any).taskType).toBeUndefined();
+    });
+
     it('creates an experimental review node', () => {
       const p = new Pipeline();
       p.task('test').run('go test ./...');

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -90,21 +90,7 @@ export type OnFailAction = 'analyze' | 'retry' | 'skip';
 export type SelectMode = 'smart' | 'always' | 'manual';
 
 /** Semantic class of an executable task */
-export type TaskType =
-  | 'build'
-  | 'test'
-  | 'lint'
-  | 'format'
-  | 'scan'
-  | 'package'
-  | 'publish'
-  | 'deploy'
-  | 'migrate'
-  | 'generate'
-  | 'verify'
-  | 'cleanup';
-
-const TASK_TYPES: readonly TaskType[] = [
+const TASK_TYPES = [
   'build',
   'test',
   'lint',
@@ -117,7 +103,9 @@ const TASK_TYPES: readonly TaskType[] = [
   'generate',
   'verify',
   'cleanup',
-];
+] as const;
+
+export type TaskType = (typeof TASK_TYPES)[number];
 
 function isTaskType(value: string): value is TaskType {
   return (TASK_TYPES as readonly string[]).includes(value);

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -89,6 +89,40 @@ export type OnFailAction = 'analyze' | 'retry' | 'skip';
 /** Task selection mode for AI */
 export type SelectMode = 'smart' | 'always' | 'manual';
 
+/** Semantic class of an executable task */
+export type TaskType =
+  | 'build'
+  | 'test'
+  | 'lint'
+  | 'format'
+  | 'scan'
+  | 'package'
+  | 'publish'
+  | 'deploy'
+  | 'migrate'
+  | 'generate'
+  | 'verify'
+  | 'cleanup';
+
+const TASK_TYPES: readonly TaskType[] = [
+  'build',
+  'test',
+  'lint',
+  'format',
+  'scan',
+  'package',
+  'publish',
+  'deploy',
+  'migrate',
+  'generate',
+  'verify',
+  'cleanup',
+];
+
+function isTaskType(value: string): value is TaskType {
+  return (TASK_TYPES as readonly string[]).includes(value);
+}
+
 /** Semantic metadata for AI understanding */
 interface Semantic {
   covers: string[];
@@ -369,6 +403,7 @@ export class Template {
 /** A single task in the pipeline */
 export class Task {
   private _command?: string;
+  private _taskType?: TaskType;
   private _container?: string;
   private _workdir?: string;
   private _env: Record<string, string> = {};
@@ -408,6 +443,15 @@ export class Task {
   /** Set the command to run */
   run(command: string): this {
     this._command = command;
+    return this;
+  }
+
+  /** Set the semantic class of this executable task */
+  taskType(taskType: TaskType): this {
+    if (!isTaskType(taskType)) {
+      throw new Error(`task '${this.name}': invalid task_type '${taskType}'`);
+    }
+    this._taskType = taskType;
     return this;
   }
 
@@ -784,6 +828,11 @@ export class Task {
     return undefined;
   }
 
+  /** @internal Whether this task declares task_type */
+  _hasTaskType(): boolean {
+    return this._taskType !== undefined;
+  }
+
   // ─────────────────────────────────────────────────────────────────────────────
   // Internal accessors (for Template and Pipeline use)
   // ─────────────────────────────────────────────────────────────────────────────
@@ -849,6 +898,7 @@ export class Task {
       name: this.name,
     };
     if (this._command) json.command = this._command;
+    if (this._taskType) json.task_type = this._taskType;
 
     if (this._container) json.container = this._container;
     if (this._workdir) json.workdir = this._workdir;
@@ -1079,6 +1129,11 @@ export class Review {
   /** @internal Get primitive */
   _getPrimitive(): string | undefined {
     return this._primitive;
+  }
+
+  /** @internal Whether this review declares task_type */
+  _hasTaskType(): boolean {
+    return false;
   }
 
   /** Convert to JSON representation (internal) */
@@ -1520,9 +1575,10 @@ export class Pipeline {
       this.directories.length > 0 ||
       this.caches.length > 0 ||
       this.tasks.some((t) => t._getContainer() || t._getMounts().length > 0);
+    const hasV3Features = this.tasks.some((t) => t._hasTaskType());
 
     const json: Record<string, unknown> = {
-      version: hasV2Features ? '2' : '1',
+      version: hasV3Features ? '3' : hasV2Features ? '2' : '1',
       tasks: this.tasks.map((t) => t._toJSON()),
     };
 

--- a/tests/conformance/cases/23-task-type.json
+++ b/tests/conformance/cases/23-task-type.json
@@ -1,0 +1,16 @@
+{
+  "version": "3",
+  "tasks": [
+    {
+      "name": "build",
+      "command": "go build ./...",
+      "task_type": "build"
+    },
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "task_type": "test",
+      "depends_on": ["build"]
+    }
+  ]
+}

--- a/tests/conformance/fixtures/elixir/23-task-type.exs
+++ b/tests/conformance/fixtures/elixir/23-task-type.exs
@@ -1,0 +1,17 @@
+use Sykli
+
+pipeline do
+  task "build" do
+    run "go build ./..."
+    task_type :build
+  end
+
+  task "test" do
+    run "go test ./..."
+    task_type :test
+    after_ ["build"]
+  end
+end
+|> Sykli.Emitter.validate!()
+|> Sykli.Emitter.to_json()
+|> IO.puts()

--- a/tests/conformance/fixtures/go/23-task-type.go
+++ b/tests/conformance/fixtures/go/23-task-type.go
@@ -1,0 +1,12 @@
+package main
+
+import sykli "github.com/yairfalse/sykli/sdk/go"
+
+func main() {
+	p := sykli.New()
+
+	p.Task("build").Run("go build ./...").TaskType(sykli.TaskTypeBuild)
+	p.Task("test").Run("go test ./...").TaskType(sykli.TaskTypeTest).After("build")
+
+	p.Emit()
+}

--- a/tests/conformance/fixtures/python/23-task-type.py
+++ b/tests/conformance/fixtures/python/23-task-type.py
@@ -1,0 +1,8 @@
+from sykli import Pipeline
+
+p = Pipeline()
+
+p.task("build").run("go build ./...").task_type("build")
+p.task("test").run("go test ./...").task_type("test").after("build")
+
+p.emit()

--- a/tests/conformance/fixtures/rust/23-task-type.rs
+++ b/tests/conformance/fixtures/rust/23-task-type.rs
@@ -1,0 +1,15 @@
+use sykli::{Pipeline, TaskType};
+
+fn main() {
+    let mut p = Pipeline::new();
+
+    p.task("build")
+        .run("go build ./...")
+        .task_type(TaskType::Build);
+    p.task("test")
+        .run("go test ./...")
+        .task_type(TaskType::Test)
+        .after(&["build"]);
+
+    p.emit();
+}

--- a/tests/conformance/fixtures/typescript/23-task-type.ts
+++ b/tests/conformance/fixtures/typescript/23-task-type.ts
@@ -1,0 +1,8 @@
+import { Pipeline } from '../../../../sdk/typescript/src/index';
+
+const p = new Pipeline();
+
+p.task('build').run('go build ./...').taskType('build');
+p.task('test').run('go test ./...').taskType('test').after('build');
+
+p.emit();


### PR DESCRIPTION
## Summary
Adds `task_type` as the first version 3 semantic contract field.

- `task_type` is executable-task-only semantic metadata
- version `3` is required when `task_type` appears
- enum is the 12 Phase 3B values
- rejected on review nodes
- no `custom`
- no preset inference
- all five SDKs support explicit APIs
- conformance adds `23-task-type` across all SDKs
- core uses a shared `Sykli.TaskType` enum source
- parse-time task_type errors have user-facing formatting

## Validation
- `python3 -c "import json; json.load(open('schemas/sykli-pipeline.schema.json'))"`
- `python3 scripts/validate-conformance-schema.py` -> 23 passed, 0 failed
- schema negative task_type checks -> passed
- `tests/conformance/run.sh` -> 140 passed, 0 failed, 0 skipped
- `mix test` in `core` -> 1476 tests, 0 failures
- `cd sdk/go && GOCACHE=/private/tmp/sykli-go-build go test ./...`
- `cd sdk/rust && cargo test --lib` -> 108 passed
- `cd sdk/typescript && npx vitest run` -> 79 passed
- `cd sdk/typescript && npx tsc --noEmit`
- `cd sdk/python && PYTHONPATH=src python3.14 -m pytest` -> 202 passed
- `cd sdk/elixir && mix test` -> 47 passed

Note: the conformance harness embedded schema-validation step still skips under `python3.14` because that interpreter lacks `jsonschema`; standalone schema validation with local `python3` passed.