### PR TITLE
Add structural schema-negative fixtures

### DIFF
--- a/tests/conformance/schema-invalid/README.md
+++ b/tests/conformance/schema-invalid/README.md
@@ -1,0 +1,36 @@
+# Schema-Invalid Conformance Fixtures
+
+Each JSON file in this directory is expected to fail validation against
+`schemas/sykli-pipeline.schema.json`. The validation script treats a passing
+fixture as a test failure.
+
+These fixtures assert structural schema rules, not runtime support decisions.
+For example, a target/runtime combination may be unsupported at execution time
+while still being schema-valid.
+
+## Fixture Intent
+
+| Fixture | Rule asserted |
+|---------|---------------|
+| `depends-on-wrong-type.json` | `depends_on` must be an array of strings. |
+| `gate-invalid-strategy.json` | `gate.strategy` must be one of the schema enum values (`prompt`, `env`, `file`, `webhook`). |
+| `gate-missing-strategy.json` | `gate.strategy` is required when a gate object is present. |
+| `k8s-extra-field.json` | `k8s` rejects fields outside the canonical `{memory,cpu,gpu,raw}` shape. |
+| `review-with-command.json` | Review nodes must not carry executable task fields such as `command`. |
+| `review-with-task-type.json` | Review nodes must not carry executable-task `task_type`. |
+| `service-extra-field.json` | Service objects reject unknown fields. |
+| `service-missing-image.json` | Service objects require `image`. |
+| `success-criteria-duplicate-exit-code.json` | A task may declare at most one `exit_code` criterion. |
+| `success-criteria-exit-code-missing-equals.json` | `exit_code` criteria require `equals`. |
+| `success-criteria-file-missing-path.json` | File criteria require `path`. |
+| `success-criteria-unknown-type.json` | Success criterion `type` is a closed enum. |
+| `success-criteria-version-1.json` | `success_criteria` is rejected under version `"1"`. |
+| `success-criteria-version-2.json` | `success_criteria` is rejected under version `"2"`. |
+| `task-type-unknown.json` | `task_type` is a closed enum. |
+| `task-type-version-1.json` | `task_type` is rejected under version `"1"`. |
+| `task-type-version-2.json` | `task_type` is rejected under version `"2"`. |
+| `task-type-wrong-type.json` | `task_type` must be a string enum value. |
+| `task-with-review-primitive.json` | Normal executable tasks must not carry review-node `primitive`. |
+| `version-*.json` | Top-level `version` is required, string-typed, non-empty, and explicitly supported. |
+| `when-and-condition.json` | `when` and `condition` are mutually exclusive aliases. |
+

--- a/tests/conformance/schema-invalid/depends-on-wrong-type.json
+++ b/tests/conformance/schema-invalid/depends-on-wrong-type.json
@@ -1,0 +1,10 @@
+{
+  "version": "1",
+  "tasks": [
+    {
+      "name": "build",
+      "command": "go build ./...",
+      "depends_on": "test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/gate-invalid-strategy.json
+++ b/tests/conformance/schema-invalid/gate-invalid-strategy.json
@@ -1,0 +1,11 @@
+{
+  "version": "1",
+  "tasks": [
+    {
+      "name": "approve",
+      "gate": {
+        "strategy": "slack"
+      }
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/gate-missing-strategy.json
+++ b/tests/conformance/schema-invalid/gate-missing-strategy.json
@@ -1,0 +1,11 @@
+{
+  "version": "1",
+  "tasks": [
+    {
+      "name": "approve",
+      "gate": {
+        "message": "Approve?"
+      }
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/k8s-extra-field.json
+++ b/tests/conformance/schema-invalid/k8s-extra-field.json
@@ -1,0 +1,13 @@
+{
+  "version": "1",
+  "tasks": [
+    {
+      "name": "train",
+      "command": "python train.py",
+      "k8s": {
+        "memory": "4Gi",
+        "namespace": "ml-jobs"
+      }
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/review-with-command.json
+++ b/tests/conformance/schema-invalid/review-with-command.json
@@ -1,0 +1,11 @@
+{
+  "version": "1",
+  "tasks": [
+    {
+      "name": "review-code",
+      "kind": "review",
+      "primitive": "lint",
+      "command": "echo should-not-run"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/review-with-command.json
+++ b/tests/conformance/schema-invalid/review-with-command.json
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "3",
   "tasks": [
     {
       "name": "review-code",

--- a/tests/conformance/schema-invalid/review-with-task-type.json
+++ b/tests/conformance/schema-invalid/review-with-task-type.json
@@ -1,0 +1,11 @@
+{
+  "version": "3",
+  "tasks": [
+    {
+      "name": "review-code",
+      "kind": "review",
+      "primitive": "lint",
+      "task_type": "lint"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/service-extra-field.json
+++ b/tests/conformance/schema-invalid/service-extra-field.json
@@ -1,0 +1,18 @@
+{
+  "version": "1",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "services": [
+        {
+          "image": "postgres:15",
+          "name": "db",
+          "ports": [
+            "5432:5432"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/service-missing-image.json
+++ b/tests/conformance/schema-invalid/service-missing-image.json
@@ -1,0 +1,14 @@
+{
+  "version": "1",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "services": [
+        {
+          "name": "db"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/success-criteria-duplicate-exit-code.json
+++ b/tests/conformance/schema-invalid/success-criteria-duplicate-exit-code.json
@@ -1,0 +1,19 @@
+{
+  "version": "3",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "success_criteria": [
+        {
+          "type": "exit_code",
+          "equals": 0
+        },
+        {
+          "type": "exit_code",
+          "equals": 1
+        }
+      ]
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/success-criteria-exit-code-missing-equals.json
+++ b/tests/conformance/schema-invalid/success-criteria-exit-code-missing-equals.json
@@ -1,0 +1,14 @@
+{
+  "version": "3",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "success_criteria": [
+        {
+          "type": "exit_code"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/success-criteria-file-missing-path.json
+++ b/tests/conformance/schema-invalid/success-criteria-file-missing-path.json
@@ -1,0 +1,14 @@
+{
+  "version": "3",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "success_criteria": [
+        {
+          "type": "file_exists"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/success-criteria-unknown-type.json
+++ b/tests/conformance/schema-invalid/success-criteria-unknown-type.json
@@ -1,0 +1,15 @@
+{
+  "version": "3",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "success_criteria": [
+        {
+          "type": "custom",
+          "path": "coverage.out"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/success-criteria-version-1.json
+++ b/tests/conformance/schema-invalid/success-criteria-version-1.json
@@ -1,0 +1,15 @@
+{
+  "version": "1",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "success_criteria": [
+        {
+          "type": "exit_code",
+          "equals": 0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/success-criteria-version-2.json
+++ b/tests/conformance/schema-invalid/success-criteria-version-2.json
@@ -1,0 +1,15 @@
+{
+  "version": "2",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "success_criteria": [
+        {
+          "type": "exit_code",
+          "equals": 0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/task-type-unknown.json
+++ b/tests/conformance/schema-invalid/task-type-unknown.json
@@ -1,0 +1,10 @@
+{
+  "version": "3",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "task_type": "custom"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/task-type-version-1.json
+++ b/tests/conformance/schema-invalid/task-type-version-1.json
@@ -1,0 +1,10 @@
+{
+  "version": "1",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "task_type": "test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/task-type-version-2.json
+++ b/tests/conformance/schema-invalid/task-type-version-2.json
@@ -1,0 +1,10 @@
+{
+  "version": "2",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "task_type": "test"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/task-type-wrong-type.json
+++ b/tests/conformance/schema-invalid/task-type-wrong-type.json
@@ -1,0 +1,10 @@
+{
+  "version": "3",
+  "tasks": [
+    {
+      "name": "test",
+      "command": "go test ./...",
+      "task_type": 1
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/task-with-review-primitive.json
+++ b/tests/conformance/schema-invalid/task-with-review-primitive.json
@@ -1,0 +1,10 @@
+{
+  "version": "1",
+  "tasks": [
+    {
+      "name": "lint",
+      "command": "golangci-lint run",
+      "primitive": "lint"
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/task-with-review-primitive.json
+++ b/tests/conformance/schema-invalid/task-with-review-primitive.json
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "3",
   "tasks": [
     {
       "name": "lint",

--- a/tests/conformance/schema-invalid/when-and-condition.json
+++ b/tests/conformance/schema-invalid/when-and-condition.json
@@ -1,0 +1,11 @@
+{
+  "version": "1",
+  "tasks": [
+    {
+      "name": "deploy",
+      "command": "make deploy",
+      "when": "branch == 'main'",
+      "condition": "tag != ''"
+    }
+  ]
+}


### PR DESCRIPTION
Summary

Adds structural schema-negative fixtures for the existing canonical pipeline schema. This is PR C in the audit cleanup train and is fixture-only.

Why

The schema-invalid fixture set previously focused almost entirely on version-field failures. The canonical schema also has important structural constraints for semantic fields, review applicability, success_criteria shape, gate/service/k8s objects, and aliased condition fields. These fixtures lock in those rules without changing schema behavior.

What changed

Added negative fixtures for:

- invalid task_type values and wrong task_type type
- task_type under version 2
- malformed success_criteria: unknown type, missing path, missing equals, duplicate exit_code, version 2 usage
- review nodes carrying task execution fields or task_type
- regular tasks carrying review-only primitive
- when plus condition together
- malformed services: missing image and extra ports field
- k8s extra field outside the canonical memory/cpu/gpu/raw shape
- gate missing strategy and invalid gate strategy
- depends_on with the wrong type

Boundary

These fixtures cover schema-invalid structure only. Runtime-unsupported behavior is intentionally not encoded as schema invalid.

Validation

- Schema JSON load passed: python3 -c "import json; json.load(open(\"schemas/sykli-pipeline.schema.json\"))"
- Schema fixture suite passed: python3 scripts/validate-conformance-schema.py -> 54 passed, 0 failed
- Full conformance passed: env GOCACHE=/private/tmp/sykli-go-build SYKLI_CONFORMANCE_PYTHON=python3.14 tests/conformance/run.sh -> 145 passed, 0 failed, 0 skipped
- git diff --check passed

Known notes

- The conformance harness still reports the known embedded schema-validation skip under python3.14 because that interpreter lacks jsonschema. Standalone schema validation passed with local python3.

Out of scope

- No SDK changes.
- No engine changes.
- No schema behavior changes.
- No executor changes.
- No review primitive implementation.

Next PR

Next PR in the train: Normalize executor result shape.