### PR TITLE
Design self-hosted team coordination for Sykli

### DIFF
--- a/docs/coordination-modes.md
+++ b/docs/coordination-modes.md
@@ -1,0 +1,283 @@
+# Sykli Coordination Modes
+
+## Status
+
+This is a design document for Sykli Team Mode. It defines the four
+coordination shapes Sykli supports as it grows from a single-machine tool
+into a team tool. Phase 0 of `docs/team-mode-roadmap.md`.
+
+No implementation in this PR. The local-only and trusted LAN mesh modes
+exist today. The self-hosted coordinator and hybrid modes are designed
+here and implemented in later phases.
+
+## Architecture sentence
+
+> The daemon executes and records; the mesh dispatches inside trusted
+> networks; the coordinator synchronizes team state across locations;
+> `.sykli/` remains the local source of detailed evidence.
+
+This sentence is normative. Every mode below is a particular composition of
+those four actors. The coordinator never executes work. The mesh never
+crosses trust domains. `.sykli/` is always the per-machine source of truth.
+
+## Why four modes
+
+Sykli is local-first. Most users start with a single laptop and a `sykli.exs`
+file. Some users grow into a trusted worker pool inside one network. Some
+teams need to coordinate work across people, agents, and machines on
+different networks. Each of those is a different trust posture and a
+different deployment shape.
+
+We refuse to collapse them into one "always-on cluster" model because that
+would force every user to operate a network. Local-first means the network
+is opt-in.
+
+The four modes are:
+
+1. **Local-only.** No network. One machine. The default.
+2. **Trusted LAN mesh.** BEAM/libcluster mesh inside a trust domain.
+3. **Self-hosted coordinator.** Team-state plane. Daemons connect outbound.
+4. **Hybrid.** Mesh inside trust domains, coordinator across them.
+
+The remainder of this document defines each.
+
+## Mode A — Local-only
+
+The default and the floor of the system.
+
+```bash
+sykli run
+```
+
+What runs:
+
+- The detected SDK pipeline emits JSON.
+- The engine executes locally through the configured target (Local or K8s).
+- `.sykli/` accumulates occurrences, attestations, run history, context,
+  and per-task evidence.
+- The local MCP server (`sykli mcp`) exposes tools to a co-located agent.
+
+What does not run:
+
+- No daemon-to-daemon network.
+- No outbound connection to a coordinator.
+- No reliance on shared cluster state.
+
+Trust boundary:
+
+- The user trusts their own machine. That is the entire trust domain.
+
+When this mode is enough:
+
+- Solo work.
+- Air-gapped environments.
+- Pre-team experimentation.
+- The first run on any new machine.
+
+## Mode B — Trusted LAN mesh
+
+The existing BEAM mesh (`Sykli.Mesh`, `Sykli.Mesh.Roles`,
+`Sykli.Mesh.Transport.*`).
+
+```bash
+# on each worker
+SYKLI_LABELS=docker,gpu sykli daemon start --role worker
+
+# on a developer machine in the same trust domain
+sykli --mesh
+```
+
+What runs:
+
+- Multiple BEAM nodes form a cluster via `libcluster` gossip.
+- Roles are advertised through `Sykli.Mesh.Roles`.
+- The dispatcher places tasks on workers by labels and capabilities.
+- Erlang distribution carries task dispatch over the local network.
+
+What this mode requires:
+
+- A shared trust domain. Every node in the mesh must hold the same
+  Erlang cookie and reach every other node over BEAM distribution
+  (TCP, EPMD-style port allocation, or a configured port).
+- A network where everyone is on equal footing — typically a LAN, a VPN,
+  or a Kubernetes cluster.
+
+What this mode is good for:
+
+- Internal CI clusters.
+- A trusted worker pool inside one office or one VPC.
+- A Kubernetes namespace whose pods run Sykli workers.
+- A homelab where every machine is on Tailscale and every Tailscale node
+  is trusted to the same degree.
+
+What this mode is **not** for:
+
+- Two people on different home networks.
+- A laptop behind NAT collaborating with a server in the cloud.
+- Cross-company collaboration.
+- Untrusted networks where one node should not be able to RPC into
+  another node.
+
+The BEAM mesh is not the WAN/team coordination mechanism. It is a
+trusted-execution-domain mechanism. Treat it as a single trust unit; if you
+would not give a node the Erlang cookie, it does not belong in the mesh.
+
+## Mode C — Self-hosted coordinator
+
+This is the new mode. Designed in `docs/self-hosted-coordinator.md`.
+
+```bash
+sykli daemon join \
+  --coordinator https://sykli.internal \
+  --org false-systems \
+  --team platform \
+  --token $SYKLI_TEAM_TOKEN \
+  --labels macos,docker,typescript \
+  --name yair-mbp
+```
+
+What runs:
+
+- The user (or the org) operates a single self-hosted **Sykli Coordinator**
+  service, deployed into their own infrastructure (typically a Kubernetes
+  cluster they already run).
+- Each daemon connects **outbound** to the coordinator over HTTPS.
+- The coordinator stores team-coordination state: org/team registry,
+  daemon sessions, work items, run summaries, gates, evidence references,
+  audit log.
+- Each daemon continues to execute locally and continues to write
+  detailed evidence into its own `.sykli/`.
+
+What this mode does **not** do:
+
+- It does not execute work.
+- It does not own logs, artifacts, or source code.
+- It does not require inbound access to developer laptops.
+- It does not assume a shared network.
+- It does not require everyone to share an Erlang cookie.
+
+Trust boundary:
+
+- Each daemon trusts the coordinator at the level granted by its team
+  token and policy.
+- Daemons do not trust each other transitively. Two daemons connected to
+  the same coordinator are not in the same execution trust domain.
+- Remote execution between daemons is **off** by default. A daemon must
+  explicitly declare `accepts_remote_work: true` before the coordinator
+  is allowed to assign work to it on behalf of a different originator.
+
+When this mode is right:
+
+- Remote teams.
+- Laptops behind NAT.
+- Home networks.
+- Cloud workers outside the LAN.
+- Cross-company collaboration where each side operates its own coordinator.
+- Anywhere you would otherwise reach for a SaaS dashboard.
+
+The coordinator's job is to coordinate metadata and state. The daemon's
+job remains to execute work where the user trusts it to run.
+
+See:
+
+- `docs/self-hosted-coordinator.md` — coordinator design.
+- `docs/daemon-join-protocol.md` — outbound connection protocol.
+- `docs/team-mode-security.md` — security defaults.
+- `docs/local-state-plane.md` — what stays local versus what is synced.
+
+## Mode D — Hybrid
+
+The composition that real organizations end up with.
+
+Shape:
+
+- Developer laptops connect **only** to the coordinator. They do not
+  participate in any BEAM mesh.
+- Inside a Kubernetes cluster, a pool of Sykli worker daemons forms a
+  trusted LAN mesh. They share an Erlang cookie and dispatch work among
+  themselves.
+- One node in the cluster mesh — or the daemon attached to the
+  coordinator — is responsible for translating coordinator instructions
+  into mesh dispatch decisions.
+- The coordinator tracks work items, claims, run summaries, gate state,
+  and evidence references across both the laptops and the cluster.
+
+Concretely:
+
+```text
+              ┌──────────────────────┐
+              │   Sykli Coordinator  │   self-hosted, HTTPS only
+              │      (your K8s)      │
+              └─────────┬────────────┘
+                        │ outbound only
+   ┌────────────────────┼─────────────────────┐
+   │                    │                     │
+   ▼                    ▼                     ▼
+  laptop A             laptop B           K8s daemon (gateway)
+  daemon                daemon                 │
+                                               │ Erlang dist (LAN mesh)
+                                       ┌───────┴───────┐
+                                       ▼               ▼
+                                     worker          worker
+                                     daemon          daemon
+```
+
+Properties:
+
+- The coordinator has **no** Erlang cookie. It speaks HTTPS only.
+- The cluster mesh is one trust domain. The coordinator is a different
+  trust domain. The two communicate through a designated daemon, not
+  through Erlang distribution.
+- Laptops never join the mesh. They never receive `:rpc.call` requests
+  from anywhere.
+- Coordinator-recorded run summaries can come from either a laptop daemon
+  or a cluster gateway daemon. Both look the same to the coordinator.
+
+This is the mode the design optimizes for. Solo and small teams stay in
+modes A, B, or C. Production usage tends to be D.
+
+## What changes per mode
+
+| Capability                  | A: Local | B: LAN mesh | C: Coordinator | D: Hybrid |
+|-----------------------------|:--------:|:-----------:|:--------------:|:---------:|
+| Run pipelines               | ✓        | ✓           | ✓              | ✓         |
+| `.sykli/` evidence          | ✓        | ✓           | ✓              | ✓         |
+| Multi-node dispatch         | —        | ✓           | —              | ✓ (mesh)  |
+| Cross-network coordination  | —        | —           | ✓              | ✓         |
+| Shared work items           | —        | —           | ✓              | ✓         |
+| Shared gate decisions       | —        | —           | ✓              | ✓         |
+| Requires shared cookie      | —        | yes         | no             | mesh only |
+| Inbound network to laptops  | —        | mesh-only   | no             | no        |
+
+## Failure modes per layer
+
+- Local-only failures stay in `.sykli/`. No external system is affected.
+- Mesh failures (split brain, partial reachability, dropped Erlang
+  distribution) degrade dispatch but do not delete history. The user
+  falls back to local execution.
+- Coordinator failures (the service is down, the network is broken,
+  the token is rejected) must not stop a daemon from running locally.
+  The daemon continues to write `.sykli/` and queues sync events for
+  the coordinator's recovery. See `docs/daemon-join-protocol.md` for
+  reconnect semantics.
+- Hybrid failures degrade gracefully: if the coordinator is unreachable,
+  the cluster mesh keeps executing; if the cluster mesh is unhealthy,
+  laptops can still record work in the coordinator.
+
+The design rule is: **no mode of failure removes a user's ability to run
+locally.** Local-first is preserved at every layer.
+
+## Non-goals across all modes
+
+The following remain out of scope for every mode in this document:
+
+- No SaaS hosted control plane.
+- No mandatory upload of source code, full logs, raw artifacts, or
+  secrets.
+- No remote shell.
+- No global scheduler that pre-empts a daemon's local execution.
+- No web UI in this phase.
+- No replacement of `.sykli/` as the local source of truth.
+
+Future phases may expand individual modes, but they may not violate the
+above without a new design doc.

--- a/docs/daemon-join-protocol.md
+++ b/docs/daemon-join-protocol.md
@@ -1,0 +1,401 @@
+# Sykli Daemon Join Protocol
+
+## Status
+
+Design document. Specifies how a Sykli daemon establishes and maintains
+a session with a self-hosted coordinator. Phase 0 of
+`docs/team-mode-roadmap.md`.
+
+No implementation in this PR. Wire shapes below are normative;
+exact field types and error codes are firmed up by the implementing PR.
+
+## Architecture sentence
+
+> The daemon executes and records; the mesh dispatches inside trusted
+> networks; the coordinator synchronizes team state across locations;
+> `.sykli/` remains the local source of detailed evidence.
+
+The join protocol is the door through which a daemon enters the
+coordinator's view. Nothing else in Team Mode works without it.
+
+## Outbound connection model
+
+The protocol is **always daemon-to-coordinator over HTTPS**.
+
+- The daemon initiates the TCP and TLS handshake.
+- The coordinator never opens a connection back to the daemon.
+- The coordinator does not know the daemon's IP address beyond what
+  the request presented; it never tries to reach it.
+- The protocol traverses NAT, residential ISPs, corporate proxies, and
+  outbound-only firewalls without changes.
+- HTTP/1.1 is required. HTTP/2 is allowed if both sides support it.
+- WebSockets are **not** required in v0. SSE on a future endpoint is
+  acceptable for streaming. See `docs/self-hosted-coordinator.md`.
+
+The daemon must:
+
+- Verify the coordinator's TLS certificate against the system trust
+  store, with the same hostname-checking rules as the rest of Sykli's
+  HTTP layer (see `Sykli.HTTP.ssl_opts/1`).
+- Refuse to connect to plaintext HTTP except when `--insecure` is set
+  for local development. `--insecure` must log a clear warning per
+  connect.
+- Carry an `Authorization: Bearer <token>` header on every request that
+  needs authentication.
+
+The coordinator must:
+
+- Reject any request without TLS unless explicitly configured for
+  development.
+- Reject any request whose token is missing, malformed, expired, revoked,
+  or scoped to a different org/team.
+- Rate-limit join attempts per source IP and per token to resist token
+  exfiltration brute force.
+
+## Daemon identity
+
+Two ids matter:
+
+- `daemon_id` — stable, operator-chosen, unique within a team. Survives
+  reboots, reinstalls, and reconnections. Default: machine hostname,
+  overridable with `--name`.
+- `session_id` — issued by the coordinator on join. Lives only as long
+  as the daemon is connected. A new join produces a new `session_id`
+  even for the same `daemon_id`.
+
+Both are required. `daemon_id` lets the team reason about a stable agent
+("Yair's MacBook"), and `session_id` lets the coordinator reason about
+liveness without trusting the daemon's clock.
+
+## Example invocation
+
+```bash
+sykli daemon join \
+  --coordinator https://sykli.internal \
+  --org false-systems \
+  --team platform \
+  --token $SYKLI_TEAM_TOKEN \
+  --labels macos,docker,typescript \
+  --name yair-mbp
+```
+
+The token is read from the environment, not the command line, in
+production. `--token` accepts a value for one-shot use; the canonical
+form is `SYKLI_TEAM_TOKEN`.
+
+## Join request
+
+```http
+POST /v1/daemon-sessions HTTP/1.1
+Host: sykli.internal
+Authorization: Bearer <SYKLI_TEAM_TOKEN>
+Content-Type: application/json
+```
+
+```json
+{
+  "daemon_id": "yair-mbp",
+  "org": "false-systems",
+  "team": "platform",
+  "labels": ["macos", "docker", "typescript"],
+  "capabilities": ["local", "docker", "shell"],
+  "version": "0.6.1",
+  "accepts_remote_work": false
+}
+```
+
+Field rules:
+
+- `daemon_id` — required, non-empty, ≤ 128 chars, `[a-z0-9._-]+`.
+- `org`, `team` — required slugs. Must match the token's scope.
+- `labels` — array of strings; matches the existing mesh label vocabulary.
+- `capabilities` — closed set drawn from the daemon's actual configured
+  runtimes and targets (e.g. `local`, `docker`, `podman`, `shell`, `k8s`).
+  The daemon must not advertise a capability it does not have.
+- `version` — the daemon's `sykli` version string.
+- `accepts_remote_work` — explicit. Defaults to `false` if omitted. The
+  coordinator must treat omission as `false`. The daemon must require an
+  explicit `--accept-remote-work` (or config equivalent) to send `true`.
+
+## Coordinator response
+
+```json
+{
+  "ok": true,
+  "version": "1",
+  "data": {
+    "session_id": "sess_123",
+    "heartbeat_interval_seconds": 15,
+    "team_id": "team_123",
+    "policy": {
+      "sync_run_summaries": true,
+      "sync_evidence_refs": true,
+      "upload_raw_logs_by_default": false
+    }
+  },
+  "error": null
+}
+```
+
+Field rules:
+
+- `session_id` — opaque, ≤ 128 chars, scoped to this session only.
+- `heartbeat_interval_seconds` — the daemon must send the next heartbeat
+  within this many seconds of the previous successful heartbeat. The
+  coordinator picks the value; the daemon does not negotiate it.
+- `team_id` — the resolved team's id. The daemon stores it for later
+  requests but does not need to display it.
+- `policy` — coordinator-side configuration the daemon must obey when
+  deciding what to sync. Initial keys:
+  - `sync_run_summaries` — daemon must POST run summaries when true.
+  - `sync_evidence_refs` — daemon must register evidence refs when true.
+  - `upload_raw_logs_by_default` — see `docs/team-mode-security.md`. The
+    default and only secure value for v0 is `false`.
+
+If the coordinator rejects the join, the response uses the standard error
+envelope with a code from `docs/error-codes.md` (with new
+coordinator-specific codes added in Phase 4). Examples:
+
+- `team.token.invalid`
+- `team.token.expired`
+- `team.token.scope_mismatch`
+- `team.daemon.label_unknown`
+- `team.policy.refused_remote_work`
+
+## Heartbeat
+
+Every `heartbeat_interval_seconds`, the daemon POSTs:
+
+```http
+POST /v1/daemon-sessions/sess_123/heartbeat HTTP/1.1
+Authorization: Bearer <SYKLI_TEAM_TOKEN>
+Content-Type: application/json
+```
+
+```json
+{
+  "session_id": "sess_123",
+  "status": "available",
+  "current_work_item_id": null,
+  "labels": ["macos", "docker", "typescript"],
+  "capabilities": ["local", "docker", "shell"],
+  "last_run_id": "run_456"
+}
+```
+
+Field rules:
+
+- `status` — one of `available`, `busy`, `draining`. `draining` means the
+  daemon is finishing in-flight work but will not accept new work; it is
+  the equivalent of the SIGTERM drain behavior in `Sykli.Application`.
+- `current_work_item_id` — if the daemon is currently running a work item.
+- `labels` and `capabilities` — re-sent on every heartbeat. The
+  coordinator treats the latest heartbeat as authoritative. A daemon may
+  reduce its labels (Docker died, GPU disconnected) without rejoining.
+- `last_run_id` — the most recent run the daemon has reported. The
+  coordinator uses this to detect dropped run summaries.
+
+The heartbeat response is the daemon's pickup channel for shared
+decisions:
+
+```json
+{
+  "ok": true,
+  "version": "1",
+  "data": {
+    "next_heartbeat_seconds": 15,
+    "decisions": [
+      {
+        "type": "gate.approved",
+        "gate_id": "gate_789",
+        "decided_by": "yair",
+        "reason": "Evidence reviewed",
+        "decided_at": "2026-05-08T12:34:56Z"
+      }
+    ],
+    "assignments": [
+      {
+        "work_item_id": "work_42",
+        "assigned_at": "2026-05-08T12:34:50Z"
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+The decisions and assignments arrays may be empty. The daemon must
+process every entry it receives idempotently; the coordinator may
+re-send a decision if the previous heartbeat's response was dropped.
+
+If the coordinator returns 401/403, the daemon must stop sending and
+surface the failure to the operator. It must not retry blindly with
+the same token.
+
+## Heartbeat liveness
+
+- Coordinator marks `daemon_sessions.status = offline` if no heartbeat
+  arrives within `heartbeat_interval_seconds * 3`.
+- An offline session may still be resumed by the same `session_id` if
+  the gap is short. The exact cutoff is implementation-defined; a
+  reasonable default is 5 minutes.
+- After the cutoff, the `session_id` is dead. A new join is required.
+
+## Capability and label announcement
+
+A daemon advertises both **labels** (operator intent: `gpu`, `macos`,
+`docker`) and **capabilities** (engine reality: `local`, `docker`,
+`shell`, `k8s`). The two have different uses:
+
+- Labels are operator-defined strings. The coordinator may match them
+  against work item requirements but does not interpret their meaning.
+- Capabilities are drawn from a closed engine vocabulary. The
+  coordinator (and future placement logic) interprets them strictly.
+
+A daemon must not advertise a capability it cannot serve. The engine's
+`Sykli.Runtime.Resolver` is authoritative for what is available locally.
+
+## `accepts_remote_work` flag
+
+A daemon that holds `accepts_remote_work: false` may:
+
+- Create work items on behalf of its operator.
+- Claim work items its operator manually selected.
+- Run pipelines its operator started locally.
+- Report run summaries, gate states, and evidence refs.
+
+A daemon that holds `accepts_remote_work: false` may **not**:
+
+- Be assigned a work item by another operator's CLI.
+- Be assigned a work item by a coordinator scheduling decision.
+- Receive any "go run this" instruction from the coordinator.
+
+Default is `false`. The CLI must require an explicit
+`--accept-remote-work` flag (or equivalent config) to set it true. The
+daemon must log loudly when this flag is enabled.
+
+This is the seam that prevents the coordinator from becoming a remote
+shell. Without explicit consent, the coordinator can only observe.
+
+## Sync events (daemon → coordinator)
+
+The daemon emits the following events as POSTs to the relevant API:
+
+- `work.created` — `POST /v1/work-items`
+- `work.claimed` — `POST /v1/work-items/:id/claim`
+- `run.started` — `POST /v1/runs`
+- `run.node.updated` — `POST /v1/runs/:id/nodes`
+- `success_criteria.failed` — recorded under `POST /v1/runs/:id/nodes`
+  with the criterion result body
+- `review.completed` — recorded under `POST /v1/runs/:id/nodes` with
+  the review result body
+- `gate.requested` — `POST /v1/gates`
+- `gate.approved` — `POST /v1/gates/:id/approve` (originates from a
+  CLI/MCP call against the coordinator, not the daemon)
+- `gate.rejected` — `POST /v1/gates/:id/reject`
+- `run.completed` — `PATCH /v1/runs/:id`
+- `evidence.ref.created` — `POST /v1/evidence-refs`
+
+Every event must carry the originating `daemon_id`, `run_id` (when
+applicable), and `contract_hash` (for runs). Each event must be
+idempotent on retry: the coordinator de-duplicates by
+`(daemon_id, run_id, node_id, kind)` for run-level events and by
+explicit ids for work and gates.
+
+## Sync events (coordinator → daemon)
+
+Delivered as the `decisions` and `assignments` arrays in the heartbeat
+response (see above). Future expansions may add an SSE stream
+(`GET /v1/events/stream`); v0 correctness does not require it.
+
+## Disconnect and reconnect
+
+Disconnect (graceful):
+
+- The daemon receives SIGTERM or `sykli daemon stop`.
+- It transitions to `status: draining` on the next heartbeat.
+- It finishes in-flight work and records run summaries.
+- It POSTs a final heartbeat with `status: offline` if reachable, then
+  closes.
+
+Disconnect (network failure):
+
+- The daemon's heartbeat fails. It backs off exponentially with jitter,
+  capped at `heartbeat_interval_seconds * 4`.
+- Local execution continues unaffected. The daemon writes everything to
+  `.sykli/` exactly as in local-only mode.
+- Sync events accumulate in a per-daemon outbox (implementation detail
+  of the daemon).
+- On reconnect, the daemon flushes the outbox in order. Coordinator
+  idempotency keys make this safe.
+
+Reconnect:
+
+- If the previous `session_id` is still valid (gap under the cutoff),
+  the daemon may resume by sending heartbeats with that `session_id`.
+- If the gap is too long, the daemon performs a fresh join and obtains
+  a new `session_id`. The coordinator records the rejoin in the audit
+  log.
+
+The daemon must not invent its own retry storms. The exponential backoff
+above is mandatory.
+
+## Token revocation
+
+The coordinator may revoke a team token at any time. On the first
+heartbeat that returns 401/403:
+
+- The daemon stops sending sync events.
+- The daemon does not block local execution.
+- The daemon surfaces a `team.token.revoked` error code to the operator.
+- The daemon does not retry the token.
+
+Operators rotate tokens out of band (`sykli team token create`).
+
+## Security notes
+
+These are summarized here and detailed in `docs/team-mode-security.md`:
+
+- Outbound HTTPS only. No inbound to daemons.
+- TLS certificate verification is mandatory.
+- Tokens scoped per team. Tokens never carry execution authority for
+  other daemons unless the target daemon has `accepts_remote_work: true`.
+- The daemon never sends raw logs, secrets, source code, full
+  stdout/stderr, or full artifacts during the join, the heartbeat, or
+  any default sync event. It sends references and summaries.
+- The daemon's own `.sykli/` is unaffected by any coordinator behavior.
+  Secrets that masked locally remain masked. The
+  `Sykli.Occurrence.SecretMasker` rules still apply.
+- Audit log captures every join, rejoin, decision, and assignment.
+
+## Failure modes and required behavior
+
+| Situation                              | Daemon behavior                                                |
+|----------------------------------------|----------------------------------------------------------------|
+| Coordinator unreachable                | Continue local execution; back off heartbeats.                 |
+| TLS cert invalid                       | Refuse connection. Surface error to operator. Do not retry.    |
+| Token rejected                         | Stop sending events. Surface error. Do not retry until rotated.|
+| Heartbeat 5xx                          | Retry with exponential backoff and jitter.                     |
+| Heartbeat returns assignment but daemon has `accepts_remote_work: false` | Reject the assignment with `team.policy.refused_remote_work` and continue. |
+| Daemon crashes during run              | On restart, last `.sykli/` state is the source of truth. Daemon resumes by joining and re-syncing the missing run summary. |
+| Coordinator returns clock-skewed timestamp | Daemon uses its own monotonic clock for retry/backoff. Display strings honor the coordinator. |
+
+The default rule for any unspecified failure is: **never block local
+execution because of a coordination failure.**
+
+## What this protocol is not
+
+- It is not a remote-execution protocol.
+- It is not a code-distribution mechanism.
+- It is not a log shipper.
+- It is not a heartbeat-based scheduler.
+- It is not a federation protocol between coordinators.
+
+Each of those, if it ever exists, gets its own design doc.
+
+## Cross-references
+
+- `docs/coordination-modes.md` — modes A–D.
+- `docs/self-hosted-coordinator.md` — coordinator data model and API.
+- `docs/team-mode-security.md` — trust model and minimization rules.
+- `docs/local-state-plane.md` — what stays local versus what is synced.

--- a/docs/local-state-plane.md
+++ b/docs/local-state-plane.md
@@ -1,0 +1,238 @@
+# Local State Plane
+
+## Status
+
+Design document for Phase 0 of `docs/team-mode-roadmap.md`. Defines the
+relationship between each daemon's local `.sykli/` directory and the
+self-hosted coordinator's stored state. Normative for future
+implementation PRs.
+
+The on-disk schema for `.sykli/` is owned by `docs/false-protocol-schema.md`.
+This document specifies what crosses the boundary into the coordinator
+and, crucially, what does not.
+
+## Architecture sentence
+
+> The daemon executes and records; the mesh dispatches inside trusted
+> networks; the coordinator synchronizes team state across locations;
+> `.sykli/` remains the local source of detailed evidence.
+
+The local state plane is the "records" half of the daemon's job. The
+coordinator is a downstream projection of part of it.
+
+## The split
+
+> Local `.sykli/` = detailed local truth.
+>
+> Coordinator = shared projection for team coordination.
+
+Two stores. Different responsibilities. Different audiences. Different
+retention rules.
+
+`.sykli/` is the source of truth for everything Sykli observed on this
+machine. It carries the raw FALSE Protocol occurrences, attestations,
+artifacts, criterion outputs, and run history necessary for `sykli
+explain`, `sykli fix`, MCP tools, and AI-readable analysis.
+
+The coordinator's database is a projection: just enough metadata so that
+multiple humans, agents, and daemons can coordinate work without each
+needing to read every other machine's filesystem.
+
+The local store is rich. The coordinator's view is intentionally thin.
+
+## What lives in `.sykli/`
+
+Documented in detail in `docs/false-protocol-schema.md`. Summary:
+
+- `.sykli/occurrence.json` — the latest terminal occurrence.
+- `.sykli/occurrences_json/<run_id>.json` — last 20 archived runs (JSON).
+- `.sykli/occurrences/<run_id>.etf` — last 50 archived runs (ETF, fast
+  BEAM reload).
+- `.sykli/attestation.json` — DSSE envelope with SLSA v1.0 provenance
+  for the latest run.
+- `.sykli/attestations/` — per-task DSSE envelopes.
+- `.sykli/context.json` — pipeline structure and health from
+  `sykli context`.
+- `.sykli/test-map.json` — file → tasks mapping.
+- `.sykli/runs/` — per-run manifests for history.
+- (Phase 1 of the roadmap) `.sykli/work/items/<id>.json` — local work
+  item state.
+- (Phase 3 of the roadmap) `.sykli/gates/<gate-id>.json` — local gate
+  decision state.
+
+The local store is self-contained. A daemon with no coordinator
+connection writes the same `.sykli/` it always did. The local-only mode
+remains identical in shape to today.
+
+## What the coordinator stores
+
+Documented in detail in `docs/self-hosted-coordinator.md`. Summary:
+
+- Org and team registry.
+- Daemon sessions (id, labels, capabilities, last seen, online status).
+- Work items, claims, assignments, notes.
+- Run summaries (status, target, error code, started/finished).
+- Per-node run state (kind, status, error code).
+- Success criteria results (kind, status, message).
+- Review result summaries.
+- Gate state and decisions.
+- Evidence references (URI + hash + visibility).
+- Contract hashes and short summaries.
+- Audit log.
+
+The coordinator's view is a structured index. It tells the team **what**
+happened, **who** did it, and **where the evidence lives**. It does not
+duplicate the evidence itself.
+
+## What the coordinator syncs by default
+
+| Concept                          | Synced by default? |
+|----------------------------------|:------------------:|
+| Work item title, intent, status  | yes                |
+| Work item assignment / claim     | yes                |
+| Daemon heartbeat / liveness      | yes                |
+| Daemon labels and capabilities   | yes                |
+| Run status (`passed`/`failed`/...) | yes              |
+| Per-node status                  | yes                |
+| Gate state                       | yes                |
+| Approval / rejection decision    | yes                |
+| Review result **summary**        | yes                |
+| Run-level error code             | yes                |
+| Evidence reference (URI + hash)  | yes                |
+| Contract **hash** and **summary**| yes                |
+
+Each of these is small, structured, and free of operator secrets when
+combined with the masking rules in `docs/team-mode-security.md`.
+
+## What the coordinator does **not** sync by default
+
+| Concept                          | Synced by default? |
+|----------------------------------|:------------------:|
+| Secrets (env, files, config)     | no                 |
+| Full logs (stdout/stderr bodies) | no                 |
+| Source code                      | no                 |
+| Raw build artifacts              | no                 |
+| Environment dumps                | no                 |
+| Full review findings (beyond summary) | no            |
+| Raw contract JSON                | no                 |
+
+These remain on the originating daemon, in `.sykli/`. The coordinator
+records a reference, not the bytes.
+
+## The evidence reference pattern
+
+Whenever a daemon has a piece of evidence the team may need to consult
+later — an occurrence file, a DSSE attestation, a Check Run result, an
+artifact in object storage — it tells the coordinator about it via a
+single record:
+
+```jsonc
+{
+  "type": "occurrence",            // or attestation / artifact / github_check / local_ref / object_ref
+  "uri": "file:///Users/yair/proj/.sykli/occurrence.json",
+  "hash": "sha256:...",
+  "summary": "run 01KQPF... failed at task lint",
+  "visibility": "local_only"       // or team / external
+}
+```
+
+Resolution:
+
+- `visibility: local_only` — the URI is meaningful only on the originating
+  daemon. The team sees the reference and the hash but cannot fetch the
+  bytes. This is the **default** for `.sykli/`-resident evidence.
+- `visibility: team` — the URI is reachable from the team (e.g. a shared
+  object store the team operates). The reference is enough.
+- `visibility: external` — the URI is publicly resolvable (e.g. a
+  GitHub Check Run permalink). Anyone with the link can fetch.
+
+The coordinator never resolves the URI itself. It is metadata.
+
+This pattern keeps the coordinator small, keeps secrets local, and lets
+the team correlate runs across machines without uploading the world.
+
+## Why hash-only by default
+
+A `contract_hash` plus `summary` lets the team:
+
+- Compare two runs to confirm they ran the same contract.
+- Detect when a run drifted from the agreed-upon plan.
+- Audit "did anyone run an unfamiliar contract?"
+
+Without ever uploading the contract content. This is the same trade-off
+the engine already makes with cache keys: hashes are durable identifiers,
+and the bytes stay where they were generated.
+
+## Survivability
+
+The local plane survives the coordinator.
+
+- A daemon that has never seen a coordinator writes `.sykli/` exactly
+  as today.
+- A daemon whose coordinator is unreachable continues to write `.sykli/`.
+  Sync events queue in an outbox until reconnect. Local execution is
+  unaffected.
+- A daemon whose token is revoked stops syncing but keeps writing
+  `.sykli/`.
+- A coordinator whose database is wiped does not corrupt any daemon's
+  `.sykli/`. The coordinator's projection can be rebuilt by re-syncing
+  from each daemon (a future operations doc covers the backfill flow).
+
+The asymmetry is deliberate: the coordinator is convenient, but
+`.sykli/` is essential.
+
+## Survivability the other way
+
+The coordinator survives a daemon.
+
+- A daemon's machine dies. The coordinator still holds the work item,
+  the claim, the run summaries it received, the gate decisions, and the
+  evidence references with `visibility: local_only`.
+- Those local-only references become unreadable. The team learns the
+  evidence existed but cannot inspect it. This is the right outcome:
+  the coordinator did not steal the data; the team simply lost a
+  machine.
+- A new daemon can be assigned the same work item, run a new contract,
+  and create new evidence references. The audit log retains the prior
+  history.
+
+## Dual-surface dual-store
+
+`docs/done.md` requires every command to satisfy a human surface and an
+agent surface. With the coordinator, the same command may touch:
+
+- The local plane (`.sykli/`) — for `sykli explain`, `sykli fix`, MCP
+  tools, full evidence.
+- The coordinator — for `sykli work list --team`, `sykli gate approve`,
+  team-wide queries.
+
+A command that operates on both must be explicit about which it is
+reading. The CLI surface in `docs/team-mode-roadmap.md` uses `--team` (or
+the equivalent `--coordinator <url>`) to mean "operate against the
+coordinator." Without that flag, every command remains a local
+operation, exactly as today.
+
+This rule must hold for `--json` output as well: the envelope's `data`
+payload must carry a clear marker for which plane the answer came from
+(e.g. `"source": "local"` vs `"source": "coordinator"`).
+
+## What the local plane gains in Phase 1+
+
+The roadmap adds local-only state for work items and gates **before**
+networking turns on. That is intentional: a user should be able to:
+
+- Create and claim local work items in solo mode.
+- Approve local gates from the CLI.
+- Track per-run evidence locally.
+
+…and only later opt in to syncing those concepts to a coordinator. The
+local plane is the foundation; the coordinator is a sync target.
+
+## Cross-references
+
+- `docs/coordination-modes.md`
+- `docs/self-hosted-coordinator.md`
+- `docs/daemon-join-protocol.md`
+- `docs/team-mode-security.md`
+- `docs/team-mode-roadmap.md`
+- `docs/false-protocol-schema.md`

--- a/docs/self-hosted-coordinator.md
+++ b/docs/self-hosted-coordinator.md
@@ -1,0 +1,535 @@
+# Sykli Self-Hosted Coordinator
+
+## Status
+
+Design document for the Sykli Coordinator service. Phase 0 of
+`docs/team-mode-roadmap.md`. No implementation in this PR.
+
+The schema, API, and deployment shape below are normative for future
+implementation PRs but illustrative in detail (table column names, exact
+HTTP paths, Helm value names) until the first slice lands.
+
+## Product sentence
+
+Sykli is local-first execution with self-hosted team coordination.
+
+Long form:
+
+> Sykli lets teams run agentic work where they trust it — locally, in
+> Kubernetes, or on trusted workers — while coordinating work items,
+> assignments, runs, gates, approvals, and evidence through a self-hosted
+> coordinator.
+
+## Architecture sentence
+
+> The daemon executes and records; the mesh dispatches inside trusted
+> networks; the coordinator synchronizes team state across locations;
+> `.sykli/` remains the local source of detailed evidence.
+
+## Purpose
+
+The coordinator gives a team one shared, self-hosted source of truth for:
+
+- which work items exist
+- who claimed them
+- which runs were executed
+- which gates are waiting
+- which approvals were granted
+- where the detailed evidence lives
+
+It does **not** become the runtime. It does not own logs, artifacts,
+secrets, or source code. Execution authority remains with each daemon and
+its configured target (Local, Docker/Podman/Shell, or Kubernetes).
+
+## Non-goals
+
+The coordinator does **not** do any of the following in v0:
+
+- Remote shell or RPC into developer laptops.
+- Full log storage or hosted log search.
+- Artifact storage.
+- Source-code storage.
+- Secret storage or distribution.
+- Billing.
+- Complex RBAC. Roles are limited to `owner`, `member`, `approver`.
+- Global scheduling. The coordinator does not pre-empt local execution.
+- LLM provider integration (OpenAI, Anthropic, etc.).
+- Hosted SaaS behavior. The coordinator runs only in infrastructure the
+  user controls.
+- Web UI. The CLI and `--json` output are the surfaces.
+- Refactor of the existing BEAM mesh. The coordinator is additive.
+
+These restrictions are not aspirational. They define what the coordinator
+must keep out to remain local-first and self-hosted.
+
+## High-level architecture
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                Sykli Coordinator (self-hosted)              │
+│                                                             │
+│  HTTP/JSON API (v1)        ──┐                              │
+│  Postgres (state)            │                              │
+│  Audit log                   │   inbound HTTPS only         │
+│  Token issuer                │                              │
+│  (optional) SSE event stream │                              │
+└──────────────────────────────┴──────────────────────────────┘
+                ▲                              ▲
+                │ outbound HTTPS only          │ outbound HTTPS only
+                │                              │
+        ┌───────┴────────┐             ┌──────┴────────┐
+        │ Sykli daemon A │             │ Sykli daemon B│
+        │ (laptop)       │             │ (K8s gateway) │
+        │ executes locally             │ dispatches to │
+        │ writes .sykli/ │             │ trusted mesh  │
+        └────────────────┘             └───────────────┘
+```
+
+Properties:
+
+- **No inbound network to daemons.** Daemons always initiate the
+  connection. The coordinator never opens a socket to a laptop.
+- **No Erlang distribution between coordinator and daemons.** The
+  coordinator does not hold a BEAM cookie shared with daemons. The
+  protocol is HTTP/JSON.
+- **No execution on the coordinator.** It does not run user pipelines.
+- **One process surface.** All state is in one Postgres database. No
+  Kafka, Redis, or external broker is required to start.
+
+## Coordinator responsibilities (v0)
+
+The v0 coordinator does only this:
+
+- Org and team registry.
+- Daemon join, heartbeat, and session tracking.
+- Work item creation, listing, claiming, assignment, notes.
+- Run summary recording (status, target, started/finished, error code).
+- Per-node run status (kind, status, error code, evidence ref).
+- Gate request, approval, rejection.
+- Evidence reference sync (URI + hash + visibility, never the artifact).
+- Mandatory append-only audit log.
+
+That is the entire feature surface for v0. Anything else waits for a
+later design doc.
+
+## Sync model
+
+The coordinator is the **shared projection**. The local `.sykli/` directory
+is the **detailed local truth**. The relationship is documented in
+`docs/local-state-plane.md`.
+
+The default sync direction is **daemon → coordinator** for state changes
+(run started, run completed, gate requested) and **coordinator → daemon**
+for shared decisions (gate approved, work claimed by someone else).
+
+Initial transport choices:
+
+- Daemons POST events to the coordinator over HTTPS.
+- Daemons poll for new shared decisions on each heartbeat.
+- A future `GET /v1/events/stream` endpoint may stream events via
+  Server-Sent Events. **WebSockets are not required in v0.** SSE is
+  preferred because it is one-way, HTTP-shaped, and crosses proxies
+  cleanly.
+
+The coordinator does not push to daemons. Daemons reach the coordinator;
+the coordinator does not reach daemons.
+
+## Storage recommendation
+
+- **Postgres** for v0. Boring, durable, well-understood, available in
+  every operator's cluster.
+- One database, one schema, one migration tool (Ecto or equivalent in the
+  implementation language; this is a coordinator-internal decision).
+- Audit log is append-only. The coordinator never deletes audit log rows.
+- No Kafka, no Redis, no external broker in v0.
+
+Future versions may add object storage for opt-in evidence uploads, but
+that is out of scope here.
+
+## Security defaults
+
+Documented in detail in `docs/team-mode-security.md`. The short version:
+
+- Daemons connect outbound only.
+- TLS is required.
+- Authentication starts as **org/team join tokens**. OIDC and GitHub org
+  mapping are deferred.
+- Raw logs, artifacts, secrets, source code, and full stdout/stderr are
+  **never** synced by default.
+- A daemon must declare `accepts_remote_work: true` to receive work
+  originated by another daemon. Default is `false`.
+- Audit log is mandatory.
+- The LAN mesh trust model and the coordinator trust model are different.
+  See `docs/team-mode-security.md` for the explicit distinction.
+
+## Deployment shape
+
+The coordinator is intended to be deployed as a single Kubernetes
+workload in a cluster the operator already runs. Components:
+
+- `Deployment: sykli-coordinator` — the API process.
+- `Service: sykli-coordinator` — ClusterIP.
+- Optional `Ingress` — for HTTPS access from daemons outside the cluster.
+- Postgres — operator-managed, in-cluster or external.
+- `Secret: sykli-coordinator-token` — coordinator signing/authentication
+  secret used to mint and verify team tokens.
+- `Secret: sykli-db-url` — Postgres URL.
+- `ConfigMap: sykli-coordinator-config` — non-secret configuration.
+- `ServiceAccount` with minimal RBAC. The coordinator does not need
+  cluster-admin; it does not run user workloads.
+
+Example Helm-style values (illustrative, not normative for v0):
+
+```yaml
+coordinator:
+  image: false-systems/sykli-coordinator
+  replicas: 1
+
+database:
+  urlFromSecret: sykli-db-url
+
+auth:
+  tokenSecret: sykli-coordinator-token
+
+ingress:
+  enabled: true
+  host: sykli.internal.false.systems
+
+sync:
+  uploadRawLogsByDefault: false
+  allowRemoteExecutionByDefault: false
+```
+
+The actual chart or kustomization lands in Phase 9
+(`docs/team-mode-roadmap.md`). It is not part of this PR.
+
+## Data model v0
+
+The schema below is the conceptual shape. Column types, indexes, and
+exact constraints will be specified by the migration in Phase 4. Names
+are normative; types are illustrative.
+
+### `orgs`
+
+| column      | type        | notes                              |
+|-------------|-------------|------------------------------------|
+| `id`        | ulid/uuid   | primary key                        |
+| `slug`      | text unique | url-safe identifier (e.g. `false-systems`) |
+| `name`     | text        | display name                       |
+| `created_at`| timestamptz | UTC                                |
+
+### `teams`
+
+| column      | type      | notes                                    |
+|-------------|-----------|------------------------------------------|
+| `id`        | ulid/uuid | primary key                              |
+| `org_id`    | fk orgs   | required                                 |
+| `slug`      | text      | unique within org                        |
+| `name`      | text      | display name                             |
+| `created_at`| timestamptz | UTC                                    |
+
+### `members`
+
+| column        | type      | notes                                  |
+|---------------|-----------|----------------------------------------|
+| `id`          | ulid/uuid | primary key                            |
+| `org_id`      | fk orgs   | required                               |
+| `display_name`| text      | shown in CLI                           |
+| `email`       | text      | identity hint, not authentication      |
+| `role`        | enum      | `owner` \| `member` \| `approver`     |
+| `created_at`  | timestamptz | UTC                                  |
+
+Roles in v0:
+
+- `owner` — manage org, teams, tokens, members.
+- `member` — create/claim/run work.
+- `approver` — approve or reject gates.
+
+That is the entire RBAC. Per-resource ACLs are deferred.
+
+### `daemon_sessions`
+
+| column             | type      | notes                                   |
+|--------------------|-----------|-----------------------------------------|
+| `id`               | ulid/uuid | primary key (the `session_id`)          |
+| `org_id`           | fk orgs   | required                                |
+| `team_id`          | fk teams  | required                                |
+| `daemon_id`        | text      | stable per-daemon identifier            |
+| `display_name`     | text      | e.g. `yair-mbp`                         |
+| `status`           | enum      | `online` \| `offline` \| `busy`         |
+| `labels_json`      | jsonb     | array of strings                        |
+| `capabilities_json`| jsonb     | array of strings                        |
+| `accepts_remote_work` | bool   | default `false`                         |
+| `last_seen_at`     | timestamptz | updated on every heartbeat            |
+| `created_at`       | timestamptz | UTC                                   |
+
+### `work_items`
+
+| column              | type       | notes                                      |
+|---------------------|------------|--------------------------------------------|
+| `id`                | ulid/uuid  | primary key                                |
+| `org_id`            | fk orgs    | required                                   |
+| `team_id`           | fk teams   | required                                   |
+| `title`             | text       | one-line description                       |
+| `intent`            | text       | longer prose; agent-readable               |
+| `status`            | enum       | see below                                  |
+| `created_by`        | actor ref  | `(type, id)` pair                          |
+| `assigned_to_type`  | enum       | `member` \| `agent` \| `daemon` \| null   |
+| `assigned_to_id`    | text       | actor identifier                           |
+| `created_at`        | timestamptz| UTC                                        |
+| `updated_at`        | timestamptz| UTC                                        |
+
+`status` values: `open`, `claimed`, `running`, `blocked`, `done`,
+`failed`, `cancelled`.
+
+### `work_notes`
+
+| column         | type       | notes                          |
+|----------------|------------|--------------------------------|
+| `id`           | ulid/uuid  | primary key                    |
+| `work_item_id` | fk         | required                       |
+| `author_type`  | enum       | `member` \| `agent` \| `daemon`|
+| `author_id`    | text       | actor identifier               |
+| `body`         | text       | markdown allowed               |
+| `created_at`   | timestamptz| UTC                            |
+
+### `contracts`
+
+| column            | type       | notes                                       |
+|-------------------|------------|---------------------------------------------|
+| `id`              | ulid/uuid  | primary key                                 |
+| `work_item_id`    | fk         | nullable; contracts may exist before claim  |
+| `schema_version`  | text       | `"1"` \| `"2"` \| `"3"`                     |
+| `contract_hash`   | text       | sha256 of canonical JSON                    |
+| `summary`         | text       | short human-readable digest                 |
+| `raw_contract_json` | jsonb    | **opt-in upload only**                      |
+| `created_by`      | actor ref  | `(type, id)`                                |
+| `created_at`      | timestamptz| UTC                                         |
+
+Default behavior is to store `contract_hash` and `summary`. Uploading
+`raw_contract_json` is explicit per-team policy and per-call.
+
+### `runs`
+
+| column         | type        | notes                                 |
+|----------------|-------------|---------------------------------------|
+| `id`           | ulid/uuid   | primary key                           |
+| `work_item_id` | fk          | nullable                              |
+| `contract_id`  | fk          | required                              |
+| `daemon_id`    | text        | the executing daemon                  |
+| `status`       | enum        | see below                             |
+| `target`       | text        | `local` \| `k8s` \| etc.              |
+| `started_at`   | timestamptz | nullable until the run starts         |
+| `finished_at`  | timestamptz | nullable until the run terminates     |
+| `summary`      | text        | one-line digest                       |
+| `error_code`   | text        | from `docs/error-codes.md` if any     |
+| `created_at`   | timestamptz | UTC                                   |
+| `updated_at`   | timestamptz | UTC                                   |
+
+`status` values: `pending`, `running`, `passed`, `failed`, `blocked`,
+`cancelled`, `errored`. The `failed` vs `errored` distinction matches the
+engine's `TaskResult` semantics: content failure vs infrastructure failure.
+
+### `run_nodes`
+
+| column         | type        | notes                                  |
+|----------------|-------------|----------------------------------------|
+| `id`           | ulid/uuid   | primary key                            |
+| `run_id`       | fk          | required                               |
+| `node_id`      | text        | the contract's task id                 |
+| `kind`         | enum        | `task` \| `review` \| `gate` \| `verify` |
+| `status`       | enum        | matches engine `TaskResult` statuses   |
+| `started_at`   | timestamptz | nullable                               |
+| `finished_at`  | timestamptz | nullable                               |
+| `summary`      | text        | one-line digest                        |
+| `error_code`   | text        | nullable                               |
+
+### `success_criteria_results`
+
+| column          | type       | notes                                   |
+|-----------------|------------|-----------------------------------------|
+| `id`            | ulid/uuid  | primary key                             |
+| `run_id`        | fk         | required                                |
+| `node_id`       | text       | the executing task                      |
+| `criterion_id`  | text       | stable id of the criterion              |
+| `kind`          | enum       | `exit_code` \| `file_exists` \| `file_non_empty` |
+| `status`        | enum       | `passed` \| `failed` \| `unsupported`   |
+| `message`       | text       | human-readable explanation              |
+| `evidence_ref_id`| fk        | optional pointer to `evidence_refs`     |
+| `created_at`    | timestamptz| UTC                                     |
+
+Tracks the engine's `Sykli.SuccessCriteria` results at the team boundary.
+
+### `review_results`
+
+| column          | type       | notes                                          |
+|-----------------|------------|------------------------------------------------|
+| `id`            | ulid/uuid  | primary key                                    |
+| `run_id`        | fk         | required                                       |
+| `node_id`       | text       | the review node                                |
+| `review_type`   | text       | e.g. `api_breakage`                            |
+| `status`        | enum       | `passed` \| `failed` \| `unsupported` \| `errored` |
+| `severity`      | enum       | `info` \| `warning` \| `error`                 |
+| `summary`       | text       | one-line digest                                |
+| `findings_json` | jsonb      | optional structured findings                   |
+| `evidence_ref_id`| fk        | optional                                       |
+| `created_at`    | timestamptz| UTC                                            |
+
+### `gates`
+
+| column            | type       | notes                                        |
+|-------------------|------------|----------------------------------------------|
+| `id`              | ulid/uuid  | primary key                                  |
+| `work_item_id`    | fk         | nullable                                     |
+| `run_id`          | fk         | required                                     |
+| `node_id`         | text       | the gate node                                |
+| `status`          | enum       | `waiting` \| `approved` \| `rejected` \| `blocked` \| `expired` |
+| `reason`          | text       | human-supplied                               |
+| `requested_by_type`| enum      | `member` \| `agent` \| `daemon`              |
+| `requested_by_id` | text       |                                              |
+| `decided_by`      | text       | nullable until decided                       |
+| `decided_at`      | timestamptz| nullable until decided                       |
+| `created_at`      | timestamptz| UTC                                          |
+
+### `evidence_refs`
+
+| column        | type       | notes                                            |
+|---------------|------------|--------------------------------------------------|
+| `id`          | ulid/uuid  | primary key                                      |
+| `work_item_id`| fk         | nullable                                         |
+| `run_id`      | fk         | nullable                                         |
+| `node_id`     | text       | nullable                                         |
+| `type`        | enum       | `occurrence` \| `attestation` \| `artifact` \| `github_check` \| `local_ref` \| `object_ref` |
+| `uri`         | text       | resolvable; may be local-only                    |
+| `hash`        | text       | sha256                                           |
+| `summary`     | text       | optional short label                             |
+| `visibility`  | enum       | `local_only` \| `team` \| `external`             |
+| `created_at`  | timestamptz| UTC                                              |
+
+`visibility = local_only` means the URI is a path on the originating
+daemon's filesystem (typically inside `.sykli/`). The coordinator records
+the reference; it does not fetch the object. `team` and `external`
+visibility imply the referenced object is accessible at the URI from the
+team or wider audience respectively.
+
+### `audit_log`
+
+| column         | type        | notes                                    |
+|----------------|-------------|------------------------------------------|
+| `id`           | ulid/uuid   | primary key                              |
+| `org_id`       | fk          | required                                 |
+| `team_id`      | fk          | nullable                                 |
+| `actor_type`   | enum        | `member` \| `agent` \| `daemon` \| `system` |
+| `actor_id`     | text        | actor identifier                         |
+| `action`       | text        | e.g. `gate.approved`                     |
+| `subject_type` | text        | e.g. `gate`, `work_item`, `run`          |
+| `subject_id`   | text        |                                          |
+| `metadata_json`| jsonb       | arbitrary structured context             |
+| `created_at`   | timestamptz | UTC                                      |
+
+The audit log is append-only. The coordinator never updates or deletes
+rows. Every state-changing API call writes at least one row.
+
+## Minimal API sketch
+
+This is a v0 sketch, not the final contract. Endpoints are versioned
+under `/v1`. All endpoints accept and return JSON. All endpoints require
+TLS. All endpoints require an `Authorization: Bearer <token>` header
+unless explicitly marked otherwise (e.g. `/healthz`).
+
+Org / team:
+
+```text
+POST  /v1/orgs                       # owner only; bootstrap or invite-driven
+POST  /v1/teams                      # owner only
+```
+
+Daemon session:
+
+```text
+POST  /v1/daemon-sessions            # daemon join (see daemon-join-protocol.md)
+POST  /v1/daemon-sessions/:id/heartbeat
+```
+
+Work items:
+
+```text
+GET   /v1/work-items                 # list, filter by team/status/assignee
+POST  /v1/work-items                 # create
+GET   /v1/work-items/:id             # show
+POST  /v1/work-items/:id/claim       # actor claims
+POST  /v1/work-items/:id/assign      # owner/approver assigns
+POST  /v1/work-items/:id/notes       # append note
+```
+
+Runs:
+
+```text
+POST  /v1/runs                       # daemon reports a new run
+PATCH /v1/runs/:id                   # update status / finished_at / summary
+POST  /v1/runs/:id/nodes             # append/update run node state
+```
+
+Gates:
+
+```text
+GET   /v1/gates                      # list waiting/decided
+POST  /v1/gates                      # daemon registers a waiting gate
+POST  /v1/gates/:id/approve          # approver decision
+POST  /v1/gates/:id/reject           # approver decision
+```
+
+Evidence:
+
+```text
+POST  /v1/evidence-refs              # daemon registers a reference
+GET   /v1/evidence-refs/:id          # show metadata; never the object body
+```
+
+Future, not v0:
+
+```text
+GET   /v1/events/stream              # SSE; not required for v0 correctness
+```
+
+Health:
+
+```text
+GET   /healthz                       # unauthenticated; returns coordinator readiness
+```
+
+Every response uses the same envelope shape Sykli already uses for `--json`
+output (`Sykli.CLI.JsonResponse`):
+
+```jsonc
+{
+  "ok": true,
+  "version": "1",
+  "data": { /* endpoint payload */ },
+  "error": null
+}
+```
+
+Errors carry `{ "ok": false, "error": { "code", "message", "hints": [..] } }`
+with codes from `docs/error-codes.md` extended with coordinator-specific
+codes when needed.
+
+## Where this document does not go
+
+The following are intentionally not specified here:
+
+- Wire-level pagination cursors and rate-limit headers — defer to Phase 4.
+- Internal storage layout (table partitioning, archival rules) — defer
+  to operator preference at deploy time.
+- Multi-region or HA topology — single replica is acceptable for v0.
+- Federation between coordinators — a future doc.
+
+## Cross-references
+
+- `docs/coordination-modes.md` — where the coordinator fits in.
+- `docs/daemon-join-protocol.md` — how a daemon connects.
+- `docs/team-mode-security.md` — trust model and minimization rules.
+- `docs/local-state-plane.md` — what stays in `.sykli/` vs the coordinator.
+- `docs/team-mode-roadmap.md` — phased implementation plan.
+- `docs/error-codes.md` — public error code catalog.
+- `docs/false-protocol-schema.md` — local on-disk schema for evidence.

--- a/docs/team-mode-roadmap.md
+++ b/docs/team-mode-roadmap.md
@@ -1,0 +1,517 @@
+# Sykli Team Mode Roadmap
+
+## Status
+
+Design document. Phase 0 of the work it describes. Defines the phased
+implementation plan from local-only Sykli to a self-hosted coordinator
+serving teams of humans, agents, and daemons.
+
+Each phase below is one or more PRs. No phase past 0 is in this PR.
+
+## Architecture sentence
+
+> The daemon executes and records; the mesh dispatches inside trusted
+> networks; the coordinator synchronizes team state across locations;
+> `.sykli/` remains the local source of detailed evidence.
+
+The roadmap below holds that sentence true at every step.
+
+## Guiding rules across all phases
+
+- **Local-first stays the floor.** Each phase must keep local-only mode
+  identical in behavior to today's experience.
+- **No phase introduces remote execution by default.** Remote work
+  requires explicit `accepts_remote_work: true` per
+  `docs/daemon-join-protocol.md`.
+- **Every CLI surface gains `--json`** before it gets a network surface.
+  `docs/done.md` applies.
+- **Every CLI surface gains an MCP counterpart** unless explicitly
+  documented as local-only.
+- **No `expected_failure` shortcuts.** New black-box and conformance
+  cases must pass on the slice that introduces them; bugs get fixed
+  before merge or get tracking issues.
+- **Defaults are minimal.** The first time a phase enables a sync, the
+  default policy must be the safest of the options in
+  `docs/team-mode-security.md`.
+
+## Phase 0 — Design docs
+
+**This PR.** No implementation. Six docs:
+
+- `docs/coordination-modes.md`
+- `docs/self-hosted-coordinator.md`
+- `docs/daemon-join-protocol.md`
+- `docs/team-mode-security.md`
+- `docs/local-state-plane.md`
+- `docs/team-mode-roadmap.md` (this file)
+
+Exit criteria: docs land. Definition of done: `docs/done.md` aligned for
+future phases; `git diff --check` passes; PR description complete.
+
+## Phase 1 — Local work item model
+
+Add local work item state **before** any networking. A team-less user
+must benefit from work items the day they ship.
+
+Suggested modules:
+
+- `Sykli.WorkItem` — struct + constructors + JSON shape.
+- `Sykli.Work.Store` — file-backed, atomic write, list/show/claim.
+
+Suggested local path:
+
+```text
+.sykli/work/items/<id>.json
+```
+
+Suggested CLI:
+
+```bash
+sykli work create "Investigate failing checkout deploy"
+sykli work list
+sykli work show <work-id>
+sykli work claim <work-id>
+sykli work note <work-id> "Found likely API breakage"
+```
+
+Each command must support `--json` and return the standard envelope.
+
+Exit criteria:
+
+- Black-box cases for the happy path and at least one negative case per
+  command.
+- `sykli context` recognizes the new directory.
+- MCP tools `list_work_items`, `get_work_item`, `claim_work_item`,
+  `create_work_item`, `append_work_note` exist (local-only).
+
+## Phase 2 — Associate runs with work items
+
+A run can belong to a work item. The local store gains a join.
+
+Suggested CLI:
+
+```bash
+sykli run contract.json --work <work-id>
+sykli work runs <work-id>
+```
+
+Run summary additions:
+
+- `work_item_id`
+- `contract_hash`
+- `status`
+- `nodes`
+- `gates`
+- `criteria_results`
+- `evidence_refs`
+
+Exit criteria:
+
+- The summary block in `.sykli/runs/<run_id>.json` carries the new fields
+  when a `--work` flag was supplied.
+- `sykli explain` and `sykli fix` surface the work item id when
+  available.
+- Conformance cases unchanged (no SDK contract change in this phase).
+
+## Phase 3 — Local gate decision state
+
+Make approvals and rejections first-class locally. This is the dry run
+of the coordinator's gate flow, but entirely on one machine.
+
+Suggested CLI:
+
+```bash
+sykli gates list
+sykli gate approve <gate-id> --reason "Looks safe"
+sykli gate reject <gate-id> --reason "API breakage not acceptable"
+```
+
+Suggested local path:
+
+```text
+.sykli/gates/<gate-id>.json
+```
+
+Exit criteria:
+
+- A blocked run with a gate persists the gate state to disk.
+- A subsequent `sykli gate approve` resumes the run on its next attempt.
+- `sykli explain` shows gate state in human and JSON output.
+- MCP tools `list_gates`, `approve_gate`, `reject_gate` exist
+  (local-only).
+
+## Phase 4 — Coordinator skeleton
+
+First server-side phase. Stand up a minimal self-hosted service.
+
+Suggested modules:
+
+- `Sykli.Coordinator.Application`
+- `Sykli.Coordinator.Router`
+- `Sykli.Coordinator.Store`
+
+Suggested storage: Postgres.
+
+Initial endpoints:
+
+```text
+GET  /healthz
+POST /v1/orgs
+POST /v1/teams
+POST /v1/daemon-sessions
+POST /v1/daemon-sessions/:id/heartbeat
+POST /v1/work-items
+GET  /v1/work-items
+GET  /v1/work-items/:id
+```
+
+Token issuance lands here too: `sykli team token create` mints a bearer
+token for a (org, team) pair.
+
+Exit criteria:
+
+- A coordinator process starts under `sykli coordinator start`.
+- `sykli coordinator migrate` runs schema migrations.
+- `sykli coordinator status` reports liveness.
+- TLS termination is documented (recommended: terminate at Ingress;
+  optional in-process TLS for direct deploys).
+- Audit log row written for every state-changing call.
+
+## Phase 5 — Daemon join and heartbeat sync
+
+Daemons connect outbound and announce themselves.
+
+Suggested CLI:
+
+```bash
+sykli daemon join \
+  --coordinator https://sykli.internal \
+  --org false-systems \
+  --team platform \
+  --token $SYKLI_TEAM_TOKEN \
+  --labels macos,docker,typescript \
+  --name yair-mbp
+
+sykli daemon status
+```
+
+Coordinator tracks:
+
+- daemon online/offline
+- labels
+- capabilities
+- `last_seen_at`
+- `accepts_remote_work` flag
+
+Exit criteria:
+
+- `daemon join` succeeds against the coordinator from Phase 4.
+- Heartbeats keep `daemon_sessions.status` in `online`.
+- A killed daemon transitions to `offline` after the documented
+  liveness cutoff.
+- `sykli daemon status` reflects coordinator-side state when joined,
+  local-only state when not.
+- Black-box cases cover token rejection, TLS failure, and reconnect.
+
+## Phase 6 — Work sync
+
+The local work store gains a `--team` mode.
+
+Suggested CLI:
+
+```bash
+sykli work create --team "Investigate failing checkout deploy"
+sykli work list --team
+sykli work claim <work-id> --team
+sykli work assign <work-id> --to agent:claude --team
+sykli work note <work-id> --team "Investigated, see local evidence"
+```
+
+Without `--team`, every command is local exactly as in Phase 1. With
+`--team`, operations write to (or read from) the coordinator and the
+audit log records each one.
+
+Exit criteria:
+
+- `sykli work list --team` returns the coordinator's view, paginated.
+- `sykli work claim <id> --team` is atomic at the coordinator: only one
+  successful claim per work item.
+- `--json` envelope distinguishes `"source": "coordinator"` from
+  `"source": "local"`.
+
+## Phase 7 — Run summary sync
+
+After a local or K8s run, a joined daemon publishes a summary to the
+coordinator.
+
+Sync set:
+
+- run status
+- node statuses
+- error codes
+- success criteria results summary
+- review results summary
+- gate state
+- evidence refs (with `visibility` per
+  `docs/local-state-plane.md`)
+
+Exit criteria:
+
+- A passing run produces one `runs` row plus N `run_nodes` rows on the
+  coordinator.
+- A failing run includes the error code and the originating evidence
+  ref.
+- A run with success criteria produces `success_criteria_results` rows.
+- Evidence refs with `visibility: local_only` are stored as references,
+  never as bytes.
+- The daemon's outbox successfully replays after a coordinator outage.
+
+## Phase 8 — Gate approval sync
+
+The coordinator becomes the place where one person approves something
+another person ran.
+
+Flow:
+
+1. The daemon executing a run reaches a gate. It POSTs `gate.requested`
+   and pauses the run.
+2. The coordinator records the gate in `waiting`.
+3. A reviewer runs `sykli gate approve <gate-id> --reason "..."` against
+   the coordinator (CLI or MCP).
+4. The coordinator records the decision in the audit log and surfaces
+   it to the daemon on the next heartbeat.
+5. The daemon resumes the run (or marks it `rejected`).
+
+Exit criteria:
+
+- A reviewer on a different machine successfully approves a gate
+  initiated by another daemon.
+- The local `.sykli/gates/<gate-id>.json` is updated by the daemon when
+  it picks up the decision.
+- `sykli gates list --team` shows waiting gates across the team.
+- The audit log reflects the full lifecycle.
+
+## Phase 9 — Kubernetes deployment
+
+Ship a deployable bundle.
+
+Suggested layout:
+
+```text
+deploy/kubernetes/
+  base/
+    deployment.yaml
+    service.yaml
+    serviceaccount.yaml
+    configmap.yaml
+    secret.example.yaml
+  overlays/
+    dev/
+    prod/
+```
+
+Or, equivalently:
+
+```text
+helm/sykli-coordinator/
+  Chart.yaml
+  values.yaml
+  templates/
+```
+
+Required components:
+
+- `Deployment: sykli-coordinator`
+- `Service: sykli-coordinator`
+- Optional `Ingress`
+- Postgres reference (in-cluster operator or external URL via Secret)
+- `Secret: sykli-coordinator-token`
+- `Secret: sykli-db-url`
+- `ConfigMap: sykli-coordinator-config`
+- `ServiceAccount` with minimal RBAC
+
+Exit criteria:
+
+- A documented `kubectl apply` (or `helm install`) flow brings up a
+  coordinator that survives a pod restart.
+- The coordinator's TLS termination is documented for both Ingress and
+  direct deploys.
+- Liveness/readiness probes hit `/healthz`.
+
+## Phase 10 — MCP team tools
+
+Expose team coordination to agents.
+
+Suggested tools:
+
+- `list_work_items`
+- `get_work_item`
+- `claim_work_item`
+- `create_work_item`
+- `append_work_note`
+- `list_runs`
+- `get_run`
+- `get_run_nodes`
+- `get_run_evidence`
+- `list_gates`
+- `approve_gate`
+- `reject_gate`
+- `list_daemons`
+- `get_daemon_capabilities`
+
+Important rule:
+
+> MCP must not expose dangerous execution by default.
+
+Tools that drive execution (`run_pipeline`, anything that triggers a
+remote daemon) require explicit per-deployment configuration and remain
+off by default. The default tool set is read-mostly: list, get, append
+note, approve gate, reject gate.
+
+Exit criteria:
+
+- The MCP server documents each tool in `docs/mcp-tools.md`.
+- Each tool returns the standard `JsonResponse`-shaped envelope.
+- Black-box and MCP tests cover at least one tool per coordinator
+  endpoint added in Phases 4–8.
+
+## CLI surface (target)
+
+Once Phases 1–10 are complete, the CLI looks like this:
+
+Coordinator lifecycle:
+
+```bash
+sykli coordinator start
+sykli coordinator migrate
+sykli coordinator status
+```
+
+Org and team:
+
+```bash
+sykli org create false-systems
+sykli team create platform --org false-systems
+sykli team token create platform
+```
+
+Daemon:
+
+```bash
+sykli daemon start
+sykli daemon join --coordinator https://sykli.internal --org false-systems --team platform
+sykli daemon status
+```
+
+Work:
+
+```bash
+sykli work create "Investigate failing checkout deploy"
+sykli work list
+sykli work show <work-id>
+sykli work claim <work-id>
+sykli work assign <work-id> --to agent:claude
+sykli work note <work-id> "Found likely API breakage"
+```
+
+Run:
+
+```bash
+sykli work run <work-id> contract.json
+sykli runs list --work <work-id>
+sykli run show <run-id>
+sykli run evidence <run-id>
+```
+
+Gates:
+
+```bash
+sykli gates list
+sykli gate show <gate-id>
+sykli gate approve <gate-id> --reason "Looks safe"
+sykli gate reject <gate-id> --reason "API breakage not acceptable"
+```
+
+Every relevant command supports `--json` because agents need
+machine-readable output. Every command's `--help` documents whether it
+operates on local state, coordinator state, or both (via `--team`).
+
+## First useful demo
+
+Concrete scenario the design optimizes for, achievable after Phases 6–8:
+
+1. Yair creates a work item:
+
+   ```bash
+   sykli work create "Review PR #176 for timeout and success criteria behavior" --team platform
+   ```
+
+2. Dima sees it and claims it:
+
+   ```bash
+   sykli work list --team platform
+   sykli work claim <work-id>
+   ```
+
+3. Dima's daemon runs a Sykli contract:
+
+   ```bash
+   sykli work run <work-id> review-contract.json
+   ```
+
+4. The run reaches a review/gate/verify node and pauses. The daemon
+   reports `gate.requested` to the coordinator.
+
+5. The gate blocks. Yair (or any approver) inspects the run:
+
+   ```bash
+   sykli gates list --team platform
+   sykli gate show <gate-id>
+   ```
+
+6. Yair approves or rejects from the CLI:
+
+   ```bash
+   sykli gate approve <gate-id> --reason "Evidence reviewed"
+   ```
+
+7. Dima's daemon picks up the decision on its next heartbeat and
+   continues the run.
+
+8. The work item records the outcome and the evidence references. Both
+   Yair and Dima can see the same run summary, the same gate decision,
+   and the same per-task statuses.
+
+This demo crosses two machines, two networks, and two humans, without
+either machine being on the same LAN. That is the whole point.
+
+## Non-goals throughout the roadmap
+
+These do not appear in any phase here. Each requires its own design doc
+if reconsidered:
+
+- SaaS hosted control plane.
+- Billing.
+- Web UI.
+- Complex RBAC beyond `owner`/`member`/`approver`.
+- Artifact or log hosting by default.
+- Remote shell.
+- Global scheduler that pre-empts local execution.
+- LLM provider integration on the coordinator.
+- OAuth enterprise admin work in v0.
+- Refactor of BEAM mesh transport.
+- Mandatory upload of full run data.
+- Secrets synced by default.
+- Federation between coordinators.
+
+## Cross-references
+
+- `docs/coordination-modes.md`
+- `docs/self-hosted-coordinator.md`
+- `docs/daemon-join-protocol.md`
+- `docs/team-mode-security.md`
+- `docs/local-state-plane.md`
+- `docs/done.md`
+- `docs/error-codes.md`
+- `docs/false-protocol-schema.md`
+- `docs/mcp-tools.md`

--- a/docs/team-mode-security.md
+++ b/docs/team-mode-security.md
@@ -1,0 +1,297 @@
+# Sykli Team Mode Security Model
+
+## Status
+
+Design document for Phase 0 of `docs/team-mode-roadmap.md`. Defines the
+trust model and security defaults for the self-hosted coordinator and
+the daemon-to-coordinator protocol. Normative for future implementation
+PRs.
+
+## Architecture sentence
+
+> The daemon executes and records; the mesh dispatches inside trusted
+> networks; the coordinator synchronizes team state across locations;
+> `.sykli/` remains the local source of detailed evidence.
+
+The security model below preserves that sentence under attack: the
+coordinator must never become a remote-execution surface, and a daemon
+must never accidentally sync data the operator did not consent to share.
+
+## Threat posture
+
+The coordinator runs on infrastructure the team operates. Daemons run on
+laptops, servers, and Kubernetes pods owned by their respective operators.
+
+Assumed adversaries:
+
+- A network observer between any daemon and the coordinator.
+- A coordinator compromise (e.g. a stolen Postgres dump).
+- A leaked team token.
+- A malicious member of the team with `member` role.
+- A daemon impersonator who learns a `daemon_id`.
+
+Assumed *not* in scope for v0:
+
+- A nation-state actor with a valid CA-signed certificate for your
+  coordinator's hostname.
+- An attacker with persistent root on a developer laptop. (At that
+  point, the local-first guarantee is already gone; secrets and logs
+  on the laptop are the bigger problem.)
+- Insider threats with `owner` role. Owners can do everything; they are
+  trusted by the design.
+
+## Hard rules
+
+These rules are enforced by code in implementation phases and tested in
+the conformance and black-box suites. They are not aspirational.
+
+1. **The coordinator is self-hosted.** No SaaS. No hosted control plane
+   from upstream Sykli.
+2. **The network is opt-in.** Local-only mode requires no network. The
+   coordinator becomes a participant only when the operator explicitly
+   joins a daemon.
+3. **The daemon connects outbound.** The coordinator never opens a
+   socket to a daemon.
+4. **TLS is required** for any non-local-development deployment. TLS
+   certificate verification follows the existing Sykli HTTP TLS rules
+   (`Sykli.HTTP.ssl_opts/1`): `verify_peer` plus hostname checking.
+5. **Raw logs are not synced by default.**
+6. **Artifacts are not uploaded by default.**
+7. **Remote execution is off by default.** A daemon must declare
+   `accepts_remote_work: true` to be assigned work originated by anyone
+   else.
+8. **Secrets are never synced by default.** Sykli's existing
+   `SecretMasker` rules apply to anything the daemon emits to the
+   coordinator. Env vars matching `_TOKEN`, `_SECRET`, `_KEY`,
+   `_PASSWORD`, `_URL`, `_DSN`, `_URI`, `_CONN`, etc. are masked before
+   transmission.
+9. **Source code is not synced by default.**
+10. **Full stdout/stderr is not synced by default.** The daemon may sync
+    a short failure excerpt for human review (e.g. last 10 lines), but
+    only when the operator's policy permits it.
+11. **The audit log is mandatory.** Every state-changing API call writes
+    at least one row in the coordinator's append-only audit log. The
+    coordinator never deletes audit log rows.
+12. **No remote shell.** There is no API to run a command on a daemon.
+    There is no API to upload code to a daemon. There is no API to
+    fetch arbitrary files from a daemon.
+
+Any violation of the above is a security bug, not a feature request.
+
+## Authentication
+
+### v0 — team join tokens
+
+The coordinator issues team-scoped tokens through `sykli team token create`.
+
+Properties:
+
+- Bearer tokens, opaque, ≥ 256 bits of entropy.
+- Issued per (org, team) pair.
+- Carry no execution authority over individual daemons.
+- Revocable at any time. Revocation invalidates all sessions on the
+  next heartbeat.
+- Stored on daemons in `SYKLI_TEAM_TOKEN` (env var) or a config file
+  with strict file permissions (`0600`). Never written to a CLI argument
+  in production.
+
+Tokens are not user identities. They authenticate a daemon's right to
+participate in a team. Member identities (who claimed a work item, who
+approved a gate) are separately recorded based on the originating CLI
+or MCP call.
+
+### Future — OIDC and GitHub org mapping
+
+Out of scope for v0. The design admits a future where:
+
+- Members authenticate via OIDC (Google Workspace, GitHub OIDC, etc.).
+- Team membership maps automatically from a GitHub org or an SSO group.
+- Tokens are short-lived and refreshed against an identity provider.
+
+That is not part of this PR. The v0 token model must not preclude it.
+
+## Authorization
+
+Three roles in v0: `owner`, `member`, `approver`.
+
+Permissions:
+
+| Action                                | owner | member | approver |
+|---------------------------------------|:-----:|:------:|:--------:|
+| Create org                            | ✓     | —      | —        |
+| Create team                           | ✓     | —      | —        |
+| Mint team tokens                      | ✓     | —      | —        |
+| Add/remove members                    | ✓     | —      | —        |
+| Create work items                     | ✓     | ✓      | ✓        |
+| Claim/assign work items               | ✓     | ✓      | ✓        |
+| Append work notes                     | ✓     | ✓      | ✓        |
+| Create runs from a daemon             | ✓ (as daemon) | ✓ (as daemon) | ✓ (as daemon) |
+| Approve gates                         | ✓     | —      | ✓        |
+| Reject gates                          | ✓     | —      | ✓        |
+| Read audit log                        | ✓     | own actions only | ✓ |
+
+Per-resource ACLs are deferred. A team-scoped token implies access to
+all work items inside that team. If a team needs finer-grained access,
+they create more teams.
+
+## LAN mesh vs coordinator: different trust models
+
+This is the single most important distinction in Team Mode. The two
+mechanisms exist for different trust postures and must not be conflated.
+
+### LAN mesh
+
+- Mechanism: BEAM/libcluster, Erlang distribution, shared cookie.
+- Trust unit: the cluster. Every node holds the cookie. Every node can
+  RPC into every other node.
+- Network: trusted (LAN, VPN, K8s namespace, Tailscale tailnet treated
+  as one trust domain).
+- Authentication: Erlang cookie + reachability.
+- Authorization: implicit. If you are in the mesh, you are in.
+- Failure mode if compromised: full RCE across every mesh node.
+- Appropriate for: internal CI clusters, trusted worker pools, K8s
+  worker daemons inside one namespace.
+- **Not** appropriate for: WAN, untrusted networks, cross-company work,
+  or any setting where mutual RPC trust is not warranted.
+
+### Coordinator
+
+- Mechanism: HTTPS, JSON, bearer tokens.
+- Trust unit: each daemon's connection to the coordinator. Daemons do
+  **not** transitively trust each other.
+- Network: untrusted by default. The coordinator may be reachable over
+  the public internet through an Ingress.
+- Authentication: TLS + team token.
+- Authorization: explicit per role and per `accepts_remote_work` flag.
+- Failure mode if compromised: the coordinator's database is exposed
+  (work items, run summaries, evidence references). Daemons remain
+  uncompromised; the coordinator cannot RCE into them.
+- Appropriate for: remote teams, NAT, home networks, cloud workers
+  outside the LAN, cross-org collaboration.
+
+The coordinator is **not** a substitute for the mesh. The mesh is **not**
+a substitute for the coordinator. Hybrid mode combines them as
+documented in `docs/coordination-modes.md`.
+
+### What this means in practice
+
+- Do not give a non-Sykli machine the BEAM cookie just to "extend the
+  mesh over the WAN." That breaks the mesh's trust model.
+- Do not trust a coordinator just because it is reachable. The token
+  determines what the coordinator may know.
+- Do not let the coordinator open inbound connections to your daemon.
+  If a future feature needs that, the design must be revisited; the
+  current model says no.
+- Do not rely on coordinator state being secret. Treat it as
+  team-visible by definition.
+
+## Data minimization
+
+The coordinator's job is coordination. It is not a log warehouse, an
+artifact registry, or a code mirror. The default sync set is:
+
+Synced by default:
+
+- Work item metadata (title, intent, status, assignment).
+- Daemon labels, capabilities, heartbeat liveness.
+- Run summaries (status, target, started/finished, error code).
+- Per-node run state (kind, status, error code).
+- Success criteria results (kind, status, message).
+- Review result summaries (review type, status, severity, summary).
+- Gate state (waiting, approved, rejected) and decision reason.
+- Evidence references (URI + sha256 + visibility), never the bytes.
+- Contract hashes and short summaries.
+
+Not synced by default:
+
+- Full stdout / stderr.
+- Local logs.
+- Source code.
+- Raw artifacts.
+- Environment variable dumps.
+- Secrets.
+- Full review findings (only the summary, unless explicitly opted in).
+
+A team may opt in to richer sync via the `policy` block returned at
+join time (see `docs/daemon-join-protocol.md`). Opting in must be a
+deliberate per-team configuration; the coordinator must not flip these
+defaults silently.
+
+## Secret handling
+
+- Secrets are not part of the contract synced to the coordinator. The
+  coordinator stores `contract_hash` and `summary`. If a team opts to
+  upload `raw_contract_json`, the daemon must run the existing
+  `Sykli.Occurrence.SecretMasker` on it first.
+- Environment variables are not synced. Capability advertisements
+  enumerate runtime presence (`docker`, `shell`, `k8s`), not the
+  configuration of those runtimes.
+- Tokens for SCM integrations (`GITHUB_TOKEN`, `GITLAB_TOKEN`, etc.)
+  remain on the daemon. The coordinator does not store them.
+- TLS private keys, signing keys, OIDC client secrets, and database
+  credentials live on the coordinator side only and are mounted from
+  Kubernetes Secrets.
+
+## Audit log
+
+Mandatory. Append-only. Written for at least:
+
+- Daemon join and rejoin.
+- Token issue and revocation.
+- Work item create, claim, assign, status change.
+- Run start and terminal status.
+- Gate request, approve, reject, expire.
+- Evidence ref creation.
+- Member add/remove and role change.
+
+The audit log row carries the actor `(type, id)`, the action, the
+subject `(type, id)`, a timestamp, and a `metadata_json` blob with
+contextual data. The blob must already have been masked by the
+`SecretMasker`; the audit log is no place to leak a token.
+
+Operators may export the audit log. The coordinator must offer a paged
+read endpoint behind owner-only authorization. Live streaming is
+deferred.
+
+## Replay and idempotency
+
+- Webhooks (`POST /v1/...`) require idempotency keys for safe retry.
+  The coordinator de-duplicates by key + actor + endpoint.
+- Heartbeats are naturally idempotent.
+- The daemon's outbox flush after a network outage must use the same
+  idempotency keys it generated when the event was first attempted.
+
+## Transport notes
+
+- HTTPS only.
+- TLS 1.2 minimum, TLS 1.3 preferred.
+- Hostname verification mandatory.
+- Certificate pinning is **not** required and **not** recommended for
+  v0; operators rotate certificates with their normal infrastructure
+  process.
+- Compression-as-a-side-channel risks (BREACH, CRIME) are mitigated by
+  TLS 1.3 and by avoiding HTTP-level compression on tokenful responses.
+  The coordinator must not enable compression on responses that include
+  bearer tokens or session ids.
+
+## What is explicitly allowed
+
+The model above does not forbid:
+
+- A team operating multiple coordinators (one per environment, one per
+  customer engagement, etc.). Each is its own trust domain.
+- A daemon connecting to multiple coordinators simultaneously, if a
+  future config supports it. The current join protocol supports one
+  active coordinator session at a time per daemon process.
+- Operating a coordinator behind an authenticating proxy (mTLS at the
+  edge, identity-aware proxy, etc.). The protocol is HTTPS-shaped, so
+  proxies fit.
+
+## Cross-references
+
+- `docs/coordination-modes.md`
+- `docs/self-hosted-coordinator.md`
+- `docs/daemon-join-protocol.md`
+- `docs/local-state-plane.md`
+- `docs/error-codes.md`
+- `docs/false-protocol-schema.md`


### PR DESCRIPTION
## Summary

This PR designs **Sykli Team Mode**: a minimal self-hosted coordinator
for org/team work coordination across remote daemons, without requiring
a shared LAN mesh.

It adds six design docs and zero implementation. Each future
implementation slice gets its own PR per `docs/team-mode-roadmap.md`.

## Why

The existing BEAM mesh (`Sykli.Mesh`, `Sykli.Mesh.Roles`,
`Sykli.Mesh.Transport.*`) is real and useful for trusted execution
domains: same LAN, same VPN, same Kubernetes cluster, same Erlang trust
domain. It is **not** appropriate as a WAN/team coordination layer
because it relies on shared Erlang cookies and mutual reachability.

But teams still need shared work items, assignments, run summaries,
gates, approvals, and evidence references. Local-first still needs a
coordination point when multiple people, agents, and daemons work
remotely.

The architecture sentence the docs converge on:

> The daemon executes and records; the mesh dispatches inside trusted
> networks; the coordinator synchronizes team state across locations;
> `.sykli/` remains the local source of detailed evidence.

## What changed

Six docs, no code:

- `docs/coordination-modes.md` — the four modes (local-only, LAN mesh,
  self-hosted coordinator, hybrid).
- `docs/self-hosted-coordinator.md` — coordinator service: purpose,
  non-goals, data model v0, v1 API sketch, Kubernetes deployment shape.
- `docs/daemon-join-protocol.md` — outbound HTTPS join, heartbeat shape
  and cadence, sync events, reconnect semantics, security notes.
- `docs/team-mode-security.md` — trust model, three-role RBAC, data
  minimization defaults, mesh-vs-coordinator trust distinction.
- `docs/local-state-plane.md` — `.sykli/` (detailed local truth) vs
  coordinator (shared projection); evidence-reference visibility levels.
- `docs/team-mode-roadmap.md` — phased plan (Phase 0..10), CLI surface,
  MCP surface, first useful demo.

## Key design decisions

- **Daemon executes and records.** Coordinator never executes work.
- **Mesh dispatches inside trusted networks.** Coordinator does not
  speak Erlang distribution.
- **Coordinator syncs team state across locations.** HTTPS only.
- **`.sykli/` remains detailed local truth.** Coordinator stores a
  shared projection and references, never the bytes.
- **Daemons connect outbound.** No inbound network to laptops.
- **Remote execution disabled by default.** A daemon must declare
  `accepts_remote_work: true` to be assignable from elsewhere.
- **Raw logs, artifacts, secrets, source code, and full stdout/stderr
  are not synced by default.** The default sync set is summaries,
  statuses, error codes, and evidence references.
- **Postgres recommended for the coordinator v0.** Boring and durable.
  No Kafka, no Redis, no external broker required to start.
- **Kubernetes deployment is first-class but future implementation.**
  Phase 9 of the roadmap.
- **No SaaS, no web UI, no remote shell, no LLM provider integration.**
  Each is enumerated as a non-goal.

## Validation

Commands run, with results:

- `git diff --check` — clean (no whitespace errors).
- `git log --oneline origin/main..HEAD` — five focused commits, one per
  doc slice (the local-state-plane and roadmap commit pairs them
  because they reference each other).
- `git status` — working tree clean after commits.
- `ls docs/*.md` — six new docs present.

This PR is documentation-only, so the engine test suite was not run.
The repo has no markdown/link lint configured (verified via `ls scripts/`
and grep against Mix aliases).

## Out of scope

Explicitly **not** included in this PR:

- No implementation. No coordinator server, no daemon join client, no
  CLI subcommands, no MCP tools, no migrations.
- No SaaS hosted control plane.
- No web UI.
- No refactor of the BEAM mesh transport.
- No remote execution system.
- No LLM provider integration.

## Next recommended PR

**Add local work item state model** (Phase 1 of the roadmap):

- `Sykli.WorkItem` struct + JSON shape.
- `Sykli.Work.Store` — file-backed atomic store under
  `.sykli/work/items/<id>.json`.
- `sykli work create / list / show / claim / note` CLI surface.
- `--json` envelope on every subcommand.
- MCP tools: `list_work_items`, `get_work_item`, `claim_work_item`,
  `create_work_item`, `append_work_note` (local-only).

Phase 1 is deliberately networkless. Local-only users benefit from work
items the day they ship, and the local plane becomes the foundation
that the coordinator later syncs against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)