### PR TITLE
docs: refresh README and CLAUDE.md for canonical schema and v3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Recent changes
 
+- **Pipeline contract is canonical.** `schemas/sykli-pipeline.schema.json` (JSON Schema 2020-12) is the source of truth for SDK-emitted JSON. `scripts/validate-conformance-schema.py` runs at the top of `tests/conformance/run.sh` and validates every fixture against it. Engine remains permissive; SDKs must emit only the canonical shape.
+- **Phase 3B `task_type` (version `"3"`).** Closed 12-value enum (`build`, `test`, `lint`, `format`, `scan`, `package`, `publish`, `deploy`, `migrate`, `generate`, `verify`, `cleanup`) classifying executable tasks. Engine vocabulary lives in `Sykli.TaskType`. Triple-layered enforcement: schema `if/then`, `Sykli.Graph.parse_task_type/4`, `Sykli.Validate.check_task_types/3`. Rejected on review nodes. Design rationale: `docs/agent-contract-semantics.md`.
+- **`target` field removed from canonical SDK output.** All five SDK builder methods are deprecated no-ops (Python raises `DeprecationWarning`). The engine never read `target`; this was contract cleanup.
+- **Review nodes (`kind: "review"`) experimental** across all five SDKs. Schema rejects task-execution fields on reviews (`command`, `outputs`, `services`, `mounts`, `k8s`, `retry`, `timeout`, `task_type`).
 - **GitHub-native foundation** shipped — GitHub App auth, webhook receiver (Plug + Bandit), Checks API client, `Sykli.Mesh.Roles`. See `docs/github-native.md`.
 - **CLI visual reset** shipped — Nordic-minimal renderer (`Sykli.CLI.Renderer/Theme/Live/FixRenderer`). The output rules are testable; banned vocabulary in §"CLI output rules" below.
-- **Cache fingerprint** scheme includes repo-relative workdir; occurrences from before this change are not backward-compatible.
 
 ## What is Sykli?
 
@@ -38,6 +41,7 @@ tests/conformance/run.sh                    # all SDKs, all cases
 tests/conformance/run.sh --sdk go           # single SDK
 tests/conformance/run.sh case-name          # single case
 ```
+The runner first runs `scripts/validate-conformance-schema.py` against `schemas/sykli-pipeline.schema.json`. The schema step gracefully skips when Python <3.12 or the `jsonschema` package is unavailable. Pin the interpreter with `SYKLI_CONFORMANCE_PYTHON=python3.X` — the runner hard-errors if that explicit value fails the >=3.12 check (rather than silently substituting another interpreter). Auto-detection probes a venv, then `python3.14`/`3.13`/`3.12`/`python3`.
 
 Black-box tests (run against the built binary — cases listed in `test/blackbox/dataset.json`):
 ```bash
@@ -70,6 +74,8 @@ eval/harness/run.sh --case 001 --dry-run    # preview without running
 - `GETTING_STARTED.md` — installation and first-pipeline walkthrough.
 - `RELEASE.md` — release process (Burrito builds, signing, tagging).
 - `CHANGELOG.md` — Keep-a-Changelog format; current line is 0.6.x.
+- `docs/sdk-schema.md` — current canonical wire contract, field-by-field.
+- `docs/agent-contract-semantics.md` — Phase 3 design doc (normative for future Phase 3 PRs).
 - `examples/` and `test_projects/` — runnable sample pipelines for manual testing.
 
 Before every commit: `mix format && mix test && mix escript.build`
@@ -189,11 +195,15 @@ See `docs/false-protocol-schema.md` for the on-disk schema, sample documents, st
 
 ## SDKs
 
-Five SDKs in `sdk/` — Go, Rust, TypeScript, Elixir, Python. All support the full API including semantic metadata, containers, mounts, services, K8s options, caches, secrets, gates, matrix, capabilities.
+Five SDKs in `sdk/` — Go, Rust, TypeScript, Elixir, Python. All support the full API: semantic metadata, containers, mounts, services, K8s options, caches, secrets, gates, matrix, capabilities, **review nodes** (`kind: "review"`), and the v3 **`task_type`** semantic field.
+
+**Wire-format version auto-detect** (consistent across all five SDKs): `"3"` if any executable task uses `task_type`; else `"2"` if any container/mount/dir/cache resource is used; else `"1"`. v3 is a *superset* of v2 — when both are present, the pipeline emits version `"3"` *and* a populated `resources` block.
+
+**SDK ↔ engine boundary.** Each SDK is a separate project (`sdk/<lang>/`) with its own dependency tree. SDKs cannot import engine modules — the engine's `Sykli.TaskType` is unreachable from the Elixir SDK at `sdk/elixir/`. Each SDK carries its own copy of shared vocabulary (the 12 task_type values, etc.). When the canonical contract gains a value, update *every* SDK's local copy plus the schema plus `Sykli.TaskType`.
 
 SDK detection order: `.go` → `.rs` → `.exs` → `.ts` → `.py`
 
-SDKs are run with `--emit`, must output valid JSON to stdout. When changing task schema fields, update all five SDKs and their conformance test cases.
+SDKs are run with `--emit`, must output valid JSON to stdout. When changing task schema fields, update: (1) `schemas/sykli-pipeline.schema.json`, (2) all five SDK emitters, (3) `Sykli.Graph` parse path + `Sykli.Validate` check path, (4) at least one `tests/conformance/cases/*.json` fixture with per-SDK fixtures.
 
 The project dogfoods itself via `sykli.exs` (root-level pipeline) and `.github/workflows/sykli-ci.yml`.
 
@@ -216,6 +226,7 @@ Key env vars (see `cli.ex` and module docs for full details):
 - `SYKLI_GITHUB_WEBHOOK_SECRET` — HMAC secret for webhook signature verification
 - `SYKLI_GITHUB_RECEIVER_PORT` — Port the receiver binds (only on the node holding `:webhook_receiver`)
 - `GITHUB_TOKEN` / `GITLAB_TOKEN` / `BITBUCKET_TOKEN` — SCM commit status integration (legacy direct-token path superseded by the GitHub App receiver but kept as a documented fallback)
+- `SYKLI_CONFORMANCE_PYTHON` — pin the Python interpreter `tests/conformance/run.sh` uses for the schema-validation step and Python SDK fixtures. Must be Python ≥3.12 with the `jsonschema` package installed for schema validation to actually run (otherwise the schema step skips with an install hint).
 
 ## Testing Patterns
 
@@ -255,6 +266,9 @@ Some cases carry `expected_failure: true`, which marks them as known-broken cont
 - **~s() with parens gotcha** — `~s()` uses `()` as delimiters, so `~s(matches(x, "y"))` breaks. Use `~s[]` or `~S||` instead
 - **No wall-clock or global RNG in simulator-facing code** — the custom `CredoSykli.Check.NoWallClock` check (`core/lib/credo_sykli/check/no_wall_clock.ex`) fails on `System.monotonic_time/os_time/system_time`, `DateTime.utc_now`, `NaiveDateTime.utc_now`, `:os.system_time`, `:erlang.now`, and bare `:rand.uniform`. Route time through transport APIs (e.g. `now_ms/0`) and randomness through explicit seeded state
 - **Runtime isolation** — no module outside `core/lib/sykli/runtime/` may name a specific runtime implementation (`Sykli.Runtime.Docker`, `Podman`, `Shell`, `Fake`, `Containerd`). Selection flows through `Sykli.Runtime.Resolver`. Enforced by `core/test/sykli/runtime_isolation_test.exs` — the test greps the source tree and fails on any offender
+- **Schema is the canonical contract for SDK emission.** `schemas/sykli-pipeline.schema.json` is strict (`additionalProperties: false`) and gates new fields by `version`. The engine in `graph.ex` is more permissive (legacy compatibility paths: unknown keys ignored, `condition` aliasing `when`, list-form `outputs`). SDK output must validate against the schema; engine acceptance is *not* the SDK's bar. Document permissive paths in `docs/sdk-schema.md` under "Contract boundary".
+- **Engine vocabulary modules** — values shared across `graph.ex` and `validate.ex` (e.g., `task_type`'s 12-value enum) live in dedicated modules like `Sykli.TaskType` (`Sykli.TaskType.all/0`, `Sykli.TaskType.valid?/1`). When adding a new closed-enum field, follow this pattern instead of duplicating the literal across modules. SDKs must carry their own copies (separate Mix projects).
+- **Engine error formatting** — parse-time errors render via `Sykli.Graph.format_error/1` (also delegated to from `Sykli.MCP.Tools`); validate-time errors render via `Sykli.Validate.format_errors/1`. Validate-path strings prefix `"Error: "`; parse-path strings don't. Keep new error tuples consistent with the path that produces them.
 
 ## CLI output rules
 

--- a/README.md
+++ b/README.md
@@ -68,32 +68,51 @@ A pipeline is a program. It deserves a programming language.
 
 ## How it works
 
-```
-sdk file (Go/Rust/TS/Elixir/Python)
-   │
-   │  --emit
-   ▼
-JSON task graph (stdout)
-   │
-   ▼
-sykli engine: validate DAG → schedule levels → execute → observe
-   │
-   ▼
-.sykli/ — structured occurrences, attestations, run history
+```mermaid
+flowchart LR
+    SDK["SDK file<br/><sub>Go · Rust · TS · Elixir · Python</sub>"]
+    JSON["Pipeline JSON<br/><sub>version 1 · 2 · 3</sub>"]
+    Schema[("sykli-pipeline.<br/>schema.json")]
+    Engine["sykli engine<br/><sub>parse · DAG validate · schedule · execute</sub>"]
+    CLI["Human CLI<br/><sub>● ○ ✕ ─ ⠋</sub>"]
+    Sykli[".sykli/<br/><sub>FALSE Protocol occurrences<br/>SLSA attestations · run history</sub>"]
+    Agents["Agents · MCP server · CI tooling"]
+
+    SDK -- "--emit" --> JSON
+    JSON -. "canonical contract" .-> Schema
+    JSON --> Engine
+    Engine --> CLI
+    Engine --> Sykli
+    Sykli --> Agents
+
+    classDef contract fill:#0d1b2a,stroke:#4ec5d4,color:#e6e6e6,stroke-width:2px;
+    class Schema contract;
 ```
 
 1. **Define.** Write your graph in a real language. Use variables, functions, types.
-2. **Emit.** sykli runs your SDK file with `--emit` and reads the resulting JSON.
+2. **Emit.** sykli runs your SDK file with `--emit` and reads the resulting JSON. The shape is governed by [`schemas/sykli-pipeline.schema.json`](schemas/sykli-pipeline.schema.json) — the canonical, versioned wire contract.
 3. **Execute.** The engine validates the DAG (cycle detection, schema, capability resolution), schedules tasks level-by-level in parallel, applies caching and retries.
 4. **Observe.** Every event becomes a [FALSE Protocol](https://github.com/false-systems) occurrence written to `.sykli/`. AI agents and downstream tools read structured data, not log scrolls.
 
 The engine runs on the BEAM VM. Same code on your laptop, in Docker, on Kubernetes, or across a mesh of nodes.
 
+**Wire-format versions are explicit**, not advisory: `"1"` baseline graphs, `"2"` adds resources/containers/mounts, `"3"` adds agent-native semantic fields starting with `task_type`. SDKs auto-detect from features used. See [`docs/sdk-schema.md`](docs/sdk-schema.md) for the field-by-field contract.
+
+## Distributed-by-default. Deterministic by design.
+
+Two properties that pipelines normally trade against each other — running across a fleet, and replaying byte-identically — both fall out of how the engine is built.
+
+- **Mesh execution without a control plane.** Cluster one sykli node onto another and either can pick up the other's tasks. No broker, no separate orchestration tier. The engine *is* the coordinator. `--mesh` and `sykli daemon start` are the user surface; capability-based placement (`requires("gpu")`) routes work to nodes that can run it.
+- **Deterministic replay.** Time, randomness, and I/O are routed through transport APIs; given a seed, runs replay byte-identically. A custom lint (`NoWallClock`) fails on raw `System.monotonic_time` or `:rand.uniform` so determinism doesn't drift.
+- **Supervision = retry semantics.** Each task runs under its own supervisor. A crashed task doesn't take the run with it; the engine sees structured exit and decides to retry, skip, or fail-and-analyze based on the task's `on_fail` declaration.
+
+The engine is built on the BEAM VM. That's what makes a single-process distributed runtime and seedable simulation possible without a second clustering layer. The substrate is incidental; the outcomes aren't.
+
 ## Agentic review as code
 
 SYKLI Reviews are experimental. A review node represents a structured review step in the execution graph; it does not yet run Codex, Claude, or any other provider directly. It models the review step so future runners can execute agents in a controlled, inspectable way.
 
-The builder API is currently available in the Go SDK only. Rust, TypeScript, Elixir, and Python SDK builders still need parity work; until then, review nodes are an experimental Go-first graph feature.
+Builders are available in **all five SDKs** (Go, Rust, TypeScript, Elixir, Python) with byte-equivalent JSON output. The schema rejects task-execution fields (`command`, `outputs`, `services`, `mounts`, `k8s`, `retry`, `timeout`, `task_type`) on review nodes — review primitives and shell tasks have separate, non-overlapping surfaces.
 
 Agentic workflows need primitives, not prompts. Asking an LLM to "review this PR" is too underspecified to be repeatable. Defining a review node with constrained inputs, expected outputs, and explicit rules is.
 
@@ -123,12 +142,12 @@ Planned primitives: `security-boundaries`, `api-breakage`, `behavior-regression`
 
 | Use case | What sykli gives you |
 |---|---|
-| **CI pipelines** | The whole CI graph as code, content-addressed cache, parallel-by-dependency-level execution, deterministic replay |
+| **Agentic workflows** | Agents are executors; the graph defines what runs, what it depends on, and what it outputs |
 | **PR reviews** | Reviews as graph nodes — agents and linters fulfill the same node contract |
 | **Release checks** | SLSA v1.0 provenance attestations per task, signed by the engine, verifiable downstream |
 | **Security validation** | Secret-scoped tasks, OIDC token exchange to cloud providers, SSRF-guarded webhooks |
 | **Infrastructure validation** | Same task graph against `local`, `k8s`, or a self-hosted mesh of nodes |
-| **Agentic workflows** | Agents are executors; the graph defines what runs, what it depends on, and what it outputs |
+| **CI pipelines** | The whole CI graph as code, content-addressed cache, parallel-by-dependency-level execution, deterministic replay |
 
 ## Design principles
 
@@ -273,9 +292,9 @@ This is the layer agents and downstream tools read. No log parsing, no regex, no
 
 | Component | Status |
 |-----------|--------|
-| Core engine, Go / Rust / TS / Elixir SDKs, local execution, containers, FALSE Protocol output | **Stable** |
-| Python SDK, mesh distribution, K8s target, gates, SLSA attestations, remote cache (S3) | **Beta** |
-| GitHub-native receiver (App + webhook + Checks API), review primitives, multi-agent execution | **In development** |
+| Core engine, all 5 SDKs (Go/Rust/TS/Elixir/Python), local execution, containers, FALSE Protocol output, canonical schema, GitHub-native receiver (App + webhook + Checks API) | **Stable** |
+| Mesh distribution, K8s target, gates, SLSA attestations, remote cache (S3), review-node graph support across all SDKs, `task_type` (v3 semantic contract) | **Beta** |
+| Review primitive implementations (security/api-breakage/coverage agents), multi-agent execution, structured review outputs | **In development** |
 
 ---
 
@@ -311,6 +330,6 @@ See [CLAUDE.md](CLAUDE.md) for architecture notes, conventions, and the design r
 
 **sykli** (Finnish: *cycle*) — built in Berlin, powered by BEAM.
 
-**[Install](#install)** · **[ADRs](docs/adr/)** · **[Issues](https://github.com/yairfalse/sykli/issues)**
+**[Install](#install)** · **[Schema](schemas/sykli-pipeline.schema.json)** · **[Contract](docs/sdk-schema.md)** · **[Issues](https://github.com/yairfalse/sykli/issues)**
 
 </div>


### PR DESCRIPTION
README:
- Replace ASCII flow diagram with Mermaid flowchart that shows the schema as canonical contract layer between SDK and engine, and the dual human-CLI / agent-readable output surfaces.
- Add "Distributed-by-default. Deterministic by design." section with three outcome-led bullets (mesh without control plane, deterministic replay with NoWallClock enforcement, supervision-as-retry).
- Reorder use-cases table: Agentic workflows first, CI pipelines last.
- Drop stale "Go SDK only" caveat on review nodes — PR #170 shipped parity across all five SDKs.
- Promote GitHub-native receiver, all-5-SDK SDKs, and canonical schema to Stable in the project-status table.
- Replace broken docs/adr/ link in footer with Schema and Contract links to schemas/sykli-pipeline.schema.json and docs/sdk-schema.md.

CLAUDE.md:
- Update Recent changes for canonical schema, Phase 3B task_type (version "3"), target removal, and review-node experimental support.
- Add SYKLI_CONFORMANCE_PYTHON env var and the schema-validator pre-flight to the conformance test commands.
- Document the SDK-engine Mix project boundary: SDKs cannot import engine modules, each carries its own copy of shared vocabulary.
- Add Patterns & Conventions bullets for: schema as canonical SDK contract, engine vocabulary modules pattern (Sykli.TaskType), and the parse-path vs. validate-path format_error split.
- Index pointers to docs/sdk-schema.md and docs/agent-contract-semantics.md.