### PR TITLE
Clarify Sykli's agent execution contract vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 # sykli
 
-**Execution graphs as code.**
+**Execution contracts for agent work.**
 
-sykli lets you define tasks, dependencies, inputs, outputs, and execution logic in a real programming language — Go, Rust, TypeScript, Elixir, or Python — and emit an explicit execution plan that any runner can execute.
+Sykli turns agentic work into typed, versioned, verifiable execution graphs.
+
+Agents can plan, generate, review, and adapt. But their work still needs
+boundaries: what is being run, what it depends on, what environment it needs,
+what success means, what evidence it produced, and what another tool can trust
+afterward.
+
+Sykli is that boundary.
+
+The goal is not to make every action perfectly deterministic. Agent work can be
+nondeterministic by nature. The goal is to make the contract around the action
+as deterministic as possible: typed SDKs, canonical JSON, schema validation,
+explicit versions, explicit dependencies, declared success criteria, and
+structured results.
+
+Sykli makes agent work executable, inspectable, and verifiable without asking
+downstream tools to reverse-engineer prompts, YAML, shell commands, or logs.
 
 ```go
 package main
@@ -14,20 +30,26 @@ func main() {
 
     s.Task("test").
         Run("go test ./...").
-        Inputs("**/*.go")
+        TaskType(sykli.TaskTypeTest).
+        Inputs("**/*.go").
+        SuccessCriteria(sykli.ExitCode(0))
 
     s.Task("build").
         Run("go build -o app").
+        TaskType(sykli.TaskTypeBuild).
         After("test").
-        Outputs("app")
+        Output("binary", "app").
+        SuccessCriteria(
+            sykli.ExitCode(0),
+            sykli.FileExists("app"),
+        )
 
     s.Review("review:api-breakage").
         Primitive("api-breakage").
         Agent("local").
         Diff("main...HEAD").
         Context("README.md", "docs/architecture.md").
-        After("test").
-        Outputs("reviews/api-breakage.json")
+        After("test")
 
     s.Emit()
 }
@@ -43,9 +65,41 @@ sykli · pipeline.go                                local · 0.6.0
   ─  2 passed · 1 review planned                   720ms
 ```
 
-The `review:api-breakage` node is not a shell task. It is a structured review node in the graph: primitive, agent identifier, diff input, context files, dependencies, outputs, and `deterministic: false`.
+The `review:api-breakage` node is not a shell task. It is a structured review
+node in the graph: primitive, agent identifier, context files, dependencies, and
+`deterministic: false`.
 
 ---
+
+## What problem Sykli solves
+
+Modern software work is increasingly performed by agents, automation, and
+remote execution systems, but most pipelines still describe work as shell
+commands glued together by YAML.
+
+That leaves the important parts implicit:
+
+- what kind of work a node performs
+- what it depends on
+- what it is allowed to use
+- what environment it needs
+- what it is expected to produce
+- how success is known
+- what should be reviewed by a human or agent
+- what evidence downstream tools can trust
+
+Sykli makes those implicit contracts explicit.
+
+A Sykli pipeline is not just a list of commands. It is a versioned execution
+contract: a typed graph of executable tasks, review nodes, gates, artifacts,
+resources, success criteria, semantic metadata, and structured runtime evidence.
+
+The engine can run the graph, but execution is only one consumer. Agents, CI
+systems, auditors, release tooling, and MCP clients can all read the same
+contract without reverse-engineering shell scripts or scraping logs.
+
+Sykli's job is to make work understandable before it is executed and verifiable
+after it runs.
 
 ## sykli is not CI
 
@@ -64,57 +118,121 @@ YAML pipelines fail at four things that get worse over time:
 - **Hidden logic.** The actual decision tree is split across `if:` conditionals, `needs:` graphs, matrix expansions, environment files, and the runner's behavior. Reading what will run requires running it.
 - **Vendor lock-in.** GitHub Actions YAML doesn't run on GitLab, doesn't run on CircleCI, doesn't run on your laptop. The pipeline is property of the vendor, not the project.
 
-A pipeline is a program. It deserves a programming language.
+A pipeline is a program. Agent work needs a contract.
 
 ## How it works
 
 ```mermaid
-flowchart LR
-    SDK["SDK file<br/><sub>Go · Rust · TS · Elixir · Python</sub>"]
-    JSON["Pipeline JSON<br/><sub>version 1 · 2 · 3</sub>"]
-    Schema[("sykli-pipeline.<br/>schema.json")]
-    Engine["sykli engine<br/><sub>parse · DAG validate · schedule · execute</sub>"]
-    CLI["Human CLI<br/><sub>● ○ ✕ ─ ⠋</sub>"]
-    Sykli[".sykli/<br/><sub>FALSE Protocol occurrences<br/>SLSA attestations · run history</sub>"]
-    Agents["Agents · MCP server · CI tooling"]
+flowchart TB
+    Human["Human or agent author<br/><sub>intent · constraints · review needs</sub>"]
+    SDK["Typed SDKs<br/><sub>Go · Rust · TypeScript · Elixir · Python</sub>"]
+    Contract["Canonical contract JSON<br/><sub>version 1 · 2 · 3</sub>"]
+    Schema[("Strict schema<br/><sub>sykli-pipeline.schema.json</sub>")]
+    Engine["BEAM engine<br/><sub>parse · validate · schedule · supervise</sub>"]
 
-    SDK -- "--emit" --> JSON
-    JSON -. "canonical contract" .-> Schema
-    JSON --> Engine
-    Engine --> CLI
-    Engine --> Sykli
-    Sykli --> Agents
+    subgraph Graph["Execution contract graph"]
+        Tasks["Executable tasks<br/><sub>command · task_type · inputs · outputs</sub>"]
+        Reviews["Review nodes<br/><sub>primitive · agent · context · deterministic</sub>"]
+        Gates["Gates<br/><sub>approval · timeout · message</sub>"]
+        Criteria["Success criteria<br/><sub>exit_code · file_exists · file_non_empty</sub>"]
+    end
+
+    subgraph Targets["Targets own execution reality"]
+        Local["Local shell"]
+        Containers["Docker / Podman"]
+        K8s["Kubernetes"]
+        Mesh["BEAM mesh"]
+    end
+
+    Evidence["Structured evidence<br/><sub>occurrences · run history · attestations · context</sub>"]
+    Tools["Agents · MCP · CI · auditors<br/><sub>read data, not logs</sub>"]
+
+    Human --> SDK --> Contract
+    Contract --> Schema
+    Schema --> Engine
+    Contract --> Tasks
+    Contract --> Reviews
+    Contract --> Gates
+    Contract --> Criteria
+    Engine --> Tasks
+    Engine --> Reviews
+    Engine --> Gates
+    Engine --> Targets
+    Targets --> Criteria
+    Targets --> Evidence
+    Evidence --> Tools
 
     classDef contract fill:#0d1b2a,stroke:#4ec5d4,color:#e6e6e6,stroke-width:2px;
-    class Schema contract;
+    classDef engine fill:#241a36,stroke:#b085f5,color:#f5f0ff,stroke-width:2px;
+    classDef evidence fill:#14291f,stroke:#65c18c,color:#effff5,stroke-width:2px;
+    class Contract,Schema,Tasks,Reviews,Gates,Criteria contract;
+    class Engine engine;
+    class Evidence evidence;
 ```
 
-1. **Define.** Write your graph in a real language. Use variables, functions, types.
+1. **Author.** Write your graph in a real language. Use variables, functions,
+   types, and SDK validation.
 2. **Emit.** sykli runs your SDK file with `--emit` and reads the resulting JSON. The shape is governed by [`schemas/sykli-pipeline.schema.json`](schemas/sykli-pipeline.schema.json) — the canonical, versioned wire contract.
-3. **Execute.** The engine validates the DAG (cycle detection, schema, capability resolution), schedules tasks level-by-level in parallel, applies caching and retries.
+3. **Execute.** The BEAM engine validates the DAG (cycle detection, schema,
+   capability resolution), schedules tasks level-by-level in parallel, applies
+   caching and retries, and supervises task execution.
 4. **Observe.** Every event becomes a [FALSE Protocol](https://github.com/false-systems) occurrence written to `.sykli/`. AI agents and downstream tools read structured data, not log scrolls.
 
 The engine runs on the BEAM VM. Same code on your laptop, in Docker, on Kubernetes, or across a mesh of nodes.
 
 **Wire-format versions are explicit**, not advisory: `"1"` baseline graphs, `"2"` adds resources/containers/mounts, `"3"` adds agent-native semantic fields starting with `task_type`. SDKs auto-detect from features used, and the engine rejects missing, malformed, or unsupported versions. See [`docs/sdk-schema.md`](docs/sdk-schema.md) for the field-by-field contract.
 
-## Distributed-by-default. Deterministic by design.
+## Why BEAM matters
+
+Sykli is not "a CLI written in Elixir." Sykli uses BEAM because agent execution
+is naturally distributed, concurrent, and failure-heavy work. The VM gives the
+engine the same shape as the problem.
+
+Agent work is not a single command. It is a graph of concurrent, failure-prone,
+partially remote work: tasks run in parallel, reviews may be nondeterministic,
+services need supervision, mesh nodes appear and disappear, retries must be
+isolated, and results must stay structured.
+
+BEAM gives Sykli the right substrate:
+
+- **Lightweight processes** for graph nodes, watchers, services, agents, and
+  background coordinators.
+- **Supervision trees** so task failures become structured events instead of
+  process-wide crashes.
+- **Message passing** for coordination without shared mutable state.
+- **Distribution primitives** for mesh execution without a separate control
+  plane.
+- **Fault isolation** between tasks, runtimes, agents, and background services.
+- **Long-running daemons** that can coordinate local, remote, and CI-triggered
+  work.
+- **Deterministic simulation hooks** around time, randomness, and transport
+  boundaries.
+
+Sykli uses BEAM to make agent execution boring: concurrent by default,
+supervised by default, observable by default.
+
+## Distributed-by-default. Deterministic where possible.
 
 Two properties that pipelines normally trade against each other — running across a fleet, and replaying byte-identically — both fall out of how the engine is built.
 
 - **Mesh execution without a control plane.** Cluster one sykli node onto another and either can pick up the other's tasks. No broker, no separate orchestration tier. The engine *is* the coordinator. `--mesh` and `sykli daemon start` are the user surface; capability-based placement (`requires("gpu")`) routes work to nodes that can run it.
-- **Deterministic replay.** Time, randomness, and I/O are routed through transport APIs; given a seed, runs replay byte-identically. A custom lint (`NoWallClock`) fails on raw `System.monotonic_time` or `:rand.uniform` so determinism doesn't drift.
+- **Deterministic boundaries.** Time, randomness, and I/O are routed through
+  transport APIs where possible. A custom lint (`NoWallClock`) fails on raw
+  `System.monotonic_time` or `:rand.uniform` so deterministic boundaries do not
+  drift.
 - **Supervision = retry semantics.** Each task runs under its own supervisor. A crashed task doesn't take the run with it; the engine sees structured exit and decides to retry, skip, or fail-and-analyze based on the task's `on_fail` declaration.
 
-The engine is built on the BEAM VM. That's what makes a single-process distributed runtime and seedable simulation possible without a second clustering layer. The substrate is incidental; the outcomes aren't.
+The substrate is not incidental. BEAM is what makes a single-process distributed
+runtime and supervised graph executor possible without bolting on a second
+clustering layer.
 
 ## Agentic review as code
 
 SYKLI Reviews are experimental. A review node represents a structured review step in the execution graph; it does not yet run Codex, Claude, or any other provider directly. It models the review step so future runners can execute agents in a controlled, inspectable way.
 
-Builders are available in **all five SDKs** (Go, Rust, TypeScript, Elixir, Python) with byte-equivalent JSON output. The schema rejects task-execution fields (`command`, `outputs`, `services`, `mounts`, `k8s`, `retry`, `timeout`, `task_type`) on review nodes — review primitives and shell tasks have separate, non-overlapping surfaces.
+Builders are available in **all five SDKs** (Go, Rust, TypeScript, Elixir, Python) with byte-equivalent JSON output. The schema rejects task-execution fields (`command`, `outputs`, `services`, `mounts`, `k8s`, `retry`, `timeout`, `task_type`, `success_criteria`) on review nodes — review primitives and shell tasks have separate, non-overlapping surfaces.
 
-Agentic workflows need primitives, not prompts. Asking an LLM to "review this PR" is too underspecified to be repeatable. Defining a review node with constrained inputs, expected outputs, and explicit rules is.
+Agentic workflows need primitives, not prompts. Asking an LLM to "review this PR" is too underspecified to be repeatable. Defining a review node with constrained context, dependencies, and explicit primitive semantics is.
 
 ```go
 s.Review("review:api-breakage").
@@ -122,15 +240,15 @@ s.Review("review:api-breakage").
     Agent("local").
     Diff("main...HEAD").
     Context("README.md", "docs/architecture.md").
-    After("test").
-    Outputs("reviews/api-breakage.json")
+    After("test")
 ```
 
 A review primitive is a node with:
 
 - **Constrained inputs.** A diff range, a directory, a manifest. Not "the whole repo, figure it out."
-- **Expected outputs.** A structured JSON report at a known path. Not freeform commentary.
 - **Explicit rules.** What counts as an api breakage, what counts as a coverage gap, what counts as an architecture-boundary violation.
+- **Separate semantics.** Review nodes do not pretend to be shell tasks and do
+  not emit task outputs in the current canonical contract.
 
 Task nodes model deterministic work such as build and test commands. Review nodes model non-deterministic evaluation work such as agent review; they are `deterministic: false` by default.
 
@@ -142,12 +260,12 @@ Planned primitives: `security-boundaries`, `api-breakage`, `behavior-regression`
 
 | Use case | What sykli gives you |
 |---|---|
-| **Agentic workflows** | Agents are executors; the graph defines what runs, what it depends on, and what it outputs |
+| **Agentic workflows** | Agents are executors; the graph defines what runs, what it depends on, and what evidence it produces |
 | **PR reviews** | Reviews as graph nodes — agents and linters fulfill the same node contract |
 | **Release checks** | SLSA v1.0 provenance attestations per task, signed by the engine, verifiable downstream |
 | **Security validation** | Secret-scoped tasks, OIDC token exchange to cloud providers, SSRF-guarded webhooks |
 | **Infrastructure validation** | Same task graph against `local`, `k8s`, or a self-hosted mesh of nodes |
-| **CI pipelines** | The whole CI graph as code, content-addressed cache, parallel-by-dependency-level execution, deterministic replay |
+| **CI pipelines** | The whole CI graph as code, content-addressed cache, parallel-by-dependency-level execution, deterministic boundaries |
 
 ## Design principles
 
@@ -157,8 +275,8 @@ Planned primitives: `security-boundaries`, `api-breakage`, `behavior-regression`
 - **Portable execution.** Same graph on a laptop, in Docker, on Kubernetes, or across a mesh.
 - **Local-first.** The engine runs on hardware you control. Network features are additive, never required.
 - **No YAML-first.** YAML is a *projection* of the graph for tools that need it, never the source of truth.
-- **Agents are executors, not magic.** A review primitive is a node with constrained inputs and expected outputs. Whatever fulfills the contract — agent, linter, classifier — is interchangeable.
-- **Determinism is testable.** Time, randomness, and clock are routed through transport APIs; runs replay byte-identically given a seed.
+- **Agents are executors, not magic.** A review primitive is a node with constrained context and explicit semantics. Whatever fulfills the contract — agent, linter, classifier — is interchangeable.
+- **Determinism is a boundary.** Sykli constrains nondeterministic work with typed APIs, explicit contracts, and structured results.
 
 ---
 
@@ -293,7 +411,7 @@ This is the layer agents and downstream tools read. No log parsing, no regex, no
 | Component | Status |
 |-----------|--------|
 | Core engine, all 5 SDKs (Go/Rust/TS/Elixir/Python), local execution, containers, FALSE Protocol output, canonical schema, GitHub-native receiver (App + webhook + Checks API) | **Stable** |
-| Mesh distribution, K8s target, gates, SLSA attestations, remote cache (S3), review-node graph support across all SDKs, `task_type` (v3 semantic contract) | **Beta** |
+| Mesh distribution, K8s target, gates, SLSA attestations, remote cache (S3), review-node graph support across all SDKs, `task_type` and `success_criteria` (v3 semantic contract) | **Beta** |
 | Review primitive implementations (security/api-breakage/coverage agents), multi-agent execution, structured review outputs | **In development** |
 
 ---


### PR DESCRIPTION
Summary
-------
This PR rewrites the top of the README around Sykli's actual abstraction: execution contracts for agent work.

What changed
------------
- Replaces the opening "execution graphs as code" framing with "execution contracts for agent work".
- Adds a concise problem statement: agent work needs typed, versioned, verifiable boundaries.
- Adds a new Mermaid diagram showing the flow from typed SDKs to canonical JSON, schema validation, BEAM execution, targets, criteria, and structured evidence.
- Adds a BEAM section explaining why supervision, processes, message passing, distribution, and deterministic boundaries matter for agent execution.
- Fixes README review-node examples so they no longer emit review outputs, matching the current canonical contract.
- Updates review-node text to avoid implying structured review outputs are canonical today.
- Mentions task_type and success_criteria as v3 semantic contract pieces in project status.

Validation
----------
- [x] git diff --check
- [x] searched README for removed/inaccurate review-output phrasing and old top-level framing

Out of scope
------------
- No code changes.
- No schema changes.
- No SDK changes.
- No success_criteria enforcement changes.

Notes
-----
This intentionally stays README-only. The goal is to make the front door match the direction of the project without rewriting the full docs set.