### PR TITLE
Add target-level success_criteria enforcement

### DIFF
--- a/core/lib/sykli/cache.ex
+++ b/core/lib/sykli/cache.ex
@@ -172,6 +172,10 @@ defmodule Sykli.Cache do
   def format_miss_reason(:corrupted), do: "cache corrupted"
   def format_miss_reason(:blobs_missing), do: "outputs missing"
   def format_miss_reason(:config_changed), do: "config changed"
+
+  def format_miss_reason(:success_criteria_requires_execution),
+    do: "success criteria require execution"
+
   def format_miss_reason(other), do: "#{other}"
 
   @doc """

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -309,12 +309,14 @@ defmodule Sykli.CLI do
   end
 
   defp task_result_to_map(%Sykli.Executor.TaskResult{} = r) do
-    base = %{
-      name: r.name,
-      status: Atom.to_string(r.status),
-      duration_ms: r.duration_ms,
-      cached: r.status == :cached
-    }
+    base =
+      %{
+        name: r.name,
+        status: Atom.to_string(r.status),
+        duration_ms: r.duration_ms,
+        cached: r.status == :cached
+      }
+      |> maybe_add_success_criteria_results(r.success_criteria_results)
 
     case r.error do
       %Sykli.Error{} = err ->
@@ -326,6 +328,25 @@ defmodule Sykli.CLI do
       other ->
         Map.put(base, :error, %{code: "unknown", message: inspect(other), hints: []})
     end
+  end
+
+  defp maybe_add_success_criteria_results(base, []), do: base
+
+  defp maybe_add_success_criteria_results(base, results) do
+    Map.put(base, :success_criteria_results, Enum.map(results, &success_criteria_result_to_map/1))
+  end
+
+  defp success_criteria_result_to_map(result) do
+    %{
+      index: result.index,
+      type: result.type,
+      status: Atom.to_string(result.status),
+      message: result.message,
+      target: result.target,
+      evidence: result.evidence
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
   end
 
   @doc false

--- a/core/lib/sykli/error.ex
+++ b/core/lib/sykli/error.ex
@@ -9,15 +9,15 @@ defmodule Sykli.Error do
   - Actionable hints for every error
   - Visual consistency across the CLI
 
-   ## Error Codes
+  ## Error Codes
 
-   | Code | Category | Description |
-   |------|----------|-------------|
-   | task_failed | execution | Task command failed |
-   | task_timeout | execution | Task timed out |
-   | success_criteria_failed | execution | Declared success criteria failed |
-   | unsupported_success_criteria_for_target | execution | Target cannot evaluate declared success criteria |
-   | missing_secrets | execution | Missing secrets |
+  | Code | Category | Description |
+  |------|----------|-------------|
+  | task_failed | execution | Task command failed |
+  | task_timeout | execution | Task timed out |
+  | success_criteria_failed | execution | Declared success criteria failed |
+  | unsupported_success_criteria_for_target | execution | Target cannot evaluate declared success criteria |
+  | missing_secrets | execution | Missing secrets |
   | dependency_cycle | validation | Circular dependency in task graph |
   | invalid_service | validation | Invalid service config |
   | invalid_mount | validation | Invalid mount config |

--- a/core/lib/sykli/error.ex
+++ b/core/lib/sykli/error.ex
@@ -9,13 +9,15 @@ defmodule Sykli.Error do
   - Actionable hints for every error
   - Visual consistency across the CLI
 
-  ## Error Codes
+   ## Error Codes
 
-  | Code | Category | Description |
-  |------|----------|-------------|
-  | task_failed | execution | Task command failed |
-  | task_timeout | execution | Task timed out |
-  | missing_secrets | execution | Missing secrets |
+   | Code | Category | Description |
+   |------|----------|-------------|
+   | task_failed | execution | Task command failed |
+   | task_timeout | execution | Task timed out |
+   | success_criteria_failed | execution | Declared success criteria failed |
+   | unsupported_success_criteria_for_target | execution | Target cannot evaluate declared success criteria |
+   | missing_secrets | execution | Missing secrets |
   | dependency_cycle | validation | Circular dependency in task graph |
   | invalid_service | validation | Invalid service config |
   | invalid_mount | validation | Invalid mount config |
@@ -168,6 +170,50 @@ defmodule Sykli.Error do
         "check for infinite loops or blocking operations"
       ],
       notes: []
+    }
+  end
+
+  @doc """
+  success_criteria_failed: Task command succeeded, but declared criteria did not.
+  """
+  def success_criteria_failed(task, results, opts \\ []) do
+    failures = Sykli.SuccessCriteria.failures(results)
+
+    %__MODULE__{
+      code: "success_criteria_failed",
+      type: :execution,
+      message: "task '#{task}' failed success_criteria",
+      task: task,
+      step: :run,
+      command: Keyword.get(opts, :command),
+      output: Keyword.get(opts, :output),
+      duration_ms: Keyword.get(opts, :duration_ms),
+      hints: [
+        "inspect the failed success_criteria and update the task command or contract"
+      ],
+      notes: criterion_notes(failures)
+    }
+  end
+
+  @doc """
+  unsupported_success_criteria_for_target: Target cannot evaluate criteria.
+  """
+  def unsupported_success_criteria_for_target(task, target_name, results, opts \\ []) do
+    %__MODULE__{
+      code: "unsupported_success_criteria_for_target",
+      type: :execution,
+      message:
+        "target '#{target_name}' does not support success_criteria evaluation for task '#{task}'",
+      task: task,
+      step: :run,
+      command: Keyword.get(opts, :command),
+      output: Keyword.get(opts, :output),
+      duration_ms: Keyword.get(opts, :duration_ms),
+      hints: [
+        "run this task on a target that can evaluate the declared success_criteria",
+        "or remove success_criteria that this target cannot evaluate"
+      ],
+      notes: criterion_notes(results)
     }
   end
 
@@ -676,6 +722,30 @@ defmodule Sykli.Error do
   # ─────────────────────────────────────────────────────────────────────────────
   # HINT GENERATION (from ErrorHints)
   # ─────────────────────────────────────────────────────────────────────────────
+
+  defp criterion_notes(results) do
+    Enum.map(results, fn result ->
+      details =
+        result.evidence
+        |> format_criterion_evidence()
+        |> case do
+          "" -> ""
+          evidence -> " (#{evidence})"
+        end
+
+      "success_criteria[#{result.index}] #{result.type}: #{result.status} - #{result.message}#{details}"
+    end)
+  end
+
+  defp format_criterion_evidence(nil), do: ""
+
+  defp format_criterion_evidence(evidence) when is_map(evidence) do
+    evidence
+    |> Enum.map(fn {key, value} -> "#{key}=#{inspect(value)}" end)
+    |> Enum.join(", ")
+  end
+
+  defp format_criterion_evidence(evidence), do: inspect(evidence)
 
   defp generate_hints(exit_code, output) do
     hints = []

--- a/core/lib/sykli/executor.ex
+++ b/core/lib/sykli/executor.ex
@@ -48,7 +48,15 @@ defmodule Sykli.Executor do
     """
 
     @enforce_keys [:name, :status, :duration_ms]
-    defstruct [:name, :status, :duration_ms, :error, :output, :command]
+    defstruct [
+      :name,
+      :status,
+      :duration_ms,
+      :error,
+      :output,
+      :command,
+      success_criteria_results: []
+    ]
 
     @type status :: :passed | :failed | :errored | :cached | :skipped | :blocked
     @type t :: %__MODULE__{
@@ -57,7 +65,8 @@ defmodule Sykli.Executor do
             duration_ms: non_neg_integer(),
             error: term() | nil,
             output: String.t() | nil,
-            command: String.t() | nil
+            command: String.t() | nil,
+            success_criteria_results: [Sykli.SuccessCriteria.Result.t()]
           }
   end
 
@@ -663,8 +672,16 @@ defmodule Sykli.Executor do
     prefix = progress_prefix(progress)
     workdir = state.workdir
 
-    # Check cache first using CacheService
-    case CacheService.check_and_restore(task, workdir) do
+    # A cached task result cannot currently prove target-owned success criteria
+    # in the execution context, so tasks with criteria run and verify normally.
+    cache_lookup =
+      if Sykli.Graph.Task.success_criteria(task) == [] do
+        CacheService.check_and_restore(task, workdir)
+      else
+        {:miss, nil, :success_criteria_requires_execution}
+      end
+
+    case cache_lookup do
       {:hit, cache_key} ->
         Output.task_cached(prefix, task.name)
 
@@ -677,7 +694,8 @@ defmodule Sykli.Executor do
           status: :cached,
           duration_ms: duration,
           error: nil,
-          command: task.command
+          command: task.command,
+          success_criteria_results: []
         }
 
       {:miss, cache_key, reason} ->
@@ -757,10 +775,11 @@ defmodule Sykli.Executor do
       result when result == :ok or (is_tuple(result) and elem(result, 0) == :ok) ->
         duration = System.monotonic_time(:millisecond) - start_time
 
-        output =
+        {output, success_criteria_results} =
           case result do
-            {:ok, out} -> out
-            :ok -> nil
+            {:ok, out, criteria_results} -> {out, criteria_results}
+            {:ok, out} -> {out, []}
+            :ok -> {nil, []}
           end
 
         %TaskResult{
@@ -769,8 +788,27 @@ defmodule Sykli.Executor do
           duration_ms: duration,
           error: nil,
           output: output,
-          command: task.command
+          command: task.command,
+          success_criteria_results: success_criteria_results
         }
+
+      {:error, reason, _success_criteria_results} when attempt < max_attempts ->
+        Output.task_retrying(task.name, attempt, max_attempts)
+
+        maybe_emit_task_retrying(task.name, attempt, max_attempts, reason, run_id, chain_id)
+
+        do_run_with_retry(
+          task,
+          state,
+          cache_key,
+          attempt + 1,
+          max_attempts,
+          progress,
+          target,
+          start_time,
+          run_id,
+          chain_id
+        )
 
       {:error, reason} when attempt < max_attempts ->
         Output.task_retrying(task.name, attempt, max_attempts)
@@ -790,6 +828,25 @@ defmodule Sykli.Executor do
           chain_id
         )
 
+      {:error, reason, success_criteria_results} ->
+        duration = System.monotonic_time(:millisecond) - start_time
+
+        output =
+          case reason do
+            %Sykli.Error{output: out} when is_binary(out) -> out
+            _ -> nil
+          end
+
+        %TaskResult{
+          name: task.name,
+          status: :failed,
+          duration_ms: duration,
+          error: reason,
+          output: output,
+          command: task.command,
+          success_criteria_results: success_criteria_results
+        }
+
       {:error, reason} ->
         duration = System.monotonic_time(:millisecond) - start_time
 
@@ -806,7 +863,8 @@ defmodule Sykli.Executor do
           duration_ms: duration,
           error: reason,
           output: output,
-          command: task.command
+          command: task.command,
+          success_criteria_results: []
         }
     end
   end
@@ -849,20 +907,42 @@ defmodule Sykli.Executor do
 
           case result do
             {:ok, output} ->
-              if cache_key do
-                Sykli.Cache.store(cache_key, task, outputs || [], duration_ms, workdir)
-              end
+              case evaluate_success_criteria(
+                     task,
+                     target,
+                     state,
+                     run_opts,
+                     0,
+                     output,
+                     duration_ms
+                   ) do
+                {:ok, success_criteria_results} ->
+                  if cache_key do
+                    Sykli.Cache.store(cache_key, task, outputs || [], duration_ms, workdir)
+                  end
 
-              maybe_github_status(name, "success")
-              {:ok, output}
+                  maybe_github_status(name, "success")
+                  {:ok, output, success_criteria_results}
+
+                {:error, reason, success_criteria_results} ->
+                  maybe_github_status(name, "failure")
+                  {:error, reason, success_criteria_results}
+              end
 
             :ok ->
-              if cache_key do
-                Sykli.Cache.store(cache_key, task, outputs || [], duration_ms, workdir)
-              end
+              case evaluate_success_criteria(task, target, state, run_opts, 0, nil, duration_ms) do
+                {:ok, success_criteria_results} ->
+                  if cache_key do
+                    Sykli.Cache.store(cache_key, task, outputs || [], duration_ms, workdir)
+                  end
 
-              maybe_github_status(name, "success")
-              :ok
+                  maybe_github_status(name, "success")
+                  {:ok, nil, success_criteria_results}
+
+                {:error, reason, success_criteria_results} ->
+                  maybe_github_status(name, "failure")
+                  {:error, reason, success_criteria_results}
+              end
 
             {:error, reason} ->
               maybe_github_status(name, "failure")
@@ -876,6 +956,46 @@ defmodule Sykli.Executor do
       {:error, reason} ->
         Output.service_start_failed(name, reason)
         {:error, {:service_start_failed, reason}}
+    end
+  end
+
+  defp evaluate_success_criteria(task, target, state, run_opts, exit_code, output, duration_ms) do
+    criteria = Sykli.Graph.Task.success_criteria(task)
+
+    if criteria == [] do
+      {:ok, []}
+    else
+      opts =
+        run_opts
+        |> Keyword.put(:command_exit_code, exit_code)
+        |> Keyword.put(:command_output, output)
+        |> Keyword.put(:duration_ms, duration_ms)
+
+      if function_exported?(target, :evaluate_success_criteria, 4) do
+        target.evaluate_success_criteria(task, criteria, state, opts)
+      else
+        target_name = target_name(target)
+        message = "target does not support success_criteria evaluation"
+        results = Sykli.SuccessCriteria.unsupported_results(criteria, target_name, message)
+
+        {:error,
+         Sykli.Error.unsupported_success_criteria_for_target(
+           task.name,
+           target_name,
+           results,
+           command: task.command,
+           output: output,
+           duration_ms: duration_ms
+         ), results}
+      end
+    end
+  end
+
+  defp target_name(target) do
+    if function_exported?(target, :name, 0) do
+      target.name()
+    else
+      inspect(target)
     end
   end
 

--- a/core/lib/sykli/executor/mesh.ex
+++ b/core/lib/sykli/executor/mesh.ex
@@ -151,6 +151,17 @@ defmodule Sykli.Executor.Mesh do
     end
   end
 
+  @impl true
+  def evaluate_success_criteria(task, criteria, _state, _opts) do
+    message = "target does not support success_criteria evaluation"
+    results = Sykli.SuccessCriteria.unsupported_results(criteria, name(), message)
+
+    {:error,
+     Sykli.Error.unsupported_success_criteria_for_target(task.name, name(), results,
+       command: task.command
+     ), results}
+  end
+
   # Build a map of node -> capabilities for NodeSelector
   defp build_capabilities_map(nodes) do
     nodes

--- a/core/lib/sykli/success_criteria.ex
+++ b/core/lib/sykli/success_criteria.ex
@@ -1,10 +1,29 @@
 defmodule Sykli.SuccessCriteria do
   @moduledoc """
-  Shared validation for success_criteria metadata in the semantic pipeline contract.
-
-  This module validates declared criteria only. It does not evaluate them during
-  task execution.
+  Shared validation and result helpers for success_criteria in the semantic
+  pipeline contract.
   """
+
+  defmodule Result do
+    @moduledoc """
+    Result of evaluating one success criterion in a target-owned execution
+    context.
+    """
+
+    @enforce_keys [:index, :type, :status, :message]
+    defstruct [:index, :type, :status, :message, :evidence, :target]
+
+    @type status :: :passed | :failed | :unsupported
+
+    @type t :: %__MODULE__{
+            index: non_neg_integer(),
+            type: String.t(),
+            status: status(),
+            message: String.t(),
+            evidence: map() | nil,
+            target: String.t() | nil
+          }
+  end
 
   @types ~w(exit_code file_exists file_non_empty)
   @exit_code_range 0..255
@@ -48,6 +67,35 @@ defmodule Sykli.SuccessCriteria do
 
   @spec format_error(term()) :: String.t()
   def format_error(reason), do: "Error: #{message(reason)}"
+
+  @spec passed?(Result.t()) :: boolean()
+  def passed?(%Result{status: :passed}), do: true
+  def passed?(%Result{}), do: false
+
+  @spec failures([Result.t()]) :: [Result.t()]
+  def failures(results) do
+    Enum.reject(results, &passed?/1)
+  end
+
+  @spec unsupported_results(
+          [map()],
+          String.t() | nil,
+          String.t()
+        ) :: [Result.t()]
+  def unsupported_results(criteria, target_name, message) do
+    criteria
+    |> Enum.with_index()
+    |> Enum.map(fn {criterion, index} ->
+      %Result{
+        index: index,
+        type: Map.get(criterion, "type", "unknown"),
+        status: :unsupported,
+        message: message,
+        evidence: criterion,
+        target: target_name
+      }
+    end)
+  end
 
   @spec message(term()) :: String.t()
   def message({:success_criteria_on_review, task_name}) do

--- a/core/lib/sykli/target/behaviour.ex
+++ b/core/lib/sykli/target/behaviour.ex
@@ -184,6 +184,31 @@ defmodule Sykli.Target.Behaviour do
   @callback run_task(task_spec(), state(), run_opts()) ::
               :ok | {:ok, String.t()} | {:error, term()}
 
+  @doc """
+  Evaluates declared success criteria in the target-owned execution context.
+
+  This callback is called only after the task command itself succeeds. Targets
+  must evaluate criteria relative to their own filesystem/runtime model. A
+  target that cannot evaluate a criterion must return an unsupported result;
+  the executor treats unsupported criteria as task failure.
+
+  Options include the run_task/3 options plus:
+
+  - `:command_exit_code` - Exit code observed by the target, when available
+  - `:command_output` - Captured command output, when available
+  - `:duration_ms` - Command execution duration, when available
+  """
+  @callback evaluate_success_criteria(
+              task_spec(),
+              [map()],
+              state(),
+              run_opts()
+            ) ::
+              {:ok, [Sykli.SuccessCriteria.Result.t()]}
+              | {:error, Sykli.Error.t(), [Sykli.SuccessCriteria.Result.t()]}
+
+  @optional_callbacks evaluate_success_criteria: 4
+
   # ─────────────────────────────────────────────────────────────────────────────
   # SECRETS
   # ─────────────────────────────────────────────────────────────────────────────

--- a/core/lib/sykli/target/k8s.ex
+++ b/core/lib/sykli/target/k8s.ex
@@ -128,6 +128,17 @@ defmodule Sykli.Target.K8s do
     :ok
   end
 
+  @impl true
+  def evaluate_success_criteria(task, criteria, _state, _opts) do
+    message = "target does not support success_criteria evaluation"
+    results = Sykli.SuccessCriteria.unsupported_results(criteria, name(), message)
+
+    {:error,
+     Sykli.Error.unsupported_success_criteria_for_target(task.name, name(), results,
+       command: task.command
+     ), results}
+  end
+
   # ─────────────────────────────────────────────────────────────────────────────
   # SECRETS
   # ─────────────────────────────────────────────────────────────────────────────

--- a/core/lib/sykli/target/local.ex
+++ b/core/lib/sykli/target/local.ex
@@ -54,6 +54,8 @@ defmodule Sykli.Target.Local do
 
   @behaviour Sykli.Target.Behaviour
 
+  alias Sykli.SuccessCriteria.Result
+
   defstruct [:workdir, :runtime, :containerless_runtime, :timeout_ms]
 
   # ─────────────────────────────────────────────────────────────────────────────
@@ -347,6 +349,44 @@ defmodule Sykli.Target.Local do
     end
   end
 
+  @impl true
+  def evaluate_success_criteria(task, criteria, state, opts) do
+    base_workdir = Keyword.get(opts, :workdir, state.workdir)
+    target_workdir = resolved_task_workdir(task, base_workdir)
+    command_exit_code = Keyword.get(opts, :command_exit_code, 0)
+
+    results =
+      criteria
+      |> Enum.with_index()
+      |> Enum.map(fn {criterion, index} ->
+        evaluate_success_criterion(criterion, index, task, target_workdir, command_exit_code)
+      end)
+
+    case Sykli.SuccessCriteria.failures(results) do
+      [] ->
+        {:ok, results}
+
+      failures ->
+        error =
+          if Enum.any?(failures, &(&1.status == :unsupported)) do
+            Sykli.Error.unsupported_success_criteria_for_target(
+              task.name,
+              name(),
+              failures,
+              command: task.command
+            )
+          else
+            Sykli.Error.success_criteria_failed(
+              task.name,
+              failures,
+              command: task.command
+            )
+          end
+
+        {:error, error, results}
+    end
+  end
+
   # ─────────────────────────────────────────────────────────────────────────────
   # EXECUTION PARAMS
   # ─────────────────────────────────────────────────────────────────────────────
@@ -362,6 +402,160 @@ defmodule Sykli.Target.Local do
     mounts = build_mounts(task.mounts || [], abs_workdir)
     display = "[#{task.container}] #{task.command}"
     {state.runtime, task.container, mounts, display}
+  end
+
+  defp resolved_task_workdir(%{container: nil, workdir: task_workdir}, base_workdir)
+       when is_binary(task_workdir) and task_workdir != "" do
+    Path.join(base_workdir, task_workdir) |> Path.expand()
+  end
+
+  defp resolved_task_workdir(_task, base_workdir), do: Path.expand(base_workdir)
+
+  defp evaluate_success_criterion(
+         %{"type" => "exit_code", "equals" => expected},
+         index,
+         _task,
+         _workdir,
+         actual
+       ) do
+    if actual == expected do
+      criterion_passed(index, "exit_code", "exit code matched #{expected}", %{
+        expected: expected,
+        actual: actual
+      })
+    else
+      criterion_failed(index, "exit_code", "expected exit code #{expected}, got #{actual}", %{
+        expected: expected,
+        actual: actual
+      })
+    end
+  end
+
+  defp evaluate_success_criterion(
+         %{"type" => type, "path" => path},
+         index,
+         %{container: nil},
+         workdir,
+         _actual
+       )
+       when type in ["file_exists", "file_non_empty"] do
+    with {:ok, resolved_path} <- resolve_criterion_path(path, workdir),
+         {:ok, stat} <- stat_regular_file(resolved_path, path) do
+      evaluate_file_criterion(type, index, path, resolved_path, stat)
+    else
+      {:error, message, evidence} ->
+        criterion_failed(index, type, message, evidence)
+    end
+  end
+
+  defp evaluate_success_criterion(
+         %{"type" => type, "path" => path},
+         index,
+         %{container: container},
+         _workdir,
+         _actual
+       )
+       when type in ["file_exists", "file_non_empty"] and is_binary(container) do
+    criterion_unsupported(
+      index,
+      type,
+      "local target cannot evaluate #{type} inside container runtime #{inspect(container)}",
+      %{path: path, container: container}
+    )
+  end
+
+  defp evaluate_success_criterion(%{"type" => type} = criterion, index, _task, _workdir, _actual) do
+    criterion_unsupported(
+      index,
+      type,
+      "unsupported success_criteria type #{inspect(type)}",
+      criterion
+    )
+  end
+
+  defp resolve_criterion_path(path, workdir) do
+    cond do
+      Path.type(path) == :absolute ->
+        {:error, "path must be relative to task workdir", %{path: path}}
+
+      true ->
+        resolved = Path.expand(Path.join(workdir, path))
+
+        if path_within?(resolved, Path.expand(workdir)) do
+          {:ok, resolved}
+        else
+          {:error, "path escapes task workdir", %{path: path}}
+        end
+    end
+  end
+
+  defp stat_regular_file(resolved_path, path) do
+    case File.stat(resolved_path) do
+      {:ok, %{type: :regular} = stat} ->
+        {:ok, stat}
+
+      {:ok, %{type: type}} ->
+        {:error, "path is not a regular file", %{path: path, file_type: type}}
+
+      {:error, reason} ->
+        {:error, "file not found", %{path: path, reason: reason}}
+    end
+  end
+
+  defp evaluate_file_criterion("file_exists", index, path, resolved_path, _stat) do
+    criterion_passed(index, "file_exists", "file exists", %{
+      path: path,
+      resolved_path: resolved_path
+    })
+  end
+
+  defp evaluate_file_criterion("file_non_empty", index, path, resolved_path, %{size: size}) do
+    if size > 0 do
+      criterion_passed(index, "file_non_empty", "file is non-empty", %{
+        path: path,
+        resolved_path: resolved_path,
+        size: size
+      })
+    else
+      criterion_failed(index, "file_non_empty", "file is empty", %{
+        path: path,
+        resolved_path: resolved_path,
+        size: size
+      })
+    end
+  end
+
+  defp criterion_passed(index, type, message, evidence) do
+    %Result{
+      index: index,
+      type: type,
+      status: :passed,
+      message: message,
+      evidence: evidence,
+      target: name()
+    }
+  end
+
+  defp criterion_failed(index, type, message, evidence) do
+    %Result{
+      index: index,
+      type: type,
+      status: :failed,
+      message: message,
+      evidence: evidence,
+      target: name()
+    }
+  end
+
+  defp criterion_unsupported(index, type, message, evidence) do
+    %Result{
+      index: index,
+      type: type,
+      status: :unsupported,
+      message: message,
+      evidence: evidence,
+      target: name()
+    }
   end
 
   defp build_mounts(mounts, abs_workdir) do

--- a/core/lib/sykli/target/local.ex
+++ b/core/lib/sykli/target/local.ex
@@ -468,7 +468,7 @@ defmodule Sykli.Target.Local do
     criterion_unsupported(
       index,
       type,
-      "unsupported success_criteria type #{inspect(type)}",
+      "unrecognized success_criteria type #{inspect(type)}",
       criterion
     )
   end
@@ -490,9 +490,12 @@ defmodule Sykli.Target.Local do
   end
 
   defp stat_regular_file(resolved_path, path) do
-    case File.stat(resolved_path) do
+    case File.lstat(resolved_path) do
       {:ok, %{type: :regular} = stat} ->
         {:ok, stat}
+
+      {:ok, %{type: :symlink}} ->
+        {:error, "symlinks are not supported for success_criteria paths", %{path: path}}
 
       {:ok, %{type: type}} ->
         {:error, "path is not a regular file", %{path: path, file_type: type}}

--- a/core/test/sykli/executor/success_criteria_enforcement_test.exs
+++ b/core/test/sykli/executor/success_criteria_enforcement_test.exs
@@ -305,6 +305,38 @@ defmodule Sykli.Executor.SuccessCriteriaEnforcementTest do
             ]} = Executor.run([task], graph(task), target: Local, workdir: workdir)
   end
 
+  test "file criteria reject symlinks instead of following them outside workdir", %{
+    workdir: workdir
+  } do
+    outside = Path.join(System.tmp_dir!(), "sykli-outside-#{System.unique_integer([:positive])}")
+    File.write!(outside, "outside")
+
+    on_exit(fn -> File.rm(outside) end)
+
+    File.ln_s!(outside, Path.join(workdir, "inside-link.txt"))
+
+    task =
+      task("symlink-file",
+        command: "echo ok",
+        success_criteria: [%{"type" => "file_exists", "path" => "inside-link.txt"}]
+      )
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "success_criteria_failed"},
+                success_criteria_results: [
+                  %Result{
+                    type: "file_exists",
+                    status: :failed,
+                    message: "symlinks are not supported for success_criteria paths"
+                  }
+                ]
+              }
+            ]} = Executor.run([task], graph(task), target: Local, workdir: workdir)
+  end
+
   defp task(name, opts) do
     struct!(
       Task,

--- a/core/test/sykli/executor/success_criteria_enforcement_test.exs
+++ b/core/test/sykli/executor/success_criteria_enforcement_test.exs
@@ -1,0 +1,327 @@
+defmodule Sykli.Executor.SuccessCriteriaEnforcementTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.Error
+  alias Sykli.Executor
+  alias Sykli.Executor.TaskResult
+  alias Sykli.Graph.Task
+  alias Sykli.SuccessCriteria.Result
+  alias Sykli.Target.Local
+
+  defmodule UnsupportedTarget do
+    @behaviour Sykli.Target.Behaviour
+
+    @impl true
+    def name, do: "unsupported"
+
+    @impl true
+    def available?, do: {:ok, %{mode: :test}}
+
+    @impl true
+    def setup(opts), do: {:ok, %{workdir: Keyword.get(opts, :workdir, ".")}}
+
+    @impl true
+    def teardown(_state), do: :ok
+
+    @impl true
+    def resolve_secret(_name, _state), do: {:error, :not_found}
+
+    @impl true
+    def create_volume(_name, _opts, _state),
+      do: {:ok, %{id: "unsupported", host_path: nil, reference: "unsupported"}}
+
+    @impl true
+    def artifact_path(_task, _artifact, _workdir, _state), do: "/unsupported/path"
+
+    @impl true
+    def copy_artifact(_src, _dest, _workdir, _state), do: :ok
+
+    @impl true
+    def start_services(_name, _services, _state), do: {:ok, nil}
+
+    @impl true
+    def stop_services(_info, _state), do: :ok
+
+    @impl true
+    def run_task(_task, _state, _opts), do: :ok
+  end
+
+  setup do
+    workdir =
+      Path.join(System.tmp_dir!(), "sykli-success-criteria-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(workdir)
+
+    on_exit(fn -> File.rm_rf!(workdir) end)
+
+    {:ok, workdir: workdir}
+  end
+
+  test "local target passes when file_exists criterion is satisfied", %{workdir: workdir} do
+    task =
+      task("produce-file",
+        command: "printf ok > result.txt",
+        success_criteria: [%{"type" => "file_exists", "path" => "result.txt"}]
+      )
+
+    assert {:ok, [%TaskResult{status: :passed, success_criteria_results: [result]}]} =
+             Executor.run([task], graph(task), target: Local, workdir: workdir)
+
+    assert %Result{type: "file_exists", status: :passed, target: "local"} = result
+  end
+
+  test "local target fails when command exits 0 but file_exists criterion fails", %{
+    workdir: workdir
+  } do
+    task =
+      task("missing-file",
+        command: "echo done",
+        success_criteria: [%{"type" => "file_exists", "path" => "missing.txt"}]
+      )
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "success_criteria_failed"},
+                success_criteria_results: [%Result{type: "file_exists", status: :failed}]
+              }
+            ]} = Executor.run([task], graph(task), target: Local, workdir: workdir)
+  end
+
+  test "success_criteria failure participates in retry behavior", %{workdir: workdir} do
+    task =
+      task("retry-criteria",
+        command: "n=$(cat attempts 2>/dev/null || echo 0); n=$((n + 1)); echo $n > attempts",
+        retry: 1,
+        success_criteria: [%{"type" => "file_exists", "path" => "missing.txt"}]
+      )
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "success_criteria_failed"}
+              }
+            ]} = Executor.run([task], graph(task), target: Local, workdir: workdir)
+
+    assert File.read!(Path.join(workdir, "attempts")) == "2\n"
+  end
+
+  test "local target passes when file_non_empty criterion is satisfied", %{workdir: workdir} do
+    task =
+      task("non-empty",
+        command: "printf ok > result.txt",
+        success_criteria: [%{"type" => "file_non_empty", "path" => "result.txt"}]
+      )
+
+    assert {:ok, [%TaskResult{status: :passed, success_criteria_results: [result]}]} =
+             Executor.run([task], graph(task), target: Local, workdir: workdir)
+
+    assert %Result{type: "file_non_empty", status: :passed} = result
+  end
+
+  test "local target fails when file_non_empty criterion sees an empty file", %{workdir: workdir} do
+    task =
+      task("empty-file",
+        command: "touch result.txt",
+        success_criteria: [%{"type" => "file_non_empty", "path" => "result.txt"}]
+      )
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "success_criteria_failed"},
+                success_criteria_results: [%Result{type: "file_non_empty", status: :failed}]
+              }
+            ]} = Executor.run([task], graph(task), target: Local, workdir: workdir)
+  end
+
+  test "local target evaluates exit_code criteria after command success", %{workdir: workdir} do
+    task =
+      task("exit-code",
+        command: "echo ok",
+        success_criteria: [%{"type" => "exit_code", "equals" => 0}]
+      )
+
+    assert {:ok, [%TaskResult{status: :passed, success_criteria_results: [result]}]} =
+             Executor.run([task], graph(task), target: Local, workdir: workdir)
+
+    assert %Result{type: "exit_code", status: :passed, evidence: %{actual: 0, expected: 0}} =
+             result
+  end
+
+  test "local target fails when exit_code criterion contradicts successful command", %{
+    workdir: workdir
+  } do
+    task =
+      task("wrong-exit-code",
+        command: "echo ok",
+        success_criteria: [%{"type" => "exit_code", "equals" => 1}]
+      )
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "success_criteria_failed"},
+                success_criteria_results: [%Result{type: "exit_code", status: :failed}]
+              }
+            ]} = Executor.run([task], graph(task), target: Local, workdir: workdir)
+  end
+
+  test "task command failure still fails normally and does not report criteria results", %{
+    workdir: workdir
+  } do
+    task =
+      task("command-fails",
+        command: "exit 7",
+        success_criteria: [%{"type" => "exit_code", "equals" => 0}]
+      )
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "task_failed", exit_code: 7},
+                success_criteria_results: []
+              }
+            ]} = Executor.run([task], graph(task), target: Local, workdir: workdir)
+  end
+
+  test "target without criteria evaluator fails explicitly", %{workdir: workdir} do
+    task =
+      task("unsupported-target",
+        command: "echo ok",
+        success_criteria: [%{"type" => "file_exists", "path" => "result.txt"}]
+      )
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "unsupported_success_criteria_for_target"},
+                success_criteria_results: [
+                  %Result{type: "file_exists", status: :unsupported, target: "unsupported"}
+                ]
+              }
+            ]} = Executor.run([task], graph(task), target: UnsupportedTarget, workdir: workdir)
+  end
+
+  test "local container runtime file criteria fail explicitly as unsupported", %{workdir: workdir} do
+    task =
+      task("container-file",
+        command: "echo ok",
+        container: "alpine:latest",
+        success_criteria: [%{"type" => "file_exists", "path" => "result.txt"}]
+      )
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "unsupported_success_criteria_for_target"},
+                success_criteria_results: [
+                  %Result{type: "file_exists", status: :unsupported, target: "local"}
+                ]
+              }
+            ]} =
+             Executor.run([task], graph(task),
+               target: Local,
+               workdir: workdir,
+               runtime: Sykli.Runtime.Fake
+             )
+  end
+
+  test "tasks without success_criteria preserve existing behavior", %{workdir: workdir} do
+    task = task("plain", command: "echo ok")
+
+    assert {:ok, [%TaskResult{status: :passed, success_criteria_results: []}]} =
+             Executor.run([task], graph(task), target: Local, workdir: workdir)
+  end
+
+  test "file criteria are evaluated relative to task workdir", %{workdir: workdir} do
+    File.mkdir_p!(Path.join(workdir, "subdir"))
+
+    task =
+      task("workdir-file",
+        command: "printf ok > result.txt",
+        workdir: "subdir",
+        success_criteria: [%{"type" => "file_exists", "path" => "result.txt"}]
+      )
+
+    assert {:ok, [%TaskResult{status: :passed, success_criteria_results: [result]}]} =
+             Executor.run([task], graph(task), target: Local, workdir: workdir)
+
+    assert result.evidence.resolved_path == Path.join([workdir, "subdir", "result.txt"])
+  end
+
+  test "file criteria cannot escape the resolved task workdir", %{workdir: workdir} do
+    task =
+      task("escape-file",
+        command: "echo ok",
+        success_criteria: [%{"type" => "file_exists", "path" => "../outside.txt"}]
+      )
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "success_criteria_failed"},
+                success_criteria_results: [
+                  %Result{
+                    type: "file_exists",
+                    status: :failed,
+                    message: "path escapes task workdir"
+                  }
+                ]
+              }
+            ]} = Executor.run([task], graph(task), target: Local, workdir: workdir)
+  end
+
+  test "absolute file criteria paths fail instead of checking arbitrary host paths", %{
+    workdir: workdir
+  } do
+    task =
+      task("absolute-file",
+        command: "echo ok",
+        success_criteria: [%{"type" => "file_exists", "path" => "/tmp/sykli-absolute"}]
+      )
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "success_criteria_failed"},
+                success_criteria_results: [
+                  %Result{
+                    type: "file_exists",
+                    status: :failed,
+                    message: "path must be relative to task workdir"
+                  }
+                ]
+              }
+            ]} = Executor.run([task], graph(task), target: Local, workdir: workdir)
+  end
+
+  defp task(name, opts) do
+    struct!(
+      Task,
+      Keyword.merge(
+        [
+          name: name,
+          command: "echo ok",
+          depends_on: [],
+          services: [],
+          outputs: %{},
+          task_inputs: [],
+          success_criteria: []
+        ],
+        opts
+      )
+    )
+  end
+
+  defp graph(%Task{} = task), do: %{task.name => task}
+end

--- a/docs/agent-contract-semantics.md
+++ b/docs/agent-contract-semantics.md
@@ -596,12 +596,16 @@ verification checks against declared status or artifacts. They do not sandbox
 syscalls, network use, filesystem writes, external API calls, or database
 writes.
 
-Phase 3C-1 stores, validates, and emits `success_criteria` only. It does not
-wire criteria into executor result, retry, cache, target, or runtime paths. The
-engine must not silently pretend to enforce criteria before target-level
-checking exists.
+Phase 3C-1 stored, validated, and emitted `success_criteria` only. Enforcement
+begins at the target boundary: the executor orchestrates checks after command
+success, and the target evaluates criteria in the execution context it owns.
+Unsupported targets or runtime combinations must fail explicitly rather than
+silently skipping criteria.
 
-The semantic direction remains engine-checkable verification for Phase 3C-2.
+Local shell execution can evaluate `exit_code`, `file_exists`, and
+`file_non_empty` relative to the resolved task workdir. Container, Kubernetes,
+and remote targets need target-specific implementations because they do not
+share the same filesystem reality as the host.
 
 ### Outputs relationship
 
@@ -666,8 +670,10 @@ Rules:
 
 - `path` is required.
 - `path` must be a string.
-- `path` is relative to the task `workdir` unless it is absolute.
-- The criterion checks existence only.
+- `path` is relative to the task `workdir`.
+- Absolute paths and paths that escape the task workdir are not portable and
+  should be rejected or reported unsupported by enforcing targets.
+- The criterion checks regular-file existence only.
 
 #### `file_non_empty`
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -25,8 +25,10 @@ No cache-prefixed `Sykli.Error` codes are emitted today. Cache failures currentl
 | Code | Description | Tier | Emitted from |
 |------|-------------|------|--------------|
 | `missing_secrets` | A task requires secrets that are not present in the execution environment. | public-stable | `core/lib/sykli/error.ex:181` |
+| `success_criteria_failed` | A task command succeeded, but one or more declared success criteria failed. | public-unstable | `core/lib/sykli/error.ex:183` |
 | `task_failed` | A task command exited non-zero; this is a content failure, not infrastructure failure. | public-stable | `core/lib/sykli/error.ex:137` |
 | `task_timeout` | A task exceeded its configured timeout. | public-stable | `core/lib/sykli/error.ex:159` |
+| `unsupported_success_criteria_for_target` | The active target or runtime cannot evaluate one or more declared success criteria. | public-unstable | `core/lib/sykli/error.ex:203` |
 
 ### github.app
 

--- a/docs/sdk-schema.md
+++ b/docs/sdk-schema.md
@@ -78,7 +78,7 @@ The full canonical field list, with stability labels:
 | `kind` | experimental | no | `"task"` (default) or `"review"` |
 | `command` | stable | conditional | required unless `gate` is set or `kind == "review"` |
 | `task_type` | stable, v3-only | no | executable-task semantic class |
-| `success_criteria` | experimental, v3-only | no | declared executable-task success checks; metadata-only in 3C-1 |
+| `success_criteria` | experimental, v3-only | no | declared executable-task success checks; enforced by targets that support them |
 | `container` | stable | no | triggers v2 |
 | `workdir` | stable | no | |
 | `env` | stable | no | object of string values |
@@ -154,7 +154,7 @@ Allowed values:
 
 ### `success_criteria`
 
-Declared verification metadata for executable task success beyond command
+Declared verification rules for executable task success beyond command
 completion.
 
 Rules:
@@ -163,15 +163,20 @@ Rules:
 - Applies only to executable tasks (`kind` omitted or `kind == "task"`).
 - Rejected on `kind == "review"` nodes.
 - Optional.
-- Criteria are conjunctive: all declared criteria must pass when engine checking
-  is implemented.
-- Does not change execution behavior in Phase 3C-1.
+- Criteria are conjunctive: all declared criteria must pass when evaluated.
+- Criteria may change execution result: if the command succeeds but a criterion
+  fails, the task fails with a `success_criteria` failure.
 - Does not replace `task_type`, review-node `primitive`, or `outputs`.
 
-Phase 3C-1 stores, validates, and emits `success_criteria` as declared
-verification metadata. It is intended to become engine-checked in Phase 3C-2,
-but the engine must not silently pretend to enforce it yet. In 3C-1, no
-executor, retry, cache, target, or runtime behavior changes.
+The executor orchestrates `success_criteria` evaluation after the task command
+succeeds. The target evaluates criteria in the execution context it owns. The
+local shell target currently supports `exit_code`, `file_exists`, and
+`file_non_empty`. Unsupported targets or runtime combinations fail explicitly
+instead of silently skipping declared criteria.
+
+Tasks with `success_criteria` are executed instead of being accepted from cache,
+because a cached result cannot currently prove target-owned criteria in the
+active execution context.
 
 Initial criterion types:
 
@@ -181,6 +186,8 @@ Initial criterion types:
 
 Only one `exit_code` criterion may appear on a task. `equals` must be an
 integer from 0 through 255. File criteria require a non-empty string `path`.
+Enforcing targets evaluate file paths relative to the resolved task workdir;
+absolute paths or paths that escape the workdir are not portable and may fail.
 
 Declared `outputs` are artifact expectations and do not imply success checks.
 To require an output path to exist or be non-empty, declare an explicit


### PR DESCRIPTION
Summary
-------
This PR makes success_criteria enforceable at the target boundary. The executor now orchestrates criteria evaluation after a task command succeeds, while targets evaluate criteria in the execution context they own. Local target support is implemented first, and unsupported target/runtime combinations fail explicitly instead of silently skipping criteria.

Why
---
Sykli is a contract layer. A task cannot be considered successful only because its command exited 0 if the contract declares additional success criteria. The engine must verify that the execution satisfied the contract, or fail clearly when the active target cannot evaluate the criteria.

What changed
------------
- Added a target-level success_criteria evaluation callback.
- Added structured success criterion result objects.
- Implemented local target evaluation for exit_code, file_exists, and file_non_empty.
- Made failed criteria fail the task/run after command success.
- Made unsupported criteria/targets fail explicitly with unsupported_success_criteria_for_target.
- Bypassed cache hits for tasks with success_criteria so cached success does not pretend to prove target-owned checks.
- Added success_criteria result visibility on executor task results and CLI JSON result maps.
- Added focused tests for passing, failing, unsupported, retry, command-failure, no-criteria, path-safety, and workdir behavior.
- Updated docs to describe target-level enforcement semantics.

Validation
----------
- [x] Schema JSON load passed: python3 -c "import json; json.load(open('schemas/sykli-pipeline.schema.json'))"
- [x] Schema fixtures passed: python3 scripts/validate-conformance-schema.py -> 36 passed, 0 failed
- [x] Focused core tests passed: mix test test/sykli/executor/success_criteria_enforcement_test.exs -> 14 tests, 0 failures
- [x] Focused parser/schema tests passed: mix test test/sykli/executor/success_criteria_enforcement_test.exs test/sykli/validate_test.exs test/sykli/graph/ai_native_test.exs -> 55 tests, 0 failures
- [x] Full core suite passed: mix test -> 1 property, 1507 tests, 0 failures, 1 skipped (13 excluded)
- [x] Full conformance passed: env GOCACHE=/private/tmp/sykli-go-build SYKLI_CONFORMANCE_PYTHON=python3.14 tests/conformance/run.sh -> 145 passed, 0 failed, 0 skipped
- [x] Go SDK tests passed: env GOCACHE=/private/tmp/sykli-go-build go test ./...
- [x] Rust SDK tests passed: cargo test --lib -> 111 passed, 0 failed
- [x] TypeScript SDK tests passed: npx vitest run -> 84 passed
- [x] Elixir SDK tests passed: mix test -> 52 tests, 0 failures
- [x] Python SDK tests passed: env PYTHONPATH=src python3.14 -m pytest -> 208 passed
- [x] git diff --check passed

Known notes
-----------
- The conformance harness still reports the known embedded schema-validation skip under python3.14 because that interpreter lacks jsonschema. Standalone schema validation passes with local python3.
- A direct Go test run attempted to use the default Go cache under ~/Library/Caches and hit sandbox permissions. Re-running with GOCACHE=/private/tmp/sykli-go-build passed.
- A direct Python SDK pytest run without PYTHONPATH could not import the local src package. Re-running with PYTHONPATH=src passed.

Out of scope
------------
- Docker/Podman/Kubernetes criteria evaluation is intentionally not implemented.
- Review/gate/verify semantic normalization is intentionally not included.
- Schema version behavior is unchanged.
- No broad runtime redesign was attempted.
- No UI/backend work was included.

Next recommended PR
-------------------
The next recommended PR is to add target-specific criteria support for Docker/Podman/Kubernetes using the same target-level interface.