### PR TITLE
Enforce contract schema version semantics in core engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,7 +277,7 @@ Some cases carry `expected_failure: true`, which marks them as known-broken cont
   - `Sykli.ContractSchemaVersion` — supported `version` values + missing/empty/wrong-type/unsupported error policy.
 
   When adding a new closed-enum field or shared-policy concept, follow this pattern. SDKs must carry their own copies (separate Mix projects — engine modules are unreachable from `sdk/<lang>/`).
-- **Engine error formatting** — parse-time errors render via `Sykli.Graph.format_error/1` (also delegated to from `Sykli.MCP.Tools`); validate-time errors render via `Sykli.Validate.format_errors/1`. Validate-path strings prefix `"Error: "`; parse-path strings don't. Keep new error tuples consistent with the path that produces them.
+- **Engine error formatting** — parse-time errors render via `Sykli.Graph.format_error/1` (also delegated to from `Sykli.MCP.Tools`); validate-time errors render via `Sykli.Validate.format_errors/1`. Both paths prefix rendered strings with `"Error: "`. Keep new error tuples consistent with the path that produces them.
 
 ## CLI output rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Recent changes
 
-- **Pipeline contract is canonical.** `schemas/sykli-pipeline.schema.json` (JSON Schema 2020-12) is the source of truth for SDK-emitted JSON. `scripts/validate-conformance-schema.py` runs at the top of `tests/conformance/run.sh` and validates every fixture against it. Engine remains permissive; SDKs must emit only the canonical shape.
+- **Engine now enforces `version` strictly.** `Sykli.ContractSchemaVersion` (`core/lib/sykli/contract_schema_version.ex`) is the central policy module — it pins supported versions (`"1"`, `"2"`, `"3"`), the current version (`"3"`), and rejects missing/empty/wrong-type/unsupported versions. `Sykli.Graph.parse/1` and `Sykli.Validate.validate_data/1` both call `ContractSchemaVersion.fetch/1`. The previous silent default-to-`"1"` behavior is gone — payloads without a valid version are rejected. Negative coverage lives in `tests/conformance/schema-invalid/` (11 fixtures: missing, empty string, arbitrary string, integer, float, array, boolean, null, object, unsupported-future, unsupported-major).
+- **Phase 3C-1 `success_criteria`.** Three criterion types (`exit_code`, `file_exists`, `file_non_empty`), conjunctive AND, at-most-one `exit_code` per task. Engine vocabulary lives in `Sykli.SuccessCriteria`. **Metadata-only** — the executor does not evaluate criteria yet (deferred to 3C-2). All five SDKs ship explicit APIs. Conformance case `24-success-criteria.json`.
+- **Pipeline contract is canonical.** `schemas/sykli-pipeline.schema.json` (JSON Schema 2020-12) is the source of truth for SDK-emitted JSON. `scripts/validate-conformance-schema.py` validates positive fixtures in `tests/conformance/cases/` AND verifies negative fixtures in `tests/conformance/schema-invalid/` are rejected. SDKs must emit only the canonical shape.
 - **Phase 3B `task_type` (version `"3"`).** Closed 12-value enum (`build`, `test`, `lint`, `format`, `scan`, `package`, `publish`, `deploy`, `migrate`, `generate`, `verify`, `cleanup`) classifying executable tasks. Engine vocabulary lives in `Sykli.TaskType`. Triple-layered enforcement: schema `if/then`, `Sykli.Graph.parse_task_type/4`, `Sykli.Validate.check_task_types/3`. Rejected on review nodes. Design rationale: `docs/agent-contract-semantics.md`.
 - **`target` field removed from canonical SDK output.** All five SDK builder methods are deprecated no-ops (Python raises `DeprecationWarning`). The engine never read `target`; this was contract cleanup.
-- **Review nodes (`kind: "review"`) experimental** across all five SDKs. Schema rejects task-execution fields on reviews (`command`, `outputs`, `services`, `mounts`, `k8s`, `retry`, `timeout`, `task_type`).
+- **Review nodes (`kind: "review"`) experimental** across all five SDKs. Schema rejects task-execution fields on reviews (`command`, `outputs`, `services`, `mounts`, `k8s`, `retry`, `timeout`, `task_type`, `success_criteria`).
 - **GitHub-native foundation** shipped — GitHub App auth, webhook receiver (Plug + Bandit), Checks API client, `Sykli.Mesh.Roles`. See `docs/github-native.md`.
 - **CLI visual reset** shipped — Nordic-minimal renderer (`Sykli.CLI.Renderer/Theme/Live/FixRenderer`). The output rules are testable; banned vocabulary in §"CLI output rules" below.
 
@@ -65,7 +67,9 @@ eval/harness/run.sh --case 001 --dry-run    # preview without running
 
 - `core/test/` — Elixir unit/integration tests run by `mix test`.
 - `test/blackbox/` — shell-driven black-box suite against the built `sykli` binary (dataset in `dataset.json`).
-- `tests/conformance/` (repo root, note the `s`) — cross-SDK JSON-output conformance cases.
+- `tests/conformance/cases/` — positive cross-SDK conformance cases. SDKs must emit byte-identical JSON for these.
+- `tests/conformance/schema-invalid/` — negative schema-rejection fixtures. The schema validator asserts each one **fails** validation; missing-rejection is itself a failure.
+- `tests/conformance/fixtures/<sdk>/` — per-SDK pipeline files for each case in `cases/`.
 - `eval/oracle/` + `eval/harness/` — ground-truth cases and the AI-agent eval loop.
 
 ### Other docs (don't duplicate; defer to)
@@ -267,7 +271,12 @@ Some cases carry `expected_failure: true`, which marks them as known-broken cont
 - **No wall-clock or global RNG in simulator-facing code** — the custom `CredoSykli.Check.NoWallClock` check (`core/lib/credo_sykli/check/no_wall_clock.ex`) fails on `System.monotonic_time/os_time/system_time`, `DateTime.utc_now`, `NaiveDateTime.utc_now`, `:os.system_time`, `:erlang.now`, and bare `:rand.uniform`. Route time through transport APIs (e.g. `now_ms/0`) and randomness through explicit seeded state
 - **Runtime isolation** — no module outside `core/lib/sykli/runtime/` may name a specific runtime implementation (`Sykli.Runtime.Docker`, `Podman`, `Shell`, `Fake`, `Containerd`). Selection flows through `Sykli.Runtime.Resolver`. Enforced by `core/test/sykli/runtime_isolation_test.exs` — the test greps the source tree and fails on any offender
 - **Schema is the canonical contract for SDK emission.** `schemas/sykli-pipeline.schema.json` is strict (`additionalProperties: false`) and gates new fields by `version`. The engine in `graph.ex` is more permissive (legacy compatibility paths: unknown keys ignored, `condition` aliasing `when`, list-form `outputs`). SDK output must validate against the schema; engine acceptance is *not* the SDK's bar. Document permissive paths in `docs/sdk-schema.md` under "Contract boundary".
-- **Engine vocabulary modules** — values shared across `graph.ex` and `validate.ex` (e.g., `task_type`'s 12-value enum) live in dedicated modules like `Sykli.TaskType` (`Sykli.TaskType.all/0`, `Sykli.TaskType.valid?/1`). When adding a new closed-enum field, follow this pattern instead of duplicating the literal across modules. SDKs must carry their own copies (separate Mix projects).
+- **Engine vocabulary modules** — values shared across `graph.ex` and `validate.ex` (closed enums, version policies, criterion type sets) live in dedicated modules. The pattern: each such module exposes a `valid?/1` (or `fetch/1`) plus a `format_error/1` and/or `to_error_map/1` so both the parse path and the validate path render errors identically. Existing instances:
+  - `Sykli.TaskType` — the 12-value `task_type` enum (Phase 3B).
+  - `Sykli.SuccessCriteria` — `success_criteria` shape and constraints (Phase 3C-1).
+  - `Sykli.ContractSchemaVersion` — supported `version` values + missing/empty/wrong-type/unsupported error policy.
+
+  When adding a new closed-enum field or shared-policy concept, follow this pattern. SDKs must carry their own copies (separate Mix projects — engine modules are unreachable from `sdk/<lang>/`).
 - **Engine error formatting** — parse-time errors render via `Sykli.Graph.format_error/1` (also delegated to from `Sykli.MCP.Tools`); validate-time errors render via `Sykli.Validate.format_errors/1`. Validate-path strings prefix `"Error: "`; parse-path strings don't. Keep new error tuples consistent with the path that produces them.
 
 ## CLI output rules

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ flowchart LR
 
 The engine runs on the BEAM VM. Same code on your laptop, in Docker, on Kubernetes, or across a mesh of nodes.
 
-**Wire-format versions are explicit**, not advisory: `"1"` baseline graphs, `"2"` adds resources/containers/mounts, `"3"` adds agent-native semantic fields starting with `task_type`. SDKs auto-detect from features used. See [`docs/sdk-schema.md`](docs/sdk-schema.md) for the field-by-field contract.
+**Wire-format versions are explicit**, not advisory: `"1"` baseline graphs, `"2"` adds resources/containers/mounts, `"3"` adds agent-native semantic fields starting with `task_type`. SDKs auto-detect from features used, and the engine rejects missing, malformed, or unsupported versions. See [`docs/sdk-schema.md`](docs/sdk-schema.md) for the field-by-field contract.
 
 ## Distributed-by-default. Deterministic by design.
 

--- a/core/lib/sykli/contract_schema_version.ex
+++ b/core/lib/sykli/contract_schema_version.ex
@@ -1,0 +1,94 @@
+defmodule Sykli.ContractSchemaVersion do
+  @moduledoc """
+  Central policy for supported Sykli pipeline contract schema versions.
+
+  The top-level `version` field is the pipeline wire-format/schema version. The
+  engine must reject missing, malformed, empty, or unsupported versions instead
+  of silently treating them as an older format.
+  """
+
+  @supported_versions ~w(1 2 3)
+  @current_version "3"
+
+  @type validation_error ::
+          :missing_contract_schema_version
+          | {:invalid_contract_schema_version_type, term()}
+          | :empty_contract_schema_version
+          | {:unsupported_contract_schema_version, String.t()}
+
+  @spec supported_versions() :: [String.t()]
+  def supported_versions, do: @supported_versions
+
+  @spec current_version() :: String.t()
+  def current_version, do: @current_version
+
+  @spec fetch(map()) :: {:ok, String.t()} | {:error, validation_error()}
+  def fetch(data) when is_map(data) do
+    if Map.has_key?(data, "version") do
+      validate(data["version"])
+    else
+      {:error, :missing_contract_schema_version}
+    end
+  end
+
+  @spec validate(term()) :: {:ok, String.t()} | {:error, validation_error()}
+  def validate(version) when is_binary(version) do
+    cond do
+      String.trim(version) == "" ->
+        {:error, :empty_contract_schema_version}
+
+      version in @supported_versions ->
+        {:ok, version}
+
+      true ->
+        {:error, {:unsupported_contract_schema_version, version}}
+    end
+  end
+
+  def validate(version), do: {:error, {:invalid_contract_schema_version_type, version}}
+
+  @spec error_type(validation_error()) :: atom()
+  def error_type(:missing_contract_schema_version), do: :missing_contract_schema_version
+  def error_type(:empty_contract_schema_version), do: :empty_contract_schema_version
+
+  def error_type({:invalid_contract_schema_version_type, _}),
+    do: :invalid_contract_schema_version_type
+
+  def error_type({:unsupported_contract_schema_version, _}),
+    do: :unsupported_contract_schema_version
+
+  @spec message(validation_error()) :: String.t()
+  def message(:missing_contract_schema_version), do: "missing contract schema version"
+
+  def message({:invalid_contract_schema_version_type, version}) do
+    "invalid contract schema version: expected string, got #{type_name(version)}"
+  end
+
+  def message(:empty_contract_schema_version), do: "empty contract schema version"
+
+  def message({:unsupported_contract_schema_version, version}) do
+    "unsupported contract schema version: #{version}; supported versions: #{supported_versions_text()}"
+  end
+
+  @spec format_error(validation_error()) :: String.t()
+  def format_error(reason), do: "Error: #{message(reason)}"
+
+  @spec to_error_map(validation_error()) :: map()
+  def to_error_map(reason) do
+    %{
+      type: error_type(reason),
+      message: message(reason)
+    }
+  end
+
+  @spec supported_versions_text() :: String.t()
+  def supported_versions_text, do: Enum.join(@supported_versions, ", ")
+
+  defp type_name(nil), do: "null"
+  defp type_name(value) when is_integer(value), do: "integer"
+  defp type_name(value) when is_float(value), do: "number"
+  defp type_name(value) when is_boolean(value), do: "boolean"
+  defp type_name(value) when is_list(value), do: "array"
+  defp type_name(value) when is_map(value), do: "object"
+  defp type_name(value), do: inspect(value)
+end

--- a/core/lib/sykli/graph.ex
+++ b/core/lib/sykli/graph.ex
@@ -358,15 +358,10 @@ defmodule Sykli.Graph do
   def parse(json) do
     case Jason.decode(json) do
       {:ok, %{"tasks" => tasks} = data} ->
-        version = Map.get(data, "version", "1")
-
-        case map_ok(tasks, &parse_task(&1, version)) do
-          {:ok, parsed_tasks} ->
-            parsed = Map.new(parsed_tasks, fn task -> {task.name, task} end)
-            {:ok, parsed}
-
-          {:error, _} = error ->
-            error
+        with {:ok, version} <- Sykli.ContractSchemaVersion.fetch(data),
+             {:ok, parsed_tasks} <- map_ok(tasks, &parse_task(&1, version)) do
+          parsed = Map.new(parsed_tasks, fn task -> {task.name, task} end)
+          {:ok, parsed}
         end
 
       {:ok, _} ->
@@ -375,6 +370,22 @@ defmodule Sykli.Graph do
       {:error, reason} ->
         {:error, {:json_parse_error, reason}}
     end
+  end
+
+  def format_error(:missing_contract_schema_version = reason) do
+    Sykli.ContractSchemaVersion.format_error(reason)
+  end
+
+  def format_error(:empty_contract_schema_version = reason) do
+    Sykli.ContractSchemaVersion.format_error(reason)
+  end
+
+  def format_error({:invalid_contract_schema_version_type, _version} = reason) do
+    Sykli.ContractSchemaVersion.format_error(reason)
+  end
+
+  def format_error({:unsupported_contract_schema_version, _version} = reason) do
+    Sykli.ContractSchemaVersion.format_error(reason)
   end
 
   def format_error({:task_type_on_review, task_name}) do

--- a/core/lib/sykli/validate.ex
+++ b/core/lib/sykli/validate.ex
@@ -82,7 +82,8 @@ defmodule Sykli.Validate do
 
   defp validate_data(data) do
     tasks = data["tasks"] || []
-    version = Map.get(data, "version", "1")
+    version_result = Sykli.ContractSchemaVersion.fetch(data)
+    version = if match?({:ok, _}, version_result), do: elem(version_result, 1), else: nil
 
     task_names =
       tasks
@@ -91,6 +92,7 @@ defmodule Sykli.Validate do
 
     errors =
       []
+      |> check_contract_schema_version(version_result)
       |> check_empty_names(tasks)
       |> check_duplicates(task_names)
       |> check_self_deps(tasks)
@@ -113,6 +115,12 @@ defmodule Sykli.Validate do
       errors: errors,
       warnings: warnings
     }
+  end
+
+  defp check_contract_schema_version(errors, {:ok, _version}), do: errors
+
+  defp check_contract_schema_version(errors, {:error, reason}) do
+    [Sykli.ContractSchemaVersion.to_error_map(reason) | errors]
   end
 
   defp check_empty_names(errors, tasks) do
@@ -350,6 +358,15 @@ defmodule Sykli.Validate do
   defp format_error(%{type: :self_dependency, message: msg}), do: "Error: #{msg}"
   defp format_error(%{type: :empty_task_name, message: msg}), do: "Error: #{msg}"
   defp format_error(%{type: :invalid_json, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :missing_contract_schema_version, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :empty_contract_schema_version, message: msg}), do: "Error: #{msg}"
+
+  defp format_error(%{type: :invalid_contract_schema_version_type, message: msg}),
+    do: "Error: #{msg}"
+
+  defp format_error(%{type: :unsupported_contract_schema_version, message: msg}),
+    do: "Error: #{msg}"
+
   defp format_error(%{message: msg}), do: "Error: #{msg}"
   defp format_error(error), do: "Error: #{inspect(error)}"
 end

--- a/core/lib/sykli/validate.ex
+++ b/core/lib/sykli/validate.ex
@@ -83,7 +83,12 @@ defmodule Sykli.Validate do
   defp validate_data(data) do
     tasks = data["tasks"] || []
     version_result = Sykli.ContractSchemaVersion.fetch(data)
-    version = if match?({:ok, _}, version_result), do: elem(version_result, 1), else: nil
+
+    version =
+      case version_result do
+        {:ok, version} -> version
+        {:error, _reason} -> nil
+      end
 
     task_names =
       tasks
@@ -98,8 +103,7 @@ defmodule Sykli.Validate do
       |> check_self_deps(tasks)
       |> check_missing_deps(tasks, task_names)
       |> check_missing_commands(tasks)
-      |> check_task_types(tasks, version)
-      |> check_success_criteria(tasks, version)
+      |> check_version_gated_fields(tasks, version_result, version)
       |> check_cycles(tasks)
 
     warnings =
@@ -121,6 +125,14 @@ defmodule Sykli.Validate do
 
   defp check_contract_schema_version(errors, {:error, reason}) do
     [Sykli.ContractSchemaVersion.to_error_map(reason) | errors]
+  end
+
+  defp check_version_gated_fields(errors, _tasks, {:error, _reason}, _version), do: errors
+
+  defp check_version_gated_fields(errors, tasks, {:ok, _version}, version) do
+    errors
+    |> check_task_types(tasks, version)
+    |> check_success_criteria(tasks, version)
   end
 
   defp check_empty_names(errors, tasks) do

--- a/core/test/core_test.exs
+++ b/core/test/core_test.exs
@@ -26,6 +26,8 @@ defmodule SykliTest do
        {:invalid_contract_schema_version_type, nil}},
       {~s({"version":"","tasks":[{"name":"test","command":"go test ./..."}]}),
        :empty_contract_schema_version},
+      {~s({"version":"   ","tasks":[{"name":"test","command":"go test ./..."}]}),
+       :empty_contract_schema_version},
       {~s({"version":1,"tasks":[{"name":"test","command":"go test ./..."}]}),
        {:invalid_contract_schema_version_type, 1}},
       {~s({"version":0.1,"tasks":[{"name":"test","command":"go test ./..."}]}),

--- a/core/test/core_test.exs
+++ b/core/test/core_test.exs
@@ -2,9 +2,65 @@ defmodule SykliTest do
   use ExUnit.Case
 
   test "parses task graph" do
-    json = ~s({"tasks":[{"name":"test","command":"go test ./..."}]})
+    json = ~s({"version":"1","tasks":[{"name":"test","command":"go test ./..."}]})
     assert {:ok, graph} = Sykli.Graph.parse(json)
     assert Map.has_key?(graph, "test")
+  end
+
+  test "accepts each supported contract schema version" do
+    for version <- Sykli.ContractSchemaVersion.supported_versions() do
+      json = ~s({"version":"#{version}","tasks":[{"name":"test","command":"go test ./..."}]})
+      assert {:ok, graph} = Sykli.Graph.parse(json)
+      assert Map.has_key?(graph, "test")
+    end
+  end
+
+  test "rejects missing contract schema version" do
+    json = ~s({"tasks":[{"name":"test","command":"go test ./..."}]})
+    assert {:error, :missing_contract_schema_version} = Sykli.Graph.parse(json)
+  end
+
+  test "rejects malformed and unsupported contract schema versions" do
+    cases = [
+      {~s({"version":null,"tasks":[{"name":"test","command":"go test ./..."}]}),
+       {:invalid_contract_schema_version_type, nil}},
+      {~s({"version":"","tasks":[{"name":"test","command":"go test ./..."}]}),
+       :empty_contract_schema_version},
+      {~s({"version":1,"tasks":[{"name":"test","command":"go test ./..."}]}),
+       {:invalid_contract_schema_version_type, 1}},
+      {~s({"version":0.1,"tasks":[{"name":"test","command":"go test ./..."}]}),
+       {:invalid_contract_schema_version_type, 0.1}},
+      {~s({"version":true,"tasks":[{"name":"test","command":"go test ./..."}]}),
+       {:invalid_contract_schema_version_type, true}},
+      {~s({"version":[],"tasks":[{"name":"test","command":"go test ./..."}]}),
+       {:invalid_contract_schema_version_type, []}},
+      {~s({"version":{},"tasks":[{"name":"test","command":"go test ./..."}]}),
+       {:invalid_contract_schema_version_type, %{}}},
+      {~s({"version":"0.2","tasks":[{"name":"test","command":"go test ./..."}]}),
+       {:unsupported_contract_schema_version, "0.2"}},
+      {~s({"version":"1.0","tasks":[{"name":"test","command":"go test ./..."}]}),
+       {:unsupported_contract_schema_version, "1.0"}},
+      {~s({"version":"banana","tasks":[{"name":"test","command":"go test ./..."}]}),
+       {:unsupported_contract_schema_version, "banana"}}
+    ]
+
+    for {json, expected_error} <- cases do
+      assert {:error, ^expected_error} = Sykli.Graph.parse(json)
+    end
+  end
+
+  test "formats contract schema version parse errors" do
+    assert Sykli.Graph.format_error(:missing_contract_schema_version) ==
+             "Error: missing contract schema version"
+
+    assert Sykli.Graph.format_error({:invalid_contract_schema_version_type, 1}) ==
+             "Error: invalid contract schema version: expected string, got integer"
+
+    assert Sykli.Graph.format_error(:empty_contract_schema_version) ==
+             "Error: empty contract schema version"
+
+    assert Sykli.Graph.format_error({:unsupported_contract_schema_version, "0.2"}) ==
+             "Error: unsupported contract schema version: 0.2; supported versions: 1, 2, 3"
   end
 
   test "parses task_type on version 3 executable tasks" do
@@ -49,7 +105,7 @@ defmodule SykliTest do
 
   test "parses review nodes with metadata" do
     json =
-      ~s({"tasks":[{"name":"test","command":"go test ./..."},{"name":"review:api-breakage","kind":"review","primitive":"api-breakage","agent":"local","inputs":["main...HEAD"],"context":["README.md","docs/architecture.md"],"outputs":["reviews/api-breakage.local.json"],"depends_on":["test"],"deterministic":false}]})
+      ~s({"version":"1","tasks":[{"name":"test","command":"go test ./..."},{"name":"review:api-breakage","kind":"review","primitive":"api-breakage","agent":"local","inputs":["main...HEAD"],"context":["README.md","docs/architecture.md"],"outputs":["reviews/api-breakage.local.json"],"depends_on":["test"],"deterministic":false}]})
 
     assert {:ok, graph} = Sykli.Graph.parse(json)
     review = Map.fetch!(graph, "review:api-breakage")
@@ -67,7 +123,7 @@ defmodule SykliTest do
   end
 
   test "topo sort with no deps" do
-    json = ~s({"tasks":[{"name":"a","command":"a"},{"name":"b","command":"b"}]})
+    json = ~s({"version":"1","tasks":[{"name":"a","command":"a"},{"name":"b","command":"b"}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     {:ok, order} = Sykli.Graph.topo_sort(graph)
     assert length(order) == 2
@@ -76,7 +132,7 @@ defmodule SykliTest do
   # ----- MATRIX EXPANSION TESTS -----
 
   test "expand_matrix with no matrix returns unchanged" do
-    json = ~s({"tasks":[{"name":"test","command":"go test"}]})
+    json = ~s({"version":"1","tasks":[{"name":"test","command":"go test"}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     expanded = Sykli.Graph.expand_matrix(graph)
     assert Map.has_key?(expanded, "test")
@@ -84,7 +140,9 @@ defmodule SykliTest do
   end
 
   test "expand_matrix single dimension" do
-    json = ~s({"tasks":[{"name":"test","command":"go test","matrix":{"version":["1.0","2.0"]}}]})
+    json =
+      ~s({"version":"1","tasks":[{"name":"test","command":"go test","matrix":{"version":["1.0","2.0"]}}]})
+
     {:ok, graph} = Sykli.Graph.parse(json)
     expanded = Sykli.Graph.expand_matrix(graph)
 
@@ -99,7 +157,7 @@ defmodule SykliTest do
 
   test "expand_matrix multi-dimensional" do
     json =
-      ~s({"tasks":[{"name":"test","command":"go test","matrix":{"os":["linux","macos"],"version":["1.0","2.0"]}}]})
+      ~s({"version":"1","tasks":[{"name":"test","command":"go test","matrix":{"os":["linux","macos"],"version":["1.0","2.0"]}}]})
 
     {:ok, graph} = Sykli.Graph.parse(json)
     expanded = Sykli.Graph.expand_matrix(graph)
@@ -109,7 +167,9 @@ defmodule SykliTest do
   end
 
   test "expand_matrix injects values into env" do
-    json = ~s({"tasks":[{"name":"test","command":"go test","matrix":{"version":["1.0"]}}]})
+    json =
+      ~s({"version":"1","tasks":[{"name":"test","command":"go test","matrix":{"version":["1.0"]}}]})
+
     {:ok, graph} = Sykli.Graph.parse(json)
     expanded = Sykli.Graph.expand_matrix(graph)
 
@@ -118,7 +178,7 @@ defmodule SykliTest do
   end
 
   test "expand_matrix updates dependencies" do
-    json = ~s({"tasks":[
+    json = ~s({"version":"1","tasks":[
       {"name":"test","command":"go test","matrix":{"v":["1","2"]}},
       {"name":"build","command":"go build","depends_on":["test"]}
     ]})
@@ -132,7 +192,7 @@ defmodule SykliTest do
   end
 
   test "expand_matrix with empty matrix returns task unchanged" do
-    json = ~s({"tasks":[{"name":"test","command":"go test","matrix":{}}]})
+    json = ~s({"version":"1","tasks":[{"name":"test","command":"go test","matrix":{}}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     expanded = Sykli.Graph.expand_matrix(graph)
     assert Map.has_key?(expanded, "test")
@@ -142,14 +202,16 @@ defmodule SykliTest do
   # ----- CONDITION PARSING TESTS -----
 
   test "parses when condition from JSON" do
-    json = ~s({"tasks":[{"name":"deploy","command":"./deploy.sh","when":"branch == 'main'"}]})
+    json =
+      ~s({"version":"1","tasks":[{"name":"deploy","command":"./deploy.sh","when":"branch == 'main'"}]})
+
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "deploy")
     assert task.condition == "branch == 'main'"
   end
 
   test "when condition is nil when not set" do
-    json = ~s({"tasks":[{"name":"test","command":"go test"}]})
+    json = ~s({"version":"1","tasks":[{"name":"test","command":"go test"}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "test")
     assert task.condition == nil
@@ -159,7 +221,7 @@ defmodule SykliTest do
 
   test "parses secrets from JSON" do
     json =
-      ~s({"tasks":[{"name":"deploy","command":"./deploy.sh","secrets":["GITHUB_TOKEN","NPM_TOKEN"]}]})
+      ~s({"version":"1","tasks":[{"name":"deploy","command":"./deploy.sh","secrets":["GITHUB_TOKEN","NPM_TOKEN"]}]})
 
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "deploy")
@@ -167,7 +229,7 @@ defmodule SykliTest do
   end
 
   test "secrets is empty list when not set" do
-    json = ~s({"tasks":[{"name":"test","command":"go test"}]})
+    json = ~s({"version":"1","tasks":[{"name":"test","command":"go test"}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "test")
     assert task.secrets == []
@@ -177,7 +239,7 @@ defmodule SykliTest do
 
   test "parses services from JSON" do
     json =
-      ~s({"tasks":[{"name":"test","command":"go test","services":[{"image":"postgres:15","name":"db"}]}]})
+      ~s({"version":"1","tasks":[{"name":"test","command":"go test","services":[{"image":"postgres:15","name":"db"}]}]})
 
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "test")
@@ -187,7 +249,7 @@ defmodule SykliTest do
   end
 
   test "services is empty list when not set" do
-    json = ~s({"tasks":[{"name":"test","command":"go test"}]})
+    json = ~s({"version":"1","tasks":[{"name":"test","command":"go test"}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "test")
     assert task.services == []
@@ -195,7 +257,7 @@ defmodule SykliTest do
 
   test "parses multiple services" do
     json =
-      ~s({"tasks":[{"name":"test","command":"go test","services":[{"image":"postgres:15","name":"db"},{"image":"redis:7","name":"cache"}]}]})
+      ~s({"version":"1","tasks":[{"name":"test","command":"go test","services":[{"image":"postgres:15","name":"db"},{"image":"redis:7","name":"cache"}]}]})
 
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "test")
@@ -206,7 +268,7 @@ defmodule SykliTest do
 
   test "expand_matrix preserves matrix_values for expanded tasks" do
     json =
-      ~s({"tasks":[{"name":"test","command":"go test","matrix":{"os":["linux"],"ver":["1.0"]}}]})
+      ~s({"version":"1","tasks":[{"name":"test","command":"go test","matrix":{"os":["linux"],"ver":["1.0"]}}]})
 
     {:ok, graph} = Sykli.Graph.parse(json)
     expanded = Sykli.Graph.expand_matrix(graph)
@@ -219,7 +281,7 @@ defmodule SykliTest do
   end
 
   test "expand_matrix with nil matrix returns task unchanged" do
-    json = ~s({"tasks":[{"name":"test","command":"go test"}]})
+    json = ~s({"version":"1","tasks":[{"name":"test","command":"go test"}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     expanded = Sykli.Graph.expand_matrix(graph)
     assert Map.has_key?(expanded, "test")
@@ -231,7 +293,7 @@ defmodule SykliTest do
 
   test "parses legacy 'condition' field" do
     json =
-      ~s({"tasks":[{"name":"deploy","command":"./deploy.sh","condition":"branch == 'main'"}]})
+      ~s({"version":"1","tasks":[{"name":"deploy","command":"./deploy.sh","condition":"branch == 'main'"}]})
 
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "deploy")
@@ -240,7 +302,7 @@ defmodule SykliTest do
 
   test "when field takes precedence over condition field" do
     json =
-      ~s({"tasks":[{"name":"deploy","command":"./deploy.sh","when":"tag != ''","condition":"branch == 'main'"}]})
+      ~s({"version":"1","tasks":[{"name":"deploy","command":"./deploy.sh","when":"tag != ''","condition":"branch == 'main'"}]})
 
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "deploy")
@@ -251,7 +313,7 @@ defmodule SykliTest do
 
   test "services parses image and name correctly" do
     json =
-      ~s({"tasks":[{"name":"test","command":"test","services":[{"image":"postgres:15","name":"db"}]}]})
+      ~s({"version":"1","tasks":[{"name":"test","command":"test","services":[{"image":"postgres:15","name":"db"}]}]})
 
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "test")
@@ -263,14 +325,14 @@ defmodule SykliTest do
   # ----- RETRY TESTS -----
 
   test "parses retry from JSON" do
-    json = ~s({"tasks":[{"name":"test","command":"go test","retry":3}]})
+    json = ~s({"version":"1","tasks":[{"name":"test","command":"go test","retry":3}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "test")
     assert task.retry == 3
   end
 
   test "retry is nil when not set" do
-    json = ~s({"tasks":[{"name":"test","command":"go test"}]})
+    json = ~s({"version":"1","tasks":[{"name":"test","command":"go test"}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "test")
     assert task.retry == nil
@@ -279,14 +341,14 @@ defmodule SykliTest do
   # ----- TIMEOUT TESTS -----
 
   test "parses timeout from JSON" do
-    json = ~s({"tasks":[{"name":"build","command":"make","timeout":600}]})
+    json = ~s({"version":"1","tasks":[{"name":"build","command":"make","timeout":600}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "build")
     assert task.timeout == 600
   end
 
   test "timeout is nil when not set" do
-    json = ~s({"tasks":[{"name":"test","command":"go test"}]})
+    json = ~s({"version":"1","tasks":[{"name":"test","command":"go test"}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "test")
     assert task.timeout == nil
@@ -295,7 +357,7 @@ defmodule SykliTest do
   # ----- CYCLE DETECTION TESTS -----
 
   test "detects self-referencing cycle" do
-    json = ~s({"tasks":[{"name":"a","command":"echo","depends_on":["a"]}]})
+    json = ~s({"version":"1","tasks":[{"name":"a","command":"echo","depends_on":["a"]}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     {:error, {:cycle_detected, path}} = Sykli.Graph.topo_sort(graph)
     assert is_list(path)
@@ -303,7 +365,7 @@ defmodule SykliTest do
   end
 
   test "detects direct cycle between two tasks" do
-    json = ~s({"tasks":[
+    json = ~s({"version":"1","tasks":[
       {"name":"a","command":"echo","depends_on":["b"]},
       {"name":"b","command":"echo","depends_on":["a"]}
     ]})
@@ -315,7 +377,7 @@ defmodule SykliTest do
   end
 
   test "detects indirect cycle: a -> b -> c -> a" do
-    json = ~s({"tasks":[
+    json = ~s({"version":"1","tasks":[
       {"name":"a","command":"echo","depends_on":["b"]},
       {"name":"b","command":"echo","depends_on":["c"]},
       {"name":"c","command":"echo","depends_on":["a"]}
@@ -327,7 +389,7 @@ defmodule SykliTest do
   end
 
   test "no cycle in valid DAG" do
-    json = ~s({"tasks":[
+    json = ~s({"version":"1","tasks":[
       {"name":"test","command":"echo"},
       {"name":"build","command":"echo","depends_on":["test"]},
       {"name":"deploy","command":"echo","depends_on":["build"]}
@@ -340,7 +402,7 @@ defmodule SykliTest do
   # ----- TASK_INPUTS TESTS (v2 artifact passing) -----
 
   test "parses task_inputs from JSON" do
-    json = ~s({"tasks":[
+    json = ~s({"version":"1","tasks":[
       {"name":"build","command":"go build -o ./app","outputs":{"binary":"./app"}},
       {"name":"deploy","command":"./deploy.sh","task_inputs":[{"from_task":"build","output":"binary","dest":"./input/app"}],"depends_on":["build"]}
     ]})
@@ -361,7 +423,7 @@ defmodule SykliTest do
   end
 
   test "task_inputs is empty list when not set" do
-    json = ~s({"tasks":[{"name":"test","command":"go test"}]})
+    json = ~s({"version":"1","tasks":[{"name":"test","command":"go test"}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "test")
     assert task.task_inputs == []
@@ -369,7 +431,7 @@ defmodule SykliTest do
 
   test "outputs map format is preserved" do
     json =
-      ~s({"tasks":[{"name":"build","command":"make","outputs":{"binary":"./app","docs":"./docs"}}]})
+      ~s({"version":"1","tasks":[{"name":"build","command":"make","outputs":{"binary":"./app","docs":"./docs"}}]})
 
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "build")
@@ -379,7 +441,9 @@ defmodule SykliTest do
   end
 
   test "outputs list format is converted to map" do
-    json = ~s({"tasks":[{"name":"build","command":"make","outputs":["./app","./lib"]}]})
+    json =
+      ~s({"version":"1","tasks":[{"name":"build","command":"make","outputs":["./app","./lib"]}]})
+
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "build")
     assert is_map(task.outputs)
@@ -391,7 +455,7 @@ defmodule SykliTest do
 
   test "parses requires from JSON" do
     json =
-      ~s({"tasks":[{"name":"train","command":"python train.py","requires":["gpu","docker"]}]})
+      ~s({"version":"1","tasks":[{"name":"train","command":"python train.py","requires":["gpu","docker"]}]})
 
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "train")
@@ -399,14 +463,14 @@ defmodule SykliTest do
   end
 
   test "requires is empty list when not set" do
-    json = ~s({"tasks":[{"name":"test","command":"go test"}]})
+    json = ~s({"version":"1","tasks":[{"name":"test","command":"go test"}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "test")
     assert task.requires == []
   end
 
   test "requires handles single label" do
-    json = ~s({"tasks":[{"name":"build","command":"make","requires":["docker"]}]})
+    json = ~s({"version":"1","tasks":[{"name":"build","command":"make","requires":["docker"]}]})
     {:ok, graph} = Sykli.Graph.parse(json)
     task = Map.get(graph, "build")
     assert task.requires == ["docker"]

--- a/core/test/sykli/attestation_test.exs
+++ b/core/test/sykli/attestation_test.exs
@@ -371,7 +371,7 @@ defmodule Sykli.AttestationTest do
   end
 
   defp parse_graph!(tasks) do
-    json = Jason.encode!(%{"tasks" => tasks})
+    json = Jason.encode!(%{"version" => "1", "tasks" => tasks})
     {:ok, graph} = Sykli.Graph.parse(json)
     graph
   end

--- a/core/test/sykli/context_test.exs
+++ b/core/test/sykli/context_test.exs
@@ -464,7 +464,7 @@ defmodule Sykli.ContextTest do
   # Helpers
 
   defp parse_graph(tasks) do
-    json = Jason.encode!(%{"tasks" => tasks})
+    json = Jason.encode!(%{"version" => "1", "tasks" => tasks})
     Graph.parse(json)
   end
 

--- a/core/test/sykli/executor_ai_hooks_test.exs
+++ b/core/test/sykli/executor_ai_hooks_test.exs
@@ -71,7 +71,7 @@ defmodule Sykli.ExecutorAiHooksTest do
   describe "secret_refs parsing" do
     test "parses secret_refs from JSON" do
       json =
-        ~s({"tasks": [{"name": "deploy", "command": "deploy.sh", "secret_refs": [{"name": "AWS_KEY", "source": "env", "key": "AWS_ACCESS_KEY_ID"}, {"name": "DB_PASS", "source": "file", "key": "/run/secrets/db"}]}]})
+        ~s({"version":"1","tasks": [{"name": "deploy", "command": "deploy.sh", "secret_refs": [{"name": "AWS_KEY", "source": "env", "key": "AWS_ACCESS_KEY_ID"}, {"name": "DB_PASS", "source": "file", "key": "/run/secrets/db"}]}]})
 
       result = Sykli.Validate.validate_json(json)
       assert result.valid == true
@@ -79,7 +79,7 @@ defmodule Sykli.ExecutorAiHooksTest do
 
     test "graph parses secret_refs into task struct" do
       json =
-        ~s({"tasks": [{"name": "deploy", "command": "deploy.sh", "secret_refs": [{"name": "TOKEN", "source": "env", "key": "DEPLOY_TOKEN"}]}]})
+        ~s({"version":"1","tasks": [{"name": "deploy", "command": "deploy.sh", "secret_refs": [{"name": "TOKEN", "source": "env", "key": "DEPLOY_TOKEN"}]}]})
 
       {:ok, graph} = Sykli.Graph.parse(json)
       task = Map.get(graph, "deploy")
@@ -92,7 +92,7 @@ defmodule Sykli.ExecutorAiHooksTest do
     end
 
     test "empty secret_refs defaults to empty list" do
-      json = ~s({"tasks": [{"name": "test", "command": "echo hi"}]})
+      json = ~s({"version":"1","tasks": [{"name": "test", "command": "echo hi"}]})
 
       {:ok, graph} = Sykli.Graph.parse(json)
       task = Map.get(graph, "test")

--- a/core/test/sykli/explain_test.exs
+++ b/core/test/sykli/explain_test.exs
@@ -358,7 +358,7 @@ defmodule Sykli.ExplainTest do
   # Helpers
 
   defp parse_graph(tasks) do
-    json = Jason.encode!(%{"tasks" => tasks})
+    json = Jason.encode!(%{"version" => "1", "tasks" => tasks})
     Graph.parse(json)
   end
 end

--- a/core/test/sykli/graph/ai_native_test.exs
+++ b/core/test/sykli/graph/ai_native_test.exs
@@ -7,6 +7,7 @@ defmodule Sykli.Graph.AiNativeTest do
   describe "parsing AI-native fields" do
     test "parses task with semantic metadata" do
       json = ~s|{
+        "version": "1",
         "tasks": [{
           "name": "test",
           "command": "mix test",
@@ -32,6 +33,7 @@ defmodule Sykli.Graph.AiNativeTest do
 
     test "parses task with AI hooks" do
       json = ~s|{
+        "version": "1",
         "tasks": [{
           "name": "lint",
           "command": "mix credo",
@@ -94,6 +96,7 @@ defmodule Sykli.Graph.AiNativeTest do
 
     test "parses task with history hints" do
       json = ~s|{
+        "version": "1",
         "tasks": [{
           "name": "flaky-test",
           "command": "mix test --flaky",
@@ -122,6 +125,7 @@ defmodule Sykli.Graph.AiNativeTest do
 
     test "parses task with all AI-native fields" do
       json = ~s|{
+        "version": "1",
         "tasks": [{
           "name": "full-ai-task",
           "command": "npm test",
@@ -161,6 +165,7 @@ defmodule Sykli.Graph.AiNativeTest do
 
     test "provides default values when AI fields are missing" do
       json = ~s|{
+        "version": "1",
         "tasks": [{
           "name": "simple",
           "command": "echo hello"

--- a/core/test/sykli/occurrence_test.exs
+++ b/core/test/sykli/occurrence_test.exs
@@ -614,7 +614,7 @@ defmodule Sykli.OccurrenceTest do
   end
 
   defp parse_graph!(tasks) do
-    json = Jason.encode!(%{"tasks" => tasks})
+    json = Jason.encode!(%{"version" => "1", "tasks" => tasks})
     {:ok, graph} = Graph.parse(json)
     graph
   end

--- a/core/test/sykli/plan_test.exs
+++ b/core/test/sykli/plan_test.exs
@@ -192,7 +192,7 @@ defmodule Sykli.PlanTest do
   # Helpers
 
   defp parse_graph(tasks) do
-    json = Jason.encode!(%{"tasks" => tasks})
+    json = Jason.encode!(%{"version" => "1", "tasks" => tasks})
     Graph.parse(json)
   end
 end

--- a/core/test/sykli/validate_test.exs
+++ b/core/test/sykli/validate_test.exs
@@ -10,6 +10,7 @@ defmodule Sykli.ValidateTest do
       # Test using JSON directly (can't run Go in test env)
       json = """
       {
+        "version": "1",
         "tasks": [
           {"name": "test", "command": "echo test"},
           {"name": "build", "command": "echo build", "depends_on": ["test"]}
@@ -41,11 +42,69 @@ defmodule Sykli.ValidateTest do
       assert result.tasks == ["test"]
     end
 
+    test "rejects missing contract schema version" do
+      json = ~s({"tasks":[{"name":"test","command":"echo test"}]})
+
+      result = Validate.validate_json(json)
+
+      refute result.valid
+
+      assert [
+               %{
+                 type: :missing_contract_schema_version,
+                 message: "missing contract schema version"
+               }
+             ] =
+               result.errors
+    end
+
+    test "rejects malformed and unsupported contract schema versions" do
+      cases = [
+        {~s({"version":null,"tasks":[{"name":"test","command":"echo test"}]}),
+         :invalid_contract_schema_version_type,
+         "invalid contract schema version: expected string, got null"},
+        {~s({"version":"","tasks":[{"name":"test","command":"echo test"}]}),
+         :empty_contract_schema_version, "empty contract schema version"},
+        {~s({"version":1,"tasks":[{"name":"test","command":"echo test"}]}),
+         :invalid_contract_schema_version_type,
+         "invalid contract schema version: expected string, got integer"},
+        {~s({"version":0.1,"tasks":[{"name":"test","command":"echo test"}]}),
+         :invalid_contract_schema_version_type,
+         "invalid contract schema version: expected string, got number"},
+        {~s({"version":true,"tasks":[{"name":"test","command":"echo test"}]}),
+         :invalid_contract_schema_version_type,
+         "invalid contract schema version: expected string, got boolean"},
+        {~s({"version":[],"tasks":[{"name":"test","command":"echo test"}]}),
+         :invalid_contract_schema_version_type,
+         "invalid contract schema version: expected string, got array"},
+        {~s({"version":{},"tasks":[{"name":"test","command":"echo test"}]}),
+         :invalid_contract_schema_version_type,
+         "invalid contract schema version: expected string, got object"},
+        {~s({"version":"0.2","tasks":[{"name":"test","command":"echo test"}]}),
+         :unsupported_contract_schema_version,
+         "unsupported contract schema version: 0.2; supported versions: 1, 2, 3"},
+        {~s({"version":"1.0","tasks":[{"name":"test","command":"echo test"}]}),
+         :unsupported_contract_schema_version,
+         "unsupported contract schema version: 1.0; supported versions: 1, 2, 3"},
+        {~s({"version":"banana","tasks":[{"name":"test","command":"echo test"}]}),
+         :unsupported_contract_schema_version,
+         "unsupported contract schema version: banana; supported versions: 1, 2, 3"}
+      ]
+
+      for {json, type, message} <- cases do
+        result = Validate.validate_json(json)
+
+        refute result.valid
+        assert Enum.any?(result.errors, &(&1.type == type and &1.message == message))
+      end
+    end
+
     test "detects cycle in dependencies" do
       # This test uses the JSON directly since creating a real cycle
       # in Go code would fail at emit time
       json = """
       {
+        "version": "1",
         "tasks": [
           {"name": "a", "command": "echo a", "depends_on": ["b"]},
           {"name": "b", "command": "echo b", "depends_on": ["a"]}
@@ -62,6 +121,7 @@ defmodule Sykli.ValidateTest do
     test "detects missing dependency" do
       json = """
       {
+        "version": "1",
         "tasks": [
           {"name": "build", "command": "echo build", "depends_on": ["nonexistent"]}
         ]
@@ -81,6 +141,7 @@ defmodule Sykli.ValidateTest do
     test "detects empty task name" do
       json = """
       {
+        "version": "1",
         "tasks": [
           {"name": "", "command": "echo test"}
         ]
@@ -96,6 +157,7 @@ defmodule Sykli.ValidateTest do
     test "detects whitespace-only task name" do
       json = """
       {
+        "version": "1",
         "tasks": [
           {"name": "   ", "command": "echo test"}
         ]
@@ -111,6 +173,7 @@ defmodule Sykli.ValidateTest do
     test "detects duplicate task names" do
       json = """
       {
+        "version": "1",
         "tasks": [
           {"name": "test", "command": "echo test1"},
           {"name": "test", "command": "echo test2"}
@@ -127,6 +190,7 @@ defmodule Sykli.ValidateTest do
     test "detects task depending on itself" do
       json = """
       {
+        "version": "1",
         "tasks": [
           {"name": "test", "command": "echo test", "depends_on": ["test"]}
         ]
@@ -144,6 +208,7 @@ defmodule Sykli.ValidateTest do
     test "returns structured result" do
       json = """
       {
+        "version": "1",
         "tasks": [
           {"name": "test", "command": "go test ./..."}
         ]
@@ -167,7 +232,7 @@ defmodule Sykli.ValidateTest do
 
     test "handles empty tasks list" do
       json = """
-      {"tasks": []}
+      {"version": "1", "tasks": []}
       """
 
       result = Validate.validate_json(json)
@@ -180,7 +245,7 @@ defmodule Sykli.ValidateTest do
 
   describe "validate_json/1 -- missing command" do
     test "detects task with no command" do
-      json = ~s({"tasks": [{"name": "test"}]})
+      json = ~s({"version":"1","tasks": [{"name": "test"}]})
 
       result = Validate.validate_json(json)
 
@@ -192,7 +257,7 @@ defmodule Sykli.ValidateTest do
     end
 
     test "detects task with empty command" do
-      json = ~s({"tasks": [{"name": "test", "command": ""}]})
+      json = ~s({"version":"1","tasks": [{"name": "test", "command": ""}]})
 
       result = Validate.validate_json(json)
 
@@ -202,7 +267,7 @@ defmodule Sykli.ValidateTest do
 
     test "exempts gate tasks from command requirement" do
       json =
-        ~s({"tasks": [{"name": "approval", "gate": {"strategy": "prompt", "message": "ok?"}}]})
+        ~s({"version":"1","tasks": [{"name": "approval", "gate": {"strategy": "prompt", "message": "ok?"}}]})
 
       result = Validate.validate_json(json)
 
@@ -211,7 +276,7 @@ defmodule Sykli.ValidateTest do
 
     test "exempts review nodes from command requirement" do
       json =
-        ~s({"tasks": [{"name": "review:api-breakage", "kind": "review", "primitive": "api-breakage", "agent": "local"}]})
+        ~s({"version":"1","tasks": [{"name": "review:api-breakage", "kind": "review", "primitive": "api-breakage", "agent": "local"}]})
 
       result = Validate.validate_json(json)
 
@@ -220,7 +285,7 @@ defmodule Sykli.ValidateTest do
     end
 
     test "passes when command is present" do
-      json = ~s({"tasks": [{"name": "test", "command": "echo hello"}]})
+      json = ~s({"version":"1","tasks": [{"name": "test", "command": "echo hello"}]})
 
       result = Validate.validate_json(json)
 

--- a/core/test/sykli/validate_test.exs
+++ b/core/test/sykli/validate_test.exs
@@ -65,6 +65,8 @@ defmodule Sykli.ValidateTest do
          "invalid contract schema version: expected string, got null"},
         {~s({"version":"","tasks":[{"name":"test","command":"echo test"}]}),
          :empty_contract_schema_version, "empty contract schema version"},
+        {~s({"version":"   ","tasks":[{"name":"test","command":"echo test"}]}),
+         :empty_contract_schema_version, "empty contract schema version"},
         {~s({"version":1,"tasks":[{"name":"test","command":"echo test"}]}),
          :invalid_contract_schema_version_type,
          "invalid contract schema version: expected string, got integer"},
@@ -97,6 +99,16 @@ defmodule Sykli.ValidateTest do
         refute result.valid
         assert Enum.any?(result.errors, &(&1.type == type and &1.message == message))
       end
+    end
+
+    test "does not cascade version-gated semantic field errors when version is invalid" do
+      json =
+        ~s({"tasks":[{"name":"test","command":"go test","task_type":"test","success_criteria":[{"type":"exit_code","equals":0}]}]})
+
+      result = Validate.validate_json(json)
+
+      refute result.valid
+      assert Enum.map(result.errors, & &1.type) == [:missing_contract_schema_version]
     end
 
     test "detects cycle in dependencies" do

--- a/docs/agent-contract-semantics.md
+++ b/docs/agent-contract-semantics.md
@@ -124,7 +124,9 @@ The version meanings are:
 The first `version: "3"` implementation must not add other Phase 3 fields just
 because the version becomes `"3"`.
 
-Do not make `version` decorative again.
+The engine accepts only explicitly supported pipeline wire-format versions.
+Missing, empty, malformed, or unsupported future versions are rejected. Do not
+make `version` decorative again.
 
 ## Semantic layers
 

--- a/docs/sdk-schema.md
+++ b/docs/sdk-schema.md
@@ -27,6 +27,10 @@ The engine is currently **more permissive** than the schema in three known ways:
 
 **The JSON Schema validates canonical SDK output. It does not validate every shape the engine can parse.** A payload that validates against the schema is guaranteed to parse and validate cleanly through the engine. A payload the engine accepts may not validate against the schema if it relies on the permissive paths above. SDK-emitted output should always be schema-conformant.
 
+The engine is **not** permissive about the top-level `version`: it rejects
+missing, empty, malformed, and unsupported pipeline schema versions before task
+parsing.
+
 ## Top-level object
 
 ```jsonc
@@ -46,8 +50,8 @@ The engine is currently **more permissive** than the schema in three known ways:
 - `"2"` is the resource-aware format: resources, mounts, caches, containers, and related execution-environment metadata.
 - `"3"` is the semantic contract format, beginning with `task_type` and `success_criteria`.
 - SDKs auto-detect: `"3"` if any executable task has semantic fields such as `task_type` or `success_criteria`; otherwise `"2"` if any task has `container` set, or any task has non-empty `mounts`, or the pipeline has any directory or cache resources; `"1"` otherwise.
-- **Current behavior:** version-aware for `task_type` and `success_criteria`. The schema and engine validation reject these fields unless `version == "3"`. Other version-aware parser behavior is still intentionally narrow.
-- **Intended future behavior:** the engine should accept known supported versions and reject unknown future versions unless an explicit compatibility mode exists. It should never silently reinterpret a newer document as an older version.
+- **Current behavior:** explicit and strict. The schema and engine accept only the supported versions above. Missing, empty, malformed, or unknown future versions are rejected. `task_type` and `success_criteria` remain valid only when `version == "3"`.
+- **Future behavior:** new pipeline wire-format versions require explicit schema and engine support. The engine must never silently reinterpret a newer document as an older version.
 
 ### `tasks`
 
@@ -352,24 +356,18 @@ It names the version of the pipeline document shape shared between SDKs, schema
 tooling, and the engine parser.
 
 It is **not** an execution capability version. It does not mean "run with v1
-features" or "run with v2 features" at execution time, and the current engine
-uses it only for narrow semantic-field validation. It is also not the
+features" or "run with v2 features" at execution time. It is also not the
 version of a particular SDK package, engine release, runtime, or JSON Schema
 draft.
 
-Current behavior is partially version-aware: SDKs emit `version`, the canonical
-schema requires `"1"`, `"2"`, or `"3"`, and the engine rejects `task_type` and
-`success_criteria` unless the top-level version is `"3"`. See the
+Current behavior is version-aware: SDKs emit `version`, the canonical schema and
+engine accept only `"1"`, `"2"`, or `"3"`, and the engine rejects `task_type`
+and `success_criteria` unless the top-level version is `"3"`. See the
 [`version` field](#version) above for the per-value definitions.
 
-Future engine behavior should become version-aware in a later implementation
-phase:
-
-- accept known supported pipeline wire-format versions
-- reject unknown future versions by default
-- allow unknown future versions only through an explicit compatibility mode, if
-  such a mode is intentionally designed
-- never silently reinterpret a newer document as an older version
+Unknown future versions are rejected by default. If a compatibility mode is ever
+designed, it must be explicit; the engine must never silently reinterpret a
+newer document as an older version.
 
 SDK auto-detection of `"1"` vs `"2"` should continue for now. This is
 transitional and reflects current SDK output. Long term, SDKs should either
@@ -386,18 +384,10 @@ but must not depend on older engines silently ignoring those additions. Do not
 design or reserve the contents of `version: "3"` until a concrete wire-format
 change requires it.
 
-The migration from today's advisory field to real version-aware parsing should
-happen in small steps:
-
-1. Keep current SDK output and schema values unchanged.
-2. Document the intended meaning of `"1"` and `"2"` in the human-readable
-   contract.
-3. Add engine parsing that reads the top-level `version` and recognizes the
-   currently supported versions.
-4. Initially preserve behavior for `"1"` and `"2"` while making unknown future
-   versions fail clearly.
-5. Only after parser support exists, introduce version-gated behavior for any
-   future wire-format changes.
+The migration from the old advisory field to real version-aware parsing is now
+in place for known versions. Future migrations should keep schema acceptance
+explicit, keep SDK auto-detection aligned with emitted features, and add tests
+before introducing any new wire-format version.
 
 ## Removed fields
 
@@ -424,7 +414,7 @@ introduce a replacement field.
 
 These are **descriptive, not prescriptive**. The schema documents current behavior; resolving these is Phase 2C / future work.
 
-1. **Version-aware behavior is still narrow.** SDKs emit `"1"`, `"2"`, or `"3"`; engine validation now checks `task_type` and `success_criteria` compatibility with `version: "3"`, but broader unknown-version rejection is still future work.
+1. **Version-aware behavior is enforced for supported versions.** SDKs emit `"1"`, `"2"`, or `"3"`; the engine rejects missing, malformed, and unsupported versions, and checks `task_type` and `success_criteria` compatibility with `version: "3"`.
 2. **Review nodes are experimental.** Engine supports `kind: "review"` and the four review-only fields, and SDKs expose minimal review builders. Review outputs are not canonical.
 3. **`verify` and `oidc` are reserved with no SDK emit.** Engine reads them; SDKs have no API. Either implement SDK support or drop from the schema once a decision lands.
 4. **`history_hint` is engine-internal.** SDKs MUST NOT emit. Schema marks `readOnly` for clarity.

--- a/schemas/sykli-pipeline.schema.json
+++ b/schemas/sykli-pipeline.schema.json
@@ -50,7 +50,7 @@
   ],
   "properties": {
     "version": {
-      "description": "Pipeline wire-format/schema version. SDKs auto-detect: '3' if any executable task uses semantic fields such as task_type or success_criteria; otherwise '2' if any container, mount, dir, or cache resource is used; '1' otherwise.",
+      "description": "Pipeline wire-format/schema version. Required; missing, malformed, or unsupported values are rejected. SDKs auto-detect: '3' if any executable task uses semantic fields such as task_type or success_criteria; otherwise '2' if any container, mount, dir, or cache resource is used; '1' otherwise.",
       "enum": [
         "1",
         "2",

--- a/scripts/validate-conformance-schema.py
+++ b/scripts/validate-conformance-schema.py
@@ -22,6 +22,7 @@ except ImportError:
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_PATH = ROOT / "schemas" / "sykli-pipeline.schema.json"
 CASES_DIR = ROOT / "tests" / "conformance" / "cases"
+INVALID_CASES_DIR = ROOT / "tests" / "conformance" / "schema-invalid"
 
 
 def load_json(path: Path) -> object:
@@ -76,6 +77,25 @@ def main() -> int:
         else:
             print(f"PASS {rel_path}")
             passed += 1
+
+    for path in sorted(INVALID_CASES_DIR.glob("*.json")):
+        rel_path = path.relative_to(ROOT)
+        try:
+            data = load_json(path)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"FAIL {rel_path}")
+            print(f"  could not load JSON: {exc}")
+            failed += 1
+            continue
+
+        errors = sorted(validator.iter_errors(data), key=lambda err: list(err.absolute_path))
+        if errors:
+            print(f"PASS {rel_path} (expected schema rejection)")
+            passed += 1
+        else:
+            print(f"FAIL {rel_path}")
+            print("  invalid fixture unexpectedly passed schema validation")
+            failed += 1
 
     print(f"Summary: {passed} passed, {failed} failed")
     return 0 if failed == 0 else 1

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -10,6 +10,7 @@ tests/conformance/
 │   ├── 01-basic.json   # Expected output for basic pipeline
 │   ├── 02-deps.json    # Expected output for dependencies
 │   └── ...
+├── schema-invalid/     # JSON fixtures expected to fail schema validation
 ├── fixtures/           # Pipeline source per SDK
 │   ├── go/
 │   ├── rust/
@@ -38,3 +39,12 @@ tests/conformance/
 1. Add expected JSON to `cases/<name>.json`
 2. Add pipeline source in each `fixtures/<sdk>/<name>.*` file
 3. Run `./tests/conformance/run.sh <name>` to verify
+
+## Schema validation
+
+`scripts/validate-conformance-schema.py` validates every JSON file in
+`cases/` and verifies every JSON file in `schema-invalid/` is rejected by the
+canonical schema.
+
+`run.sh` also checks that expected and emitted conformance JSON declares a
+supported top-level contract schema version.

--- a/tests/conformance/run.sh
+++ b/tests/conformance/run.sh
@@ -16,6 +16,7 @@ CONF="$ROOT/tests/conformance"
 CASES_DIR="$CONF/cases"
 FIXTURES_DIR="$CONF/fixtures"
 TMP_DIR=$(mktemp -d)
+SUPPORTED_SCHEMA_VERSIONS=("1" "2" "3")
 
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -132,7 +133,27 @@ def normalize(obj):
     return obj
 
 print(json.dumps(normalize(data), sort_keys=True, separators=(',', ':')))
+  "
+}
+
+json_version() {
+  python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+version = data.get('version')
+if not isinstance(version, str):
+    sys.exit(2)
+print(version)
 "
+}
+
+supported_schema_version() {
+  local version="$1"
+  local supported
+  for supported in "${SUPPORTED_SCHEMA_VERSIONS[@]}"; do
+    [[ "$version" == "$supported" ]] && return 0
+  done
+  return 1
 }
 
 # SDK runners — each captures JSON to stdout
@@ -196,6 +217,19 @@ run_case() {
   local expected
   expected=$(normalize_json < "$expected_file")
 
+  local expected_version
+  if ! expected_version=$(json_version < "$expected_file"); then
+    echo -e "  ${RED}✗${NC} $case_name — expected output has missing or malformed version"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if ! supported_schema_version "$expected_version"; then
+    echo -e "  ${RED}✗${NC} $case_name — expected output uses unsupported version $expected_version"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
   local sdks=("go" "python" "typescript" "rust" "elixir")
 
   for sdk in "${sdks[@]}"; do
@@ -236,6 +270,19 @@ run_case() {
     local err_file="$TMP_DIR/err_${sdk}_${case_name}"
 
     if actual_raw=$("run_${sdk}" "$fixture" 2>"$err_file"); then
+      local actual_version
+      if ! actual_version=$(echo "$actual_raw" | json_version); then
+        echo -e "  ${RED}✗${NC} $case_name/$sdk — emitted missing or malformed version"
+        FAIL=$((FAIL + 1))
+        continue
+      fi
+
+      if ! supported_schema_version "$actual_version"; then
+        echo -e "  ${RED}✗${NC} $case_name/$sdk — emitted unsupported version $actual_version"
+        FAIL=$((FAIL + 1))
+        continue
+      fi
+
       actual=$(echo "$actual_raw" | normalize_json)
 
       if [[ "$expected" == "$actual" ]]; then

--- a/tests/conformance/schema-invalid/version-arbitrary-string.json
+++ b/tests/conformance/schema-invalid/version-arbitrary-string.json
@@ -1,0 +1,9 @@
+{
+  "version": "banana",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "echo test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/version-array.json
+++ b/tests/conformance/schema-invalid/version-array.json
@@ -1,0 +1,9 @@
+{
+  "version": [],
+  "tasks": [
+    {
+      "name": "test",
+      "command": "echo test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/version-boolean.json
+++ b/tests/conformance/schema-invalid/version-boolean.json
@@ -1,0 +1,9 @@
+{
+  "version": true,
+  "tasks": [
+    {
+      "name": "test",
+      "command": "echo test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/version-empty-string.json
+++ b/tests/conformance/schema-invalid/version-empty-string.json
@@ -1,0 +1,9 @@
+{
+  "version": "",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "echo test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/version-missing.json
+++ b/tests/conformance/schema-invalid/version-missing.json
@@ -1,0 +1,8 @@
+{
+  "tasks": [
+    {
+      "name": "test",
+      "command": "echo test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/version-null.json
+++ b/tests/conformance/schema-invalid/version-null.json
@@ -1,0 +1,9 @@
+{
+  "version": null,
+  "tasks": [
+    {
+      "name": "test",
+      "command": "echo test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/version-numeric-float.json
+++ b/tests/conformance/schema-invalid/version-numeric-float.json
@@ -1,0 +1,9 @@
+{
+  "version": 0.1,
+  "tasks": [
+    {
+      "name": "test",
+      "command": "echo test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/version-numeric-integer.json
+++ b/tests/conformance/schema-invalid/version-numeric-integer.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "tasks": [
+    {
+      "name": "test",
+      "command": "echo test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/version-object.json
+++ b/tests/conformance/schema-invalid/version-object.json
@@ -1,0 +1,9 @@
+{
+  "version": {},
+  "tasks": [
+    {
+      "name": "test",
+      "command": "echo test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/version-unsupported-future.json
+++ b/tests/conformance/schema-invalid/version-unsupported-future.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.2",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "echo test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/version-unsupported-major.json
+++ b/tests/conformance/schema-invalid/version-unsupported-major.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "echo test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/version-whitespace-only.json
+++ b/tests/conformance/schema-invalid/version-whitespace-only.json
@@ -1,0 +1,9 @@
+{
+  "version": "   ",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "echo test"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR makes Sykli enforce contract schema version semantics in the core engine. Contracts must now declare one of the repository supported pipeline wire-format/schema versions: `"1"`, `"2"`, or `"3"`. Missing, empty, malformed, or unsupported versions are rejected with explicit structured errors.

Note: the task prompt mentioned `"0.1"` as a possible current canonical version. This repository already defines the canonical contract versions as `"1"`, `"2"`, and `"3"` in the schema, SDKs, conformance fixtures, and docs, so this PR preserves and enforces that existing contract instead of introducing a new `"0.1"` version.

## Why

Sykli is a contract layer. The engine must not ignore the contract version. Without explicit version enforcement, SDKs and agents can emit contracts the engine does not actually understand, and future versions could be silently treated as older documents.

## What changed

- Added `Sykli.ContractSchemaVersion` as the single core policy for supported versions, current version, validation, and error formatting.
- Enforced version validation in `Sykli.Graph.parse/1` before task parsing.
- Enforced version validation in `Sykli.Validate.validate_json/1` with structured validation errors.
- Removed the previous silent default-to-`"1"` behavior for missing versions.
- Added positive core coverage for supported versions `"1"`, `"2"`, and `"3"`.
- Added negative core coverage for missing, null, empty string, numeric, boolean, array, object, unsupported future, unsupported major, and arbitrary string versions.
- Added schema-negative fixtures under `tests/conformance/schema-invalid/` for malformed and unsupported versions.
- Updated `scripts/validate-conformance-schema.py` to validate positive fixtures and assert negative schema fixtures are rejected.
- Updated `tests/conformance/run.sh` to check that both expected and SDK-emitted JSON declare a supported schema version.
- Updated README/docs to state that unsupported versions are rejected and future versions require explicit engine support.

## Validation

- [x] Schema JSON valid: `python3 -c "import json; json.load(open("schemas/sykli-pipeline.schema.json"))"` passed.
- [x] Schema fixtures passed: `python3 scripts/validate-conformance-schema.py` -> `Summary: 35 passed, 0 failed` (24 valid fixtures + 11 expected schema rejections).
- [x] Focused core parser/validator tests passed: `cd core && mix test test/core_test.exs test/sykli/validate_test.exs` -> `78 tests, 0 failures`.
- [x] Focused AI-native parser regression passed: `cd core && mix test test/sykli/graph/ai_native_test.exs` -> `7 tests, 0 failures`.
- [x] Full conformance passed: `env GOCACHE=/private/tmp/sykli-go-build SYKLI_CONFORMANCE_PYTHON=python3.14 tests/conformance/run.sh` -> `145 passed, 0 failed, 0 skipped`.
- [x] Core tests passed: `cd core && mix test` -> `1 property, 1492 tests, 0 failures, 1 skipped (13 excluded)`.
- [x] Go SDK tests passed: `cd sdk/go && env GOCACHE=/private/tmp/sykli-go-build go test ./...` -> passed.
- [x] Rust SDK tests passed: `cd sdk/rust && cargo test --lib` -> `111 passed, 0 failed`.
- [x] TypeScript SDK tests passed: `cd sdk/typescript && npx vitest run` -> `84 passed`.
- [x] Elixir SDK tests passed: `cd sdk/elixir && mix test` -> `52 tests, 0 failures`.
- [x] Python SDK tests passed: `cd sdk/python && env PYTHONPATH=src python3.14 -m pytest` -> `208 passed`.
- [x] Diff hygiene passed: `git diff --check` passed.

## Known notes

The conformance harness still reports the known embedded schema-validation skip under `python3.14` because that interpreter lacks `jsonschema`:

```text
Schema Validation
⚠ skipped — jsonschema package not installed for python3.14
```

Standalone schema validation was run with local `python3` and passed (`35 passed, 0 failed`). Full SDK conformance still passed (`145 passed, 0 failed, 0 skipped`).

## Out of scope

- Target-level `success_criteria` enforcement is intentionally not included.
- Review/gate/verify semantic normalization is intentionally not included.
- No runtime behavior, target behavior, or SDK feature expansion was attempted.
- No new contract fields were added.
- No compatibility mode for unknown future versions was introduced.

## Next recommended PR

The next recommended PR is target-level `success_criteria` enforcement, where the executor orchestrates criteria evaluation but each target evaluates criteria in its own execution context.