### PR TITLE
Normalize executor result shape

### DIFF
--- a/core/lib/sykli/executor.ex
+++ b/core/lib/sykli/executor.ex
@@ -70,6 +70,26 @@ defmodule Sykli.Executor do
           }
   end
 
+  defmodule TaskRunResult do
+    @moduledoc false
+
+    @enforce_keys [:status]
+    defstruct [
+      :status,
+      :error,
+      :output,
+      success_criteria_results: []
+    ]
+
+    @type status :: :ok | :error
+    @type t :: %__MODULE__{
+            status: status(),
+            error: term() | nil,
+            output: String.t() | nil,
+            success_criteria_results: [Sykli.SuccessCriteria.Result.t()]
+          }
+  end
+
   defmodule Config do
     @moduledoc "Executor configuration to avoid parameter explosion."
 
@@ -769,33 +789,36 @@ defmodule Sykli.Executor do
          run_id,
          chain_id
        ) do
-    case Sykli.Telemetry.span_task(task.name, %{}, fn ->
-           run_and_cache(task, state, cache_key, progress, target)
-         end) do
-      result when result == :ok or (is_tuple(result) and elem(result, 0) == :ok) ->
-        duration = System.monotonic_time(:millisecond) - start_time
+    run_result =
+      Sykli.Telemetry.span_task(task.name, %{}, fn ->
+        run_and_cache(task, state, cache_key, progress, target)
+      end)
 
-        {output, success_criteria_results} =
-          case result do
-            {:ok, out, criteria_results} -> {out, criteria_results}
-            {:ok, out} -> {out, []}
-            :ok -> {nil, []}
-          end
+    case run_result do
+      %TaskRunResult{status: :ok} ->
+        duration = System.monotonic_time(:millisecond) - start_time
 
         %TaskResult{
           name: task.name,
           status: :passed,
           duration_ms: duration,
           error: nil,
-          output: output,
+          output: run_result.output,
           command: task.command,
-          success_criteria_results: success_criteria_results
+          success_criteria_results: run_result.success_criteria_results
         }
 
-      {:error, reason, _success_criteria_results} when attempt < max_attempts ->
+      %TaskRunResult{status: :error} when attempt < max_attempts ->
         Output.task_retrying(task.name, attempt, max_attempts)
 
-        maybe_emit_task_retrying(task.name, attempt, max_attempts, reason, run_id, chain_id)
+        maybe_emit_task_retrying(
+          task.name,
+          attempt,
+          max_attempts,
+          run_result.error,
+          run_id,
+          chain_id
+        )
 
         do_run_with_retry(
           task,
@@ -810,61 +833,17 @@ defmodule Sykli.Executor do
           chain_id
         )
 
-      {:error, reason} when attempt < max_attempts ->
-        Output.task_retrying(task.name, attempt, max_attempts)
-
-        maybe_emit_task_retrying(task.name, attempt, max_attempts, reason, run_id, chain_id)
-
-        do_run_with_retry(
-          task,
-          state,
-          cache_key,
-          attempt + 1,
-          max_attempts,
-          progress,
-          target,
-          start_time,
-          run_id,
-          chain_id
-        )
-
-      {:error, reason, success_criteria_results} ->
+      %TaskRunResult{status: :error} ->
         duration = System.monotonic_time(:millisecond) - start_time
-
-        output =
-          case reason do
-            %Sykli.Error{output: out} when is_binary(out) -> out
-            _ -> nil
-          end
 
         %TaskResult{
           name: task.name,
           status: :failed,
           duration_ms: duration,
-          error: reason,
-          output: output,
+          error: run_result.error,
+          output: run_result.output,
           command: task.command,
-          success_criteria_results: success_criteria_results
-        }
-
-      {:error, reason} ->
-        duration = System.monotonic_time(:millisecond) - start_time
-
-        # Extract output from Sykli.Error if available
-        output =
-          case reason do
-            %Sykli.Error{output: out} when is_binary(out) -> out
-            _ -> nil
-          end
-
-        %TaskResult{
-          name: task.name,
-          status: :failed,
-          duration_ms: duration,
-          error: reason,
-          output: output,
-          command: task.command,
-          success_criteria_results: []
+          success_criteria_results: run_result.success_criteria_results
         }
     end
   end
@@ -922,11 +901,11 @@ defmodule Sykli.Executor do
                   end
 
                   maybe_github_status(name, "success")
-                  {:ok, output, success_criteria_results}
+                  task_run_ok(output, success_criteria_results)
 
                 {:error, reason, success_criteria_results} ->
                   maybe_github_status(name, "failure")
-                  {:error, reason, success_criteria_results}
+                  task_run_error(reason, success_criteria_results)
               end
 
             :ok ->
@@ -937,16 +916,16 @@ defmodule Sykli.Executor do
                   end
 
                   maybe_github_status(name, "success")
-                  {:ok, nil, success_criteria_results}
+                  task_run_ok(nil, success_criteria_results)
 
                 {:error, reason, success_criteria_results} ->
                   maybe_github_status(name, "failure")
-                  {:error, reason, success_criteria_results}
+                  task_run_error(reason, success_criteria_results)
               end
 
             {:error, reason} ->
               maybe_github_status(name, "failure")
-              {:error, reason}
+              task_run_error(reason)
           end
         after
           # Always stop services, even on failure
@@ -955,9 +934,29 @@ defmodule Sykli.Executor do
 
       {:error, reason} ->
         Output.service_start_failed(name, reason)
-        {:error, {:service_start_failed, reason}}
+        task_run_error({:service_start_failed, reason})
     end
   end
+
+  defp task_run_ok(output, success_criteria_results) do
+    %TaskRunResult{
+      status: :ok,
+      output: output,
+      success_criteria_results: success_criteria_results
+    }
+  end
+
+  defp task_run_error(reason, success_criteria_results \\ []) do
+    %TaskRunResult{
+      status: :error,
+      error: reason,
+      output: error_output(reason),
+      success_criteria_results: success_criteria_results
+    }
+  end
+
+  defp error_output(%Sykli.Error{output: output}) when is_binary(output), do: output
+  defp error_output(_reason), do: nil
 
   defp evaluate_success_criteria(task, target, state, run_opts, exit_code, output, duration_ms) do
     criteria = Sykli.Graph.Task.success_criteria(task)

--- a/core/lib/sykli/executor.ex
+++ b/core/lib/sykli/executor.ex
@@ -71,7 +71,9 @@ defmodule Sykli.Executor do
   end
 
   defmodule TaskRunResult do
-    @moduledoc false
+    @moduledoc """
+    Internal normalized result from one task execution attempt.
+    """
 
     @enforce_keys [:status]
     defstruct [
@@ -81,13 +83,43 @@ defmodule Sykli.Executor do
       success_criteria_results: []
     ]
 
-    @type status :: :ok | :error
+    @type status :: :ok | :error | :errored
     @type t :: %__MODULE__{
             status: status(),
             error: term() | nil,
             output: String.t() | nil,
             success_criteria_results: [Sykli.SuccessCriteria.Result.t()]
           }
+
+    def ok(output, success_criteria_results) do
+      %__MODULE__{
+        status: :ok,
+        output: output,
+        success_criteria_results: success_criteria_results
+      }
+    end
+
+    def error(reason, success_criteria_results \\ []) do
+      %__MODULE__{
+        status: :error,
+        error: reason,
+        output: error_output(reason),
+        success_criteria_results: success_criteria_results
+      }
+    end
+
+    def errored(reason, success_criteria_results \\ []) do
+      %__MODULE__{
+        status: :errored,
+        error: reason,
+        output: error_output(reason),
+        success_criteria_results: success_criteria_results
+      }
+    end
+
+    # Extension point for error shapes that carry user-visible process output.
+    defp error_output(%Sykli.Error{output: output}) when is_binary(output), do: output
+    defp error_output(_reason), do: nil
   end
 
   defmodule Config do
@@ -845,6 +877,19 @@ defmodule Sykli.Executor do
           command: task.command,
           success_criteria_results: run_result.success_criteria_results
         }
+
+      %TaskRunResult{status: :errored} ->
+        duration = System.monotonic_time(:millisecond) - start_time
+
+        %TaskResult{
+          name: task.name,
+          status: :errored,
+          duration_ms: duration,
+          error: run_result.error,
+          output: run_result.output,
+          command: task.command,
+          success_criteria_results: run_result.success_criteria_results
+        }
     end
   end
 
@@ -901,11 +946,11 @@ defmodule Sykli.Executor do
                   end
 
                   maybe_github_status(name, "success")
-                  task_run_ok(output, success_criteria_results)
+                  TaskRunResult.ok(output, success_criteria_results)
 
                 {:error, reason, success_criteria_results} ->
                   maybe_github_status(name, "failure")
-                  task_run_error(reason, success_criteria_results)
+                  TaskRunResult.error(reason, success_criteria_results)
               end
 
             :ok ->
@@ -916,16 +961,16 @@ defmodule Sykli.Executor do
                   end
 
                   maybe_github_status(name, "success")
-                  task_run_ok(nil, success_criteria_results)
+                  TaskRunResult.ok(nil, success_criteria_results)
 
                 {:error, reason, success_criteria_results} ->
                   maybe_github_status(name, "failure")
-                  task_run_error(reason, success_criteria_results)
+                  TaskRunResult.error(reason, success_criteria_results)
               end
 
             {:error, reason} ->
               maybe_github_status(name, "failure")
-              task_run_error(reason)
+              TaskRunResult.error(reason)
           end
         after
           # Always stop services, even on failure
@@ -934,29 +979,9 @@ defmodule Sykli.Executor do
 
       {:error, reason} ->
         Output.service_start_failed(name, reason)
-        task_run_error({:service_start_failed, reason})
+        TaskRunResult.error({:service_start_failed, reason})
     end
   end
-
-  defp task_run_ok(output, success_criteria_results) do
-    %TaskRunResult{
-      status: :ok,
-      output: output,
-      success_criteria_results: success_criteria_results
-    }
-  end
-
-  defp task_run_error(reason, success_criteria_results \\ []) do
-    %TaskRunResult{
-      status: :error,
-      error: reason,
-      output: error_output(reason),
-      success_criteria_results: success_criteria_results
-    }
-  end
-
-  defp error_output(%Sykli.Error{output: output}) when is_binary(output), do: output
-  defp error_output(_reason), do: nil
 
   defp evaluate_success_criteria(task, target, state, run_opts, exit_code, output, duration_ms) do
     criteria = Sykli.Graph.Task.success_criteria(task)


### PR DESCRIPTION
## Summary

This PR normalizes the executor internal task run result shape without changing the public `Sykli.Executor.TaskResult` structure or CLI JSON output. `run_and_cache/5` now returns one internal `TaskRunResult` struct instead of several tuple variants, and the retry path has a single error branch.

## Why

Recent semantic layers added success criteria results to task execution. The executor had started carrying those through multiple incompatible return shapes: `:ok`, `{:ok, out}`, `{:ok, out, criteria}`, `{:error, reason}`, and `{:error, reason, criteria}`. That made retry handling duplicate branches and would get worse as review/gate/verify result payloads grow.

## What changed

- Added an internal `Sykli.Executor.TaskRunResult` struct.
- Normalized `run_and_cache/5` to return `%TaskRunResult{}` for success and failure.
- Collapsed duplicated retry handling for two-tuple and three-tuple error shapes.
- Preserved public `%Sykli.Executor.TaskResult{}` output, including `success_criteria_results`.
- Preserved CLI/result JSON behavior by not touching rendering or result serialization.

## Validation

- [x] Focused executor tests passed: `mix test test/sykli/executor/success_criteria_enforcement_test.exs test/sykli/executor/retry_test.exs test/sykli/executor/artifact_validation_test.exs test/sykli/executor/opts_threading_test.exs` -> 34 tests, 0 failures.
- [x] Full core suite passed: `mix test` -> 1 property, 1508 tests, 0 failures, 1 skipped, 13 excluded.
- [x] Schema JSON load passed: `python3 -c "import json; json.load(open('schemas/sykli-pipeline.schema.json'))"`.
- [x] Schema fixtures passed: `python3 scripts/validate-conformance-schema.py` -> 36 passed, 0 failed.
- [x] Full conformance passed: `env GOCACHE=/private/tmp/sykli-go-build SYKLI_CONFORMANCE_PYTHON=python3.14 tests/conformance/run.sh` -> 145 passed, 0 failed, 0 skipped.
- [x] `git diff --check` passed.

## Known notes

The conformance harness still reports the known embedded schema-validation skip under python3.14 because that interpreter lacks `jsonschema`. Standalone schema validation passed with local `python3`.

## Out of scope

- No CLI monolith refactor.
- No schema changes.
- No SDK changes.
- No execution semantics changes.
- No api_breakage primitive.
- No backend/UI work.

## Next PR

The next PR in the audit train is security and determinism hardening.