### PR TITLE
Add api_breakage review primitive foundation

### DIFF
--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -317,6 +317,7 @@ defmodule Sykli.CLI do
         cached: r.status == :cached
       }
       |> maybe_add_success_criteria_results(r.success_criteria_results)
+      |> maybe_add_review_result(r.review_result)
 
     case r.error do
       %Sykli.Error{} = err ->
@@ -334,6 +335,24 @@ defmodule Sykli.CLI do
 
   defp maybe_add_success_criteria_results(base, results) do
     Map.put(base, :success_criteria_results, Enum.map(results, &success_criteria_result_to_map/1))
+  end
+
+  defp maybe_add_review_result(base, nil), do: base
+
+  defp maybe_add_review_result(base, result) do
+    Map.put(base, :review_result, review_result_to_map(result))
+  end
+
+  defp review_result_to_map(result) do
+    %{
+      review_type: result.review_type,
+      status: Atom.to_string(result.status),
+      severity: result.severity,
+      message: result.message,
+      tool: result.tool,
+      findings: result.findings,
+      evidence: result.evidence
+    }
   end
 
   defp success_criteria_result_to_map(result) do

--- a/core/lib/sykli/error.ex
+++ b/core/lib/sykli/error.ex
@@ -184,13 +184,24 @@ defmodule Sykli.Error do
       message: "review primitive failed for '#{task}'",
       task: task,
       step: :run,
-      hints: ["inspect the review_result evidence and fix or configure the review primitive"],
+      hints: review_primitive_hints(review_result),
       notes: [
         "review_type: #{review_result.review_type}",
         "status: #{review_result.status}",
         "message: #{review_result.message}"
       ]
     }
+  end
+
+  defp review_primitive_hints(%{status: :unsupported, review_type: "api_breakage"}) do
+    [
+      "configure an api_breakage adapter with Application.put_env(:sykli, :api_breakage_review_runner, MyAdapter)",
+      "see docs/review-primitives.md for the review_result contract"
+    ]
+  end
+
+  defp review_primitive_hints(_review_result) do
+    ["inspect the review_result evidence and fix or configure the review primitive"]
   end
 
   @doc """

--- a/core/lib/sykli/error.ex
+++ b/core/lib/sykli/error.ex
@@ -15,6 +15,7 @@ defmodule Sykli.Error do
   |------|----------|-------------|
   | task_failed | execution | Task command failed |
   | task_timeout | execution | Task timed out |
+  | review_primitive_failed | execution | Review primitive failed or is unsupported |
   | success_criteria_failed | execution | Declared success criteria failed |
   | unsupported_success_criteria_for_target | execution | Target cannot evaluate declared success criteria |
   | missing_secrets | execution | Missing secrets |
@@ -170,6 +171,25 @@ defmodule Sykli.Error do
         "check for infinite loops or blocking operations"
       ],
       notes: []
+    }
+  end
+
+  @doc """
+  review_primitive_failed: Review primitive failed or could not be evaluated.
+  """
+  def review_primitive_failed(task, review_result) do
+    %__MODULE__{
+      code: "review_primitive_failed",
+      type: :execution,
+      message: "review primitive failed for '#{task}'",
+      task: task,
+      step: :run,
+      hints: ["inspect the review_result evidence and fix or configure the review primitive"],
+      notes: [
+        "review_type: #{review_result.review_type}",
+        "status: #{review_result.status}",
+        "message: #{review_result.message}"
+      ]
     }
   end
 

--- a/core/lib/sykli/executor.ex
+++ b/core/lib/sykli/executor.ex
@@ -55,6 +55,7 @@ defmodule Sykli.Executor do
       :error,
       :output,
       :command,
+      :review_result,
       success_criteria_results: []
     ]
 
@@ -66,6 +67,7 @@ defmodule Sykli.Executor do
             error: term() | nil,
             output: String.t() | nil,
             command: String.t() | nil,
+            review_result: Sykli.ReviewPrimitive.Result.t() | nil,
             success_criteria_results: [Sykli.SuccessCriteria.Result.t()]
           }
   end
@@ -525,77 +527,107 @@ defmodule Sykli.Executor do
   defp run_single(%Sykli.Graph.Task{} = task, state, progress, target, run_id) do
     start_time = System.monotonic_time(:millisecond)
 
-    # Handle gates (approval points)
-    if Sykli.Graph.Task.gate?(task) do
-      run_gate(task, state, progress, run_id)
-    else
-      # Check condition first
-      if should_run?(task) do
-        # Resolve secret_refs before execution
-        task = resolve_secret_refs(task)
+    cond do
+      Sykli.Graph.Task.review?(task) ->
+        run_review(task, state, progress)
 
-        # OIDC credential exchange (if configured)
-        try do
-          case OIDCService.exchange(task, state) do
-            {:ok, oidc_env} ->
-              # Merge OIDC env vars into task env
-              task =
-                if map_size(oidc_env) > 0 do
-                  %{task | env: Map.merge(task.env || %{}, oidc_env)}
-                else
-                  task
+      Sykli.Graph.Task.gate?(task) ->
+        run_gate(task, state, progress, run_id)
+
+      true ->
+        # Check condition first
+        if should_run?(task) do
+          # Resolve secret_refs before execution
+          task = resolve_secret_refs(task)
+
+          # OIDC credential exchange (if configured)
+          try do
+            case OIDCService.exchange(task, state) do
+              {:ok, oidc_env} ->
+                # Merge OIDC env vars into task env
+                task =
+                  if map_size(oidc_env) > 0 do
+                    %{task | env: Map.merge(task.env || %{}, oidc_env)}
+                  else
+                    task
+                  end
+
+                # Validate required secrets are present (via target)
+                case validate_secrets(task, state, target) do
+                  :ok ->
+                    run_task_with_cache(task, state, progress, target, start_time, run_id)
+
+                  {:error, missing} ->
+                    Output.missing_secrets(task.name, missing)
+
+                    duration = System.monotonic_time(:millisecond) - start_time
+
+                    %TaskResult{
+                      name: task.name,
+                      status: :errored,
+                      duration_ms: duration,
+                      error: Error.missing_secrets(task.name, missing),
+                      command: task.command
+                    }
                 end
 
-              # Validate required secrets are present (via target)
-              case validate_secrets(task, state, target) do
-                :ok ->
-                  run_task_with_cache(task, state, progress, target, start_time, run_id)
+              {:error, reason} ->
+                Output.oidc_failed(task.name, reason)
 
-                {:error, missing} ->
-                  Output.missing_secrets(task.name, missing)
+                duration = System.monotonic_time(:millisecond) - start_time
 
-                  duration = System.monotonic_time(:millisecond) - start_time
-
-                  %TaskResult{
-                    name: task.name,
-                    status: :errored,
-                    duration_ms: duration,
-                    error: Error.missing_secrets(task.name, missing),
-                    command: task.command
-                  }
-              end
-
-            {:error, reason} ->
-              Output.oidc_failed(task.name, reason)
-
-              duration = System.monotonic_time(:millisecond) - start_time
-
-              %TaskResult{
-                name: task.name,
-                status: :errored,
-                duration_ms: duration,
-                error: Error.internal("OIDC credential exchange failed: #{reason}"),
-                command: task.command
-              }
+                %TaskResult{
+                  name: task.name,
+                  status: :errored,
+                  duration_ms: duration,
+                  error: Error.internal("OIDC credential exchange failed: #{reason}"),
+                  command: task.command
+                }
+            end
+          after
+            OIDCService.cleanup_temp_files()
           end
-        after
-          OIDCService.cleanup_temp_files()
+        else
+          Output.task_skipped("", task.name, "condition not met")
+
+          maybe_emit_task_skipped(task.name, :condition_not_met, run_id)
+          duration = System.monotonic_time(:millisecond) - start_time
+
+          %TaskResult{
+            name: task.name,
+            status: :skipped,
+            duration_ms: duration,
+            error: nil,
+            command: task.command
+          }
         end
-      else
-        Output.task_skipped("", task.name, "condition not met")
-
-        maybe_emit_task_skipped(task.name, :condition_not_met, run_id)
-        duration = System.monotonic_time(:millisecond) - start_time
-
-        %TaskResult{
-          name: task.name,
-          status: :skipped,
-          duration_ms: duration,
-          error: nil,
-          command: task.command
-        }
-      end
     end
+  end
+
+  defp run_review(%Sykli.Graph.Task{} = task, state, progress) do
+    prefix = progress_prefix(progress)
+    start_time = System.monotonic_time(:millisecond)
+
+    Output.task_starting(prefix, task.name, "review: #{Sykli.Graph.Task.primitive(task)}")
+
+    {status, error, review_result} =
+      case Sykli.ReviewPrimitive.evaluate(task, state) do
+        {:ok, result} ->
+          {:passed, nil, result}
+
+        {:error, result} ->
+          Output.task_failed(prefix, task.name, result.message)
+          {:failed, Error.review_primitive_failed(task.name, result), result}
+      end
+
+    %TaskResult{
+      name: task.name,
+      status: status,
+      duration_ms: System.monotonic_time(:millisecond) - start_time,
+      error: error,
+      command: nil,
+      review_result: review_result
+    }
   end
 
   defp run_gate(%Sykli.Graph.Task{} = task, _state, progress, run_id) do

--- a/core/lib/sykli/review_primitive.ex
+++ b/core/lib/sykli/review_primitive.ex
@@ -1,0 +1,117 @@
+defmodule Sykli.ReviewPrimitive do
+  @moduledoc """
+  Deterministic review primitive dispatch.
+
+  Review primitives are not shell commands and do not call LLM providers. They
+  evaluate a `kind: "review"` graph node and return structured evidence that can
+  be surfaced to agents, gates, humans, and JSON consumers.
+  """
+
+  alias Sykli.Graph.Task
+
+  defmodule Result do
+    @moduledoc "Structured result returned by a review primitive."
+
+    @enforce_keys [:review_type, :status, :message]
+    defstruct [
+      :review_type,
+      :status,
+      :severity,
+      :message,
+      :tool,
+      findings: [],
+      evidence: %{}
+    ]
+
+    @type status :: :passed | :failed | :unsupported | :errored
+    @type t :: %__MODULE__{
+            review_type: String.t(),
+            status: status(),
+            severity: String.t() | nil,
+            message: String.t(),
+            tool: String.t() | nil,
+            findings: [map()],
+            evidence: map()
+          }
+  end
+
+  @api_breakage_primitives ~w(api_breakage api-breakage)
+
+  @doc """
+  Evaluate the review primitive for a review node.
+  """
+  @spec evaluate(Task.t(), map(), keyword()) :: {:ok, Result.t()} | {:error, Result.t()}
+  def evaluate(%Task{} = task, state, opts \\ []) do
+    primitive = Task.primitive(task)
+
+    cond do
+      primitive in @api_breakage_primitives ->
+        api_breakage_runner(opts).evaluate(task, state, opts)
+
+      is_binary(primitive) ->
+        unsupported(task, primitive, "unsupported review primitive: #{primitive}")
+
+      true ->
+        unsupported(task, "unknown", "review node is missing a primitive")
+    end
+  end
+
+  @doc """
+  Return true when a review primitive result should fail the review node.
+  """
+  @spec failed?(Result.t()) :: boolean()
+  def failed?(%Result{status: status}), do: status in [:failed, :unsupported, :errored]
+
+  defp api_breakage_runner(opts) do
+    Keyword.get(opts, :review_primitive_runner) ||
+      Application.get_env(:sykli, :api_breakage_review_runner, Sykli.ReviewPrimitive.ApiBreakage)
+  end
+
+  defp unsupported(task, review_type, message) do
+    result = %Result{
+      review_type: review_type,
+      status: :unsupported,
+      severity: "warning",
+      message: message,
+      evidence: %{
+        "task" => task.name,
+        "context" => Task.context(task),
+        "agent" => Task.agent(task)
+      }
+    }
+
+    {:error, result}
+  end
+end
+
+defmodule Sykli.ReviewPrimitive.ApiBreakage do
+  @moduledoc """
+  Default api_breakage review primitive.
+
+  This module defines the runtime boundary for deterministic API breakage
+  checks. Real language/tool adapters are intentionally not bundled here yet;
+  until configured, api_breakage returns an explicit unsupported result instead
+  of silently passing.
+  """
+
+  alias Sykli.Graph.Task
+  alias Sykli.ReviewPrimitive.Result
+
+  @spec evaluate(Task.t(), map(), keyword()) :: {:error, Result.t()}
+  def evaluate(%Task{} = task, _state, _opts) do
+    {:error,
+     %Result{
+       review_type: "api_breakage",
+       status: :unsupported,
+       severity: "warning",
+       message: "api_breakage review primitive has no configured adapter",
+       tool: nil,
+       findings: [],
+       evidence: %{
+         "task" => task.name,
+         "context" => Task.context(task),
+         "agent" => Task.agent(task)
+       }
+     }}
+  end
+end

--- a/core/lib/sykli/review_primitive.ex
+++ b/core/lib/sykli/review_primitive.ex
@@ -35,7 +35,7 @@ defmodule Sykli.ReviewPrimitive do
           }
   end
 
-  @api_breakage_primitives ~w(api_breakage api-breakage)
+  @api_breakage_primitive "api_breakage"
 
   @doc """
   Evaluate the review primitive for a review node.
@@ -45,8 +45,9 @@ defmodule Sykli.ReviewPrimitive do
     primitive = Task.primitive(task)
 
     cond do
-      primitive in @api_breakage_primitives ->
-        api_breakage_runner(opts).evaluate(task, state, opts)
+      primitive == @api_breakage_primitive ->
+        runner = api_breakage_runner(opts)
+        classify_result(runner.evaluate(task, state, opts))
 
       is_binary(primitive) ->
         unsupported(task, primitive, "unsupported review primitive: #{primitive}")
@@ -61,6 +62,12 @@ defmodule Sykli.ReviewPrimitive do
   """
   @spec failed?(Result.t()) :: boolean()
   def failed?(%Result{status: status}), do: status in [:failed, :unsupported, :errored]
+
+  defp classify_result({:ok, %Result{} = result}) do
+    if failed?(result), do: {:error, result}, else: {:ok, result}
+  end
+
+  defp classify_result({:error, %Result{} = result}), do: {:error, result}
 
   defp api_breakage_runner(opts) do
     Keyword.get(opts, :review_primitive_runner) ||

--- a/core/test/sykli/executor/review_primitive_test.exs
+++ b/core/test/sykli/executor/review_primitive_test.exs
@@ -18,7 +18,7 @@ defmodule Sykli.Executor.ReviewPrimitiveTest do
          message: "no public API breakage detected",
          tool: "fixture",
          findings: [],
-         evidence: %{"task" => task.name}
+         evidence: Sykli.Executor.ReviewPrimitiveTest.evidence(task)
        }}
     end
   end
@@ -33,7 +33,21 @@ defmodule Sykli.Executor.ReviewPrimitiveTest do
          message: "public API breakage detected",
          tool: "fixture",
          findings: [%{"symbol" => "Client.connect", "change" => "removed"}],
-         evidence: %{"task" => task.name}
+         evidence: Sykli.Executor.ReviewPrimitiveTest.evidence(task)
+       }}
+    end
+  end
+
+  defmodule MisclassifiedFailingRunner do
+    def evaluate(task, _state, _opts) do
+      {:ok,
+       %Result{
+         review_type: "api_breakage",
+         status: :failed,
+         severity: "breaking",
+         message: "runner returned ok tuple with failed status",
+         findings: [],
+         evidence: Sykli.Executor.ReviewPrimitiveTest.evidence(task)
        }}
     end
   end
@@ -118,6 +132,40 @@ defmodule Sykli.Executor.ReviewPrimitiveTest do
             ]} = Executor.run([task], graph(task), target: Local)
   end
 
+  test "hyphenated api-breakage spelling is rejected as non-canonical" do
+    task = review_task("review-api", primitive: "api-breakage")
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "review_primitive_failed"},
+                review_result: %Result{
+                  review_type: "api-breakage",
+                  status: :unsupported,
+                  message: "unsupported review primitive: api-breakage"
+                }
+              }
+            ]} = Executor.run([task], graph(task), target: Local)
+  end
+
+  test "failed result status fails even if runner returns ok tuple" do
+    Application.put_env(:sykli, :api_breakage_review_runner, MisclassifiedFailingRunner)
+    task = review_task("review-api")
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                review_result: %Result{
+                  review_type: "api_breakage",
+                  status: :failed,
+                  message: "runner returned ok tuple with failed status"
+                }
+              }
+            ]} = Executor.run([task], graph(task), target: Local)
+  end
+
   defp review_task(name, opts \\ []) do
     primitive = Keyword.get(opts, :primitive, "api_breakage")
 
@@ -140,4 +188,12 @@ defmodule Sykli.Executor.ReviewPrimitiveTest do
   end
 
   defp graph(%Task{} = task), do: %{task.name => task}
+
+  def evidence(%Task{} = task) do
+    %{
+      "task" => task.name,
+      "context" => Task.context(task),
+      "agent" => Task.agent(task)
+    }
+  end
 end

--- a/core/test/sykli/executor/review_primitive_test.exs
+++ b/core/test/sykli/executor/review_primitive_test.exs
@@ -1,0 +1,143 @@
+defmodule Sykli.Executor.ReviewPrimitiveTest do
+  use ExUnit.Case, async: false
+
+  alias Sykli.Error
+  alias Sykli.Executor
+  alias Sykli.Executor.TaskResult
+  alias Sykli.Graph.{Review, Task}
+  alias Sykli.ReviewPrimitive.Result
+  alias Sykli.Target.Local
+
+  defmodule PassingApiBreakageRunner do
+    def evaluate(task, _state, _opts) do
+      {:ok,
+       %Result{
+         review_type: "api_breakage",
+         status: :passed,
+         severity: "info",
+         message: "no public API breakage detected",
+         tool: "fixture",
+         findings: [],
+         evidence: %{"task" => task.name}
+       }}
+    end
+  end
+
+  defmodule FailingApiBreakageRunner do
+    def evaluate(task, _state, _opts) do
+      {:error,
+       %Result{
+         review_type: "api_breakage",
+         status: :failed,
+         severity: "breaking",
+         message: "public API breakage detected",
+         tool: "fixture",
+         findings: [%{"symbol" => "Client.connect", "change" => "removed"}],
+         evidence: %{"task" => task.name}
+       }}
+    end
+  end
+
+  setup do
+    original_runner = Application.get_env(:sykli, :api_breakage_review_runner)
+
+    on_exit(fn ->
+      if original_runner do
+        Application.put_env(:sykli, :api_breakage_review_runner, original_runner)
+      else
+        Application.delete_env(:sykli, :api_breakage_review_runner)
+      end
+    end)
+  end
+
+  test "api_breakage review node invokes configured primitive runner and passes" do
+    Application.put_env(:sykli, :api_breakage_review_runner, PassingApiBreakageRunner)
+    task = review_task("review-api")
+
+    assert {:ok, [%TaskResult{status: :passed, review_result: result, command: nil}]} =
+             Executor.run([task], graph(task), target: Local)
+
+    assert %Result{
+             review_type: "api_breakage",
+             status: :passed,
+             message: "no public API breakage detected"
+           } = result
+  end
+
+  test "failing api_breakage result fails the review node with structured evidence" do
+    Application.put_env(:sykli, :api_breakage_review_runner, FailingApiBreakageRunner)
+    task = review_task("review-api")
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "review_primitive_failed"},
+                review_result: %Result{
+                  review_type: "api_breakage",
+                  status: :failed,
+                  severity: "breaking",
+                  findings: [%{"symbol" => "Client.connect"}]
+                }
+              }
+            ]} = Executor.run([task], graph(task), target: Local)
+  end
+
+  test "default api_breakage behavior is explicit unsupported failure" do
+    Application.delete_env(:sykli, :api_breakage_review_runner)
+    task = review_task("review-api")
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "review_primitive_failed"},
+                review_result: %Result{
+                  review_type: "api_breakage",
+                  status: :unsupported,
+                  message: "api_breakage review primitive has no configured adapter"
+                }
+              }
+            ]} = Executor.run([task], graph(task), target: Local)
+  end
+
+  test "unknown review primitive fails explicitly" do
+    task = review_task("review-unknown", primitive: "unknown_check")
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                error: %Error{code: "review_primitive_failed"},
+                review_result: %Result{
+                  review_type: "unknown_check",
+                  status: :unsupported,
+                  message: "unsupported review primitive: unknown_check"
+                }
+              }
+            ]} = Executor.run([task], graph(task), target: Local)
+  end
+
+  defp review_task(name, opts \\ []) do
+    primitive = Keyword.get(opts, :primitive, "api_breakage")
+
+    %Task{
+      name: name,
+      kind: :review,
+      command: nil,
+      depends_on: [],
+      inputs: [],
+      outputs: %{},
+      services: [],
+      task_inputs: [],
+      review: %Review{
+        primitive: primitive,
+        agent: "local",
+        context: ["lib/**/*.ex"],
+        deterministic: true
+      }
+    }
+  end
+
+  defp graph(%Task{} = task), do: %{task.name => task}
+end

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -25,6 +25,7 @@ No cache-prefixed `Sykli.Error` codes are emitted today. Cache failures currentl
 | Code | Description | Tier | Emitted from |
 |------|-------------|------|--------------|
 | `missing_secrets` | A task requires secrets that are not present in the execution environment. | public-stable | `core/lib/sykli/error.ex:181` |
+| `review_primitive_failed` | A review primitive failed, errored, or was unsupported. | public-unstable | `core/lib/sykli/error.ex` |
 | `success_criteria_failed` | A task command succeeded, but one or more declared success criteria failed. | public-unstable | `core/lib/sykli/error.ex:183` |
 | `task_failed` | A task command exited non-zero; this is a content failure, not infrastructure failure. | public-stable | `core/lib/sykli/error.ex:137` |
 | `task_timeout` | A task exceeded its configured timeout. | public-stable | `core/lib/sykli/error.ex:159` |

--- a/docs/review-primitives.md
+++ b/docs/review-primitives.md
@@ -11,6 +11,32 @@ The executor treats review nodes as first-class graph nodes:
 - `failed`, `unsupported`, and `errored` results fail the review node.
 - Unsupported primitives fail explicitly; they are never silently skipped.
 
+The canonical primitive name is `api_breakage`. Hyphenated aliases such as
+`api-breakage` are not accepted by the review primitive dispatcher.
+
+## `review_result` Shape
+
+All review primitive providers return the same result shape:
+
+| Field | Type | Semantics |
+|-------|------|-----------|
+| `review_type` | string | Primitive identifier, such as `api_breakage`. |
+| `status` | enum | One of `passed`, `failed`, `unsupported`, or `errored`. |
+| `severity` | enum or null | One of `info`, `warning`, `breaking`, or `critical` when set. |
+| `message` | string | Human-readable summary of the result. |
+| `tool` | string or null | Adapter/tool name when known. |
+| `findings` | array | Structured primitive-specific findings. |
+| `evidence` | object | Structured evidence with the canonical keys below. |
+
+Canonical `evidence` keys:
+
+- `task`: review node name.
+- `context`: review node context array.
+- `agent`: review node agent string or null.
+
+Adapters may add primitive-specific evidence keys, but they must preserve the
+canonical keys above so downstream tools can enumerate the common surface.
+
 ## `api_breakage`
 
 `api_breakage` is the first review primitive boundary. It is intended for

--- a/docs/review-primitives.md
+++ b/docs/review-primitives.md
@@ -1,0 +1,44 @@
+# Review Primitives
+
+Review primitives are deterministic checks attached to `kind: "review"` graph
+nodes. They are not shell-command tasks and they do not call LLM providers.
+
+The executor treats review nodes as first-class graph nodes:
+
+- The review node invokes the primitive named by `primitive`.
+- The primitive returns a structured `review_result`.
+- `passed` results pass the review node.
+- `failed`, `unsupported`, and `errored` results fail the review node.
+- Unsupported primitives fail explicitly; they are never silently skipped.
+
+## `api_breakage`
+
+`api_breakage` is the first review primitive boundary. It is intended for
+deterministic public API compatibility checks.
+
+The current implementation provides the runtime interface and structured result
+model. Real language/tool adapters are intentionally not bundled yet. Until an
+adapter is configured, `api_breakage` returns an explicit unsupported result:
+
+```json
+{
+  "review_type": "api_breakage",
+  "status": "unsupported",
+  "severity": "warning",
+  "message": "api_breakage review primitive has no configured adapter",
+  "tool": null,
+  "findings": [],
+  "evidence": {
+    "task": "review-api",
+    "context": ["lib/**/*.ex"],
+    "agent": "local"
+  }
+}
+```
+
+This is deliberate. Sykli should not pretend an API review passed when no
+deterministic adapter evaluated it.
+
+Future adapters may use tools such as API Extractor, griffe, gorelease/apidiff,
+or cargo-public-api, but each adapter must return the same structured result
+shape.

--- a/docs/sdk-schema.md
+++ b/docs/sdk-schema.md
@@ -329,6 +329,11 @@ left out of the current experimental contract. The schema rejects task execution
 fields on review nodes: `command`, `outputs`, `gate`, `container`, `services`,
 `k8s`, `mounts`, `retry`, `timeout`, `task_type`, and `success_criteria`.
 
+At execution time, review nodes invoke deterministic review primitives rather
+than shell commands. The first primitive boundary is `api_breakage`; it returns
+structured `review_result` data and fails explicitly when no adapter is
+configured. See [review-primitives.md](review-primitives.md).
+
 ## Normalization behavior
 
 Documented engine normalizations the schema does not perform:


### PR DESCRIPTION
## Summary

This PR adds the first review primitive foundation for Sykli review nodes, centered on the `api_breakage` primitive boundary.

Review nodes now execute through a deterministic review primitive dispatcher instead of being treated like shell-command tasks. Primitive results are structured as `review_result` data and are exposed through executor results and CLI JSON mapping.

This is intentionally a foundation slice: `api_breakage` now has a runtime boundary and result model, but no bundled language adapter yet. Without a configured adapter it fails explicitly as unsupported instead of silently passing.

## Why

Review nodes should become useful execution-contract nodes, not just inert graph shapes. The smallest honest product step is a deterministic review primitive boundary that can return structured evidence and fail clearly when unsupported.

`api_breakage` is the first primitive because API compatibility checks have a deterministic floor. Real tool adapters can be added later without changing the graph shape or result envelope.

## What changed

- Added `Sykli.ReviewPrimitive` and structured `Sykli.ReviewPrimitive.Result`.
- Added `api_breakage` / `api-breakage` primitive dispatch.
- Added explicit unsupported behavior for `api_breakage` when no adapter is configured.
- Added explicit unsupported behavior for unknown review primitives.
- Updated executor review-node execution to invoke review primitives.
- Added `review_result` to executor task results and CLI JSON task result mapping.
- Added `review_primitive_failed` public error code.
- Added focused review primitive executor tests.
- Added `docs/review-primitives.md` and linked it from the SDK schema docs.

## Validation

- [x] Focused core tests passed: `cd core && mix test test/sykli/executor/review_primitive_test.exs test/sykli/validate_test.exs test/sykli/plan_test.exs` -> 49 tests, 0 failures
- [x] Full core suite passed: `cd core && mix test` -> 1 property, 1512 tests, 0 failures, 1 skipped, 13 excluded
- [x] Schema JSON load passed: `python3 -c "import json; json.load(open('schemas/sykli-pipeline.schema.json'))"`
- [x] Schema fixtures passed: `python3 scripts/validate-conformance-schema.py` -> 36 passed, 0 failed
- [x] Full conformance passed: `env GOCACHE=/private/tmp/sykli-go-build SYKLI_CONFORMANCE_PYTHON=python3.14 tests/conformance/run.sh` -> 145 passed, 0 failed, 0 skipped
- [x] Diff hygiene passed: `git diff --check`

SDK unit suites were not run because this PR does not change SDK emitters or SDK APIs. Cross-SDK contract conformance was run and passed.

## Known notes

The conformance harness still reports the known embedded schema-validation skip under `python3.14` because that interpreter lacks `jsonschema`. Standalone schema validation passes with local `python3`.

## Out of scope

- No LLM provider integration.
- No Claude/OpenAI/Gemini calls.
- No bundled API Extractor, griffe, gorelease/apidiff, or cargo-public-api adapter yet.
- No all-language `api_breakage` support.
- No gate policy redesign.
- No Vartio runtime integration.
- No SDK or schema changes.
- No backend/UI work.

## Next recommended PR

The next recommended PR is the Vartio integration design doc, unless we want to add a narrow real `api_breakage` adapter first.
