### PR TITLE
Add local work item state model

### DIFF
--- a/core/lib/sykli/work/store.ex
+++ b/core/lib/sykli/work/store.ex
@@ -5,6 +5,11 @@ defmodule Sykli.Work.Store do
   The store persists work items under `.sykli/work/items/<id>.json` in the
   requested project path. It is intentionally local-only; coordinator sync is a
   later Team Mode phase.
+
+  Writes are atomic per file, but this store does not provide cross-process
+  locking. Read-modify-write operations, including claims, enforce model rules
+  for the loaded item and remain last-writer-wins under concurrent writers until
+  the coordinator store adds transactional claims.
   """
 
   alias Sykli.WorkItem
@@ -120,9 +125,10 @@ defmodule Sykli.Work.Store do
   end
 
   defp encode(%WorkItem{} = item) do
-    {:ok, Jason.encode!(WorkItem.to_map(item), pretty: true)}
-  rescue
-    error -> {:error, {:work_item_encode_failed, error}}
+    case Jason.encode(WorkItem.to_map(item), pretty: true) do
+      {:ok, json} -> {:ok, json}
+      {:error, error} -> {:error, {:work_item_encode_failed, error}}
+    end
   end
 
   defp decode(json, path) do

--- a/core/lib/sykli/work/store.ex
+++ b/core/lib/sykli/work/store.ex
@@ -1,0 +1,159 @@
+defmodule Sykli.Work.Store do
+  @moduledoc """
+  File-backed local work item store.
+
+  The store persists work items under `.sykli/work/items/<id>.json` in the
+  requested project path. It is intentionally local-only; coordinator sync is a
+  later Team Mode phase.
+  """
+
+  alias Sykli.WorkItem
+
+  @items_dir ".sykli/work/items"
+
+  @doc "Returns the work item storage directory for a base path."
+  def items_dir(opts \\ []) do
+    opts
+    |> base_path()
+    |> Path.join(@items_dir)
+  end
+
+  @doc "Creates and persists a new work item."
+  def create(title, opts \\ []) do
+    with {:ok, item} <- WorkItem.new(title, opts),
+         :ok <- save(item, opts) do
+      {:ok, item}
+    end
+  end
+
+  @doc "Persists an existing work item."
+  def save(%WorkItem{} = item, opts \\ []) do
+    with :ok <- WorkItem.validate_id(item.id),
+         {:ok, path} <- item_path(item.id, opts),
+         :ok <- File.mkdir_p(Path.dirname(path)),
+         {:ok, json} <- encode(item),
+         :ok <- atomic_write(path, json) do
+      :ok
+    end
+  end
+
+  @doc "Loads a work item by id."
+  def get(id, opts \\ []) do
+    with {:ok, path} <- item_path(id, opts) do
+      case File.read(path) do
+        {:ok, json} -> decode(json, path)
+        {:error, :enoent} -> {:error, {:work_item_not_found, id}}
+        {:error, reason} -> {:error, {:work_item_read_failed, id, reason}}
+      end
+    end
+  end
+
+  @doc "Lists all persisted work items in deterministic id order."
+  def list(opts \\ []) do
+    dir = items_dir(opts)
+
+    case File.ls(dir) do
+      {:ok, files} ->
+        files
+        |> Enum.filter(&String.ends_with?(&1, ".json"))
+        |> Enum.sort()
+        |> Enum.reduce_while({:ok, []}, fn file, {:ok, items} ->
+          id = String.trim_trailing(file, ".json")
+
+          case get(id, opts) do
+            {:ok, item} -> {:cont, {:ok, [item | items]}}
+            {:error, reason} -> {:halt, {:error, reason}}
+          end
+        end)
+        |> case do
+          {:ok, items} -> {:ok, Enum.reverse(items)}
+          error -> error
+        end
+
+      {:error, :enoent} ->
+        {:ok, []}
+
+      {:error, reason} ->
+        {:error, {:work_item_list_failed, reason}}
+    end
+  end
+
+  @doc "Updates a persisted work item's status."
+  def update_status(id, status, opts \\ []) do
+    with {:ok, item} <- get(id, opts),
+         {:ok, updated} <- WorkItem.update_status(item, status, opts),
+         :ok <- save(updated, opts) do
+      {:ok, updated}
+    end
+  end
+
+  @doc "Claims a persisted work item."
+  def claim(id, assignment_type, assignment_id, opts \\ []) do
+    with {:ok, item} <- get(id, opts),
+         {:ok, updated} <- WorkItem.claim(item, assignment_type, assignment_id, opts),
+         :ok <- save(updated, opts) do
+      {:ok, updated}
+    end
+  end
+
+  @doc "Appends a note to a persisted work item."
+  def append_note(id, body, opts \\ []) do
+    with {:ok, item} <- get(id, opts),
+         {:ok, updated} <- WorkItem.append_note(item, body, opts),
+         :ok <- save(updated, opts) do
+      {:ok, List.last(updated.notes), updated}
+    end
+  end
+
+  defp item_path(id, opts) do
+    with :ok <- WorkItem.validate_id(id) do
+      dir = items_dir(opts)
+      path = Path.expand(Path.join(dir, "#{id}.json"))
+      expanded_dir = Path.expand(dir)
+
+      if path_within?(path, expanded_dir) do
+        {:ok, path}
+      else
+        {:error, {:work_item_path_escape, id}}
+      end
+    end
+  end
+
+  defp encode(%WorkItem{} = item) do
+    {:ok, Jason.encode!(WorkItem.to_map(item), pretty: true)}
+  rescue
+    error -> {:error, {:work_item_encode_failed, error}}
+  end
+
+  defp decode(json, path) do
+    with {:ok, data} <- Jason.decode(json),
+         {:ok, item} <- WorkItem.from_map(data) do
+      {:ok, item}
+    else
+      {:error, %Jason.DecodeError{} = error} -> {:error, {:malformed_work_item_json, path, error}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp atomic_write(path, json) do
+    tmp_path = "#{path}.tmp-#{System.unique_integer([:positive])}"
+
+    with :ok <- File.write(tmp_path, json),
+         :ok <- File.rename(tmp_path, path) do
+      :ok
+    else
+      {:error, reason} ->
+        File.rm(tmp_path)
+        {:error, {:work_item_write_failed, path, reason}}
+    end
+  end
+
+  defp base_path(opts), do: Keyword.get(opts, :path, ".")
+
+  defp path_within?(path, base) do
+    expanded_path = Path.expand(path)
+    expanded_base = Path.expand(base)
+
+    expanded_path == expanded_base or String.starts_with?(expanded_path, expanded_base <> "/")
+  end
+end

--- a/core/lib/sykli/work_item.ex
+++ b/core/lib/sykli/work_item.ex
@@ -1,0 +1,241 @@
+defmodule Sykli.WorkItem do
+  @moduledoc """
+  Local work item model for Team Mode.
+
+  A work item is a local coordination record stored under
+  `.sykli/work/items/<id>.json`. Networking and coordinator sync are added in
+  later Team Mode phases; this module only defines the local shape and
+  validation rules.
+  """
+
+  @version "1"
+  @statuses ~w(open claimed running blocked done failed cancelled)
+  @assignment_types ~w(member agent daemon)
+
+  @enforce_keys [:id, :title, :status, :created_at, :updated_at]
+  defstruct [
+    :id,
+    version: @version,
+    title: nil,
+    intent: nil,
+    status: "open",
+    created_by: nil,
+    assigned_to_type: nil,
+    assigned_to_id: nil,
+    created_at: nil,
+    updated_at: nil,
+    notes: []
+  ]
+
+  @type status :: String.t()
+  @type assignment_type :: String.t() | nil
+
+  @type note :: %{
+          required(String.t()) => String.t() | nil
+        }
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          version: String.t(),
+          title: String.t(),
+          intent: String.t() | nil,
+          status: status(),
+          created_by: String.t() | nil,
+          assigned_to_type: assignment_type(),
+          assigned_to_id: String.t() | nil,
+          created_at: String.t(),
+          updated_at: String.t(),
+          notes: [map()]
+        }
+
+  @doc "Returns the current persisted work item schema version."
+  def version, do: @version
+
+  @doc "Returns valid work item status strings."
+  def statuses, do: @statuses
+
+  @doc "Returns valid assignment type strings."
+  def assignment_types, do: @assignment_types
+
+  @doc "Builds a new work item."
+  def new(title, opts \\ [])
+
+  def new(title, opts) when is_binary(title) do
+    now = Keyword.get_lazy(opts, :now, &now_iso8601/0)
+
+    attrs = %{
+      id: Keyword.get_lazy(opts, :id, &Sykli.ULID.generate/0),
+      title: String.trim(title),
+      intent: blank_to_nil(Keyword.get(opts, :intent)),
+      status: Keyword.get(opts, :status, "open"),
+      created_by: blank_to_nil(Keyword.get(opts, :created_by)),
+      assigned_to_type: Keyword.get(opts, :assigned_to_type),
+      assigned_to_id: blank_to_nil(Keyword.get(opts, :assigned_to_id)),
+      created_at: now,
+      updated_at: now,
+      notes: Keyword.get(opts, :notes, [])
+    }
+
+    from_map(attrs)
+  end
+
+  def new(_title, _opts), do: {:error, {:invalid_title, :not_string}}
+
+  @doc "Updates a work item's status."
+  def update_status(%__MODULE__{} = item, status, opts \\ []) do
+    with :ok <- validate_status(status) do
+      {:ok,
+       %__MODULE__{
+         item
+         | status: status,
+           updated_at: Keyword.get_lazy(opts, :now, &now_iso8601/0)
+       }}
+    end
+  end
+
+  @doc "Claims a work item for a member, agent, or daemon."
+  def claim(%__MODULE__{} = item, assignment_type, assignment_id, opts \\ []) do
+    with :ok <- validate_assignment_type(assignment_type),
+         :ok <- validate_assignment_id(assignment_id) do
+      now = Keyword.get_lazy(opts, :now, &now_iso8601/0)
+
+      {:ok,
+       %__MODULE__{
+         item
+         | status: "claimed",
+           assigned_to_type: assignment_type,
+           assigned_to_id: assignment_id,
+           updated_at: now
+       }}
+    end
+  end
+
+  @doc "Appends a note to a work item."
+  def append_note(item, body, opts \\ [])
+
+  def append_note(%__MODULE__{} = item, body, opts) when is_binary(body) do
+    trimmed = String.trim(body)
+
+    if trimmed == "" do
+      {:error, {:invalid_note, :empty_body}}
+    else
+      now = Keyword.get_lazy(opts, :now, &now_iso8601/0)
+
+      note = %{
+        "id" => Keyword.get_lazy(opts, :note_id, &Sykli.ULID.generate/0),
+        "author_type" => blank_to_nil(Keyword.get(opts, :author_type)),
+        "author_id" => blank_to_nil(Keyword.get(opts, :author_id)),
+        "body" => trimmed,
+        "created_at" => now
+      }
+
+      {:ok, %__MODULE__{item | notes: item.notes ++ [note], updated_at: now}}
+    end
+  end
+
+  def append_note(%__MODULE__{}, _body, _opts), do: {:error, {:invalid_note, :not_string}}
+
+  @doc "Converts a work item to the persisted JSON map shape."
+  def to_map(%__MODULE__{} = item) do
+    %{
+      "id" => item.id,
+      "version" => item.version,
+      "title" => item.title,
+      "intent" => item.intent,
+      "status" => item.status,
+      "created_by" => item.created_by,
+      "assigned_to_type" => item.assigned_to_type,
+      "assigned_to_id" => item.assigned_to_id,
+      "created_at" => item.created_at,
+      "updated_at" => item.updated_at,
+      "notes" => item.notes
+    }
+  end
+
+  @doc "Builds a work item from a persisted JSON map."
+  def from_map(map) when is_map(map) do
+    attrs = normalize_keys(map)
+
+    with :ok <- validate_id(attrs["id"]),
+         :ok <- validate_title(attrs["title"]),
+         :ok <- validate_version(attrs["version"]),
+         :ok <- validate_status(attrs["status"] || "open"),
+         :ok <- validate_assignment_type(attrs["assigned_to_type"]),
+         :ok <- validate_notes(attrs["notes"] || []) do
+      {:ok,
+       %__MODULE__{
+         id: attrs["id"],
+         version: attrs["version"] || @version,
+         title: String.trim(attrs["title"]),
+         intent: blank_to_nil(attrs["intent"]),
+         status: attrs["status"] || "open",
+         created_by: blank_to_nil(attrs["created_by"]),
+         assigned_to_type: attrs["assigned_to_type"],
+         assigned_to_id: blank_to_nil(attrs["assigned_to_id"]),
+         created_at: attrs["created_at"] || now_iso8601(),
+         updated_at: attrs["updated_at"] || attrs["created_at"] || now_iso8601(),
+         notes: attrs["notes"] || []
+       }}
+    end
+  end
+
+  def from_map(_), do: {:error, {:invalid_work_item, :not_object}}
+
+  def validate_id(id) when is_binary(id) do
+    if Regex.match?(~r/^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/, id) do
+      :ok
+    else
+      {:error, {:invalid_work_item_id, id}}
+    end
+  end
+
+  def validate_id(id), do: {:error, {:invalid_work_item_id, id}}
+
+  def validate_status(status) when status in @statuses, do: :ok
+  def validate_status(status), do: {:error, {:invalid_work_item_status, status}}
+
+  def validate_assignment_type(nil), do: :ok
+  def validate_assignment_type(type) when type in @assignment_types, do: :ok
+  def validate_assignment_type(type), do: {:error, {:invalid_assignment_type, type}}
+
+  defp validate_title(title) when is_binary(title) do
+    if String.trim(title) == "", do: {:error, {:invalid_title, :empty}}, else: :ok
+  end
+
+  defp validate_title(title), do: {:error, {:invalid_title, title}}
+
+  defp validate_version(nil), do: :ok
+  defp validate_version(@version), do: :ok
+  defp validate_version(version), do: {:error, {:unsupported_work_item_version, version}}
+
+  defp validate_assignment_id(nil), do: {:error, {:invalid_assignment_id, :empty}}
+
+  defp validate_assignment_id(id) when is_binary(id) do
+    if String.trim(id) == "", do: {:error, {:invalid_assignment_id, :empty}}, else: :ok
+  end
+
+  defp validate_assignment_id(id), do: {:error, {:invalid_assignment_id, id}}
+
+  defp validate_notes(notes) when is_list(notes), do: :ok
+  defp validate_notes(notes), do: {:error, {:invalid_notes, notes}}
+
+  defp normalize_keys(map) do
+    Map.new(map, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+      {key, value} -> {key, value}
+    end)
+  end
+
+  defp blank_to_nil(value) when is_binary(value) do
+    value = String.trim(value)
+    if value == "", do: nil, else: value
+  end
+
+  defp blank_to_nil(value), do: value
+
+  defp now_iso8601 do
+    DateTime.utc_now()
+    |> DateTime.truncate(:second)
+    |> DateTime.to_iso8601()
+  end
+end

--- a/core/lib/sykli/work_item.ex
+++ b/core/lib/sykli/work_item.ex
@@ -10,7 +10,8 @@ defmodule Sykli.WorkItem do
 
   @version "1"
   @statuses ~w(open claimed running blocked done failed cancelled)
-  @assignment_types ~w(member agent daemon)
+  @actor_types ~w(member agent daemon)
+  @assignment_types @actor_types
 
   @enforce_keys [:id, :title, :status, :created_at, :updated_at]
   defstruct [
@@ -19,7 +20,8 @@ defmodule Sykli.WorkItem do
     title: nil,
     intent: nil,
     status: "open",
-    created_by: nil,
+    created_by_type: nil,
+    created_by_id: nil,
     assigned_to_type: nil,
     assigned_to_id: nil,
     created_at: nil,
@@ -40,7 +42,8 @@ defmodule Sykli.WorkItem do
           title: String.t(),
           intent: String.t() | nil,
           status: status(),
-          created_by: String.t() | nil,
+          created_by_type: assignment_type(),
+          created_by_id: String.t() | nil,
           assigned_to_type: assignment_type(),
           assigned_to_id: String.t() | nil,
           created_at: String.t(),
@@ -57,6 +60,9 @@ defmodule Sykli.WorkItem do
   @doc "Returns valid assignment type strings."
   def assignment_types, do: @assignment_types
 
+  @doc "Returns valid work item actor type strings."
+  def actor_types, do: @actor_types
+
   @doc "Builds a new work item."
   def new(title, opts \\ [])
 
@@ -65,10 +71,12 @@ defmodule Sykli.WorkItem do
 
     attrs = %{
       id: Keyword.get_lazy(opts, :id, &Sykli.ULID.generate/0),
+      version: @version,
       title: String.trim(title),
       intent: blank_to_nil(Keyword.get(opts, :intent)),
       status: Keyword.get(opts, :status, "open"),
-      created_by: blank_to_nil(Keyword.get(opts, :created_by)),
+      created_by_type: Keyword.get(opts, :created_by_type),
+      created_by_id: blank_to_nil(Keyword.get(opts, :created_by_id)),
       assigned_to_type: Keyword.get(opts, :assigned_to_type),
       assigned_to_id: blank_to_nil(Keyword.get(opts, :assigned_to_id)),
       created_at: now,
@@ -95,7 +103,8 @@ defmodule Sykli.WorkItem do
 
   @doc "Claims a work item for a member, agent, or daemon."
   def claim(%__MODULE__{} = item, assignment_type, assignment_id, opts \\ []) do
-    with :ok <- validate_assignment_type(assignment_type),
+    with :ok <- ensure_claimable(item),
+         :ok <- validate_assignment_type(assignment_type),
          :ok <- validate_assignment_id(assignment_id) do
       now = Keyword.get_lazy(opts, :now, &now_iso8601/0)
 
@@ -143,7 +152,8 @@ defmodule Sykli.WorkItem do
       "title" => item.title,
       "intent" => item.intent,
       "status" => item.status,
-      "created_by" => item.created_by,
+      "created_by_type" => item.created_by_type,
+      "created_by_id" => item.created_by_id,
       "assigned_to_type" => item.assigned_to_type,
       "assigned_to_id" => item.assigned_to_id,
       "created_at" => item.created_at,
@@ -160,21 +170,27 @@ defmodule Sykli.WorkItem do
          :ok <- validate_title(attrs["title"]),
          :ok <- validate_version(attrs["version"]),
          :ok <- validate_status(attrs["status"] || "open"),
+         :ok <- validate_created_by(attrs["created_by_type"], attrs["created_by_id"]),
          :ok <- validate_assignment_type(attrs["assigned_to_type"]),
+         :ok <-
+           validate_optional_assignment_id(attrs["assigned_to_type"], attrs["assigned_to_id"]),
          :ok <- validate_notes(attrs["notes"] || []) do
+      notes = Enum.map(attrs["notes"] || [], &normalize_keys/1)
+
       {:ok,
        %__MODULE__{
          id: attrs["id"],
-         version: attrs["version"] || @version,
+         version: attrs["version"],
          title: String.trim(attrs["title"]),
          intent: blank_to_nil(attrs["intent"]),
          status: attrs["status"] || "open",
-         created_by: blank_to_nil(attrs["created_by"]),
+         created_by_type: attrs["created_by_type"],
+         created_by_id: blank_to_nil(attrs["created_by_id"]),
          assigned_to_type: attrs["assigned_to_type"],
          assigned_to_id: blank_to_nil(attrs["assigned_to_id"]),
          created_at: attrs["created_at"] || now_iso8601(),
          updated_at: attrs["updated_at"] || attrs["created_at"] || now_iso8601(),
-         notes: attrs["notes"] || []
+         notes: notes
        }}
     end
   end
@@ -198,15 +214,55 @@ defmodule Sykli.WorkItem do
   def validate_assignment_type(type) when type in @assignment_types, do: :ok
   def validate_assignment_type(type), do: {:error, {:invalid_assignment_type, type}}
 
+  def validate_actor_type(nil), do: :ok
+  def validate_actor_type(type) when type in @actor_types, do: :ok
+  def validate_actor_type(type), do: {:error, {:invalid_actor_type, type}}
+
   defp validate_title(title) when is_binary(title) do
     if String.trim(title) == "", do: {:error, {:invalid_title, :empty}}, else: :ok
   end
 
   defp validate_title(title), do: {:error, {:invalid_title, title}}
 
-  defp validate_version(nil), do: :ok
+  defp validate_version(nil), do: {:error, {:missing_work_item_version, nil}}
   defp validate_version(@version), do: :ok
   defp validate_version(version), do: {:error, {:unsupported_work_item_version, version}}
+
+  defp ensure_claimable(%__MODULE__{status: "open"}), do: :ok
+
+  defp ensure_claimable(%__MODULE__{} = item) do
+    {:error,
+     {:work_item_already_claimed, item.id,
+      %{
+        "status" => item.status,
+        "assigned_to_type" => item.assigned_to_type,
+        "assigned_to_id" => item.assigned_to_id
+      }}}
+  end
+
+  defp validate_created_by(nil, nil), do: :ok
+  defp validate_created_by(nil, actor_id) when actor_id in [nil, ""], do: :ok
+  defp validate_created_by(nil, _actor_id), do: {:error, {:invalid_created_by, :missing_type}}
+
+  defp validate_created_by(actor_type, actor_id) do
+    with :ok <- validate_actor_type(actor_type),
+         :ok <- validate_actor_id(actor_id, :created_by) do
+      :ok
+    end
+  end
+
+  defp validate_optional_assignment_id(nil, nil), do: :ok
+
+  defp validate_optional_assignment_id(nil, assignment_id) when assignment_id in [nil, ""],
+    do: :ok
+
+  defp validate_optional_assignment_id(nil, _assignment_id) do
+    {:error, {:invalid_assignment_id, :missing_type}}
+  end
+
+  defp validate_optional_assignment_id(_assignment_type, assignment_id) do
+    validate_assignment_id(assignment_id)
+  end
 
   defp validate_assignment_id(nil), do: {:error, {:invalid_assignment_id, :empty}}
 
@@ -216,8 +272,54 @@ defmodule Sykli.WorkItem do
 
   defp validate_assignment_id(id), do: {:error, {:invalid_assignment_id, id}}
 
-  defp validate_notes(notes) when is_list(notes), do: :ok
+  defp validate_actor_id(nil, field), do: {:error, {:invalid_actor_id, field, :empty}}
+
+  defp validate_actor_id(id, field) when is_binary(id) do
+    if String.trim(id) == "", do: {:error, {:invalid_actor_id, field, :empty}}, else: :ok
+  end
+
+  defp validate_actor_id(id, field), do: {:error, {:invalid_actor_id, field, id}}
+
+  defp validate_notes(notes) when is_list(notes) do
+    Enum.reduce_while(notes, :ok, fn note, :ok ->
+      case validate_note(note) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
   defp validate_notes(notes), do: {:error, {:invalid_notes, notes}}
+
+  defp validate_note(note) when is_map(note) do
+    attrs = normalize_keys(note)
+
+    with :ok <- validate_note_string(attrs["id"], :id),
+         :ok <- validate_note_string(attrs["body"], :body),
+         :ok <- validate_note_string(attrs["created_at"], :created_at),
+         :ok <- validate_note_author(attrs["author_type"], attrs["author_id"]) do
+      :ok
+    end
+  end
+
+  defp validate_note(note), do: {:error, {:invalid_note, note}}
+
+  defp validate_note_string(value, field) when is_binary(value) do
+    if String.trim(value) == "", do: {:error, {:invalid_note, {field, :empty}}}, else: :ok
+  end
+
+  defp validate_note_string(value, field), do: {:error, {:invalid_note, {field, value}}}
+
+  defp validate_note_author(nil, nil), do: :ok
+  defp validate_note_author(nil, author_id) when author_id in [nil, ""], do: :ok
+  defp validate_note_author(nil, _author_id), do: {:error, {:invalid_note_author, :missing_type}}
+
+  defp validate_note_author(author_type, author_id) do
+    with :ok <- validate_actor_type(author_type),
+         :ok <- validate_actor_id(author_id, :note_author) do
+      :ok
+    end
+  end
 
   defp normalize_keys(map) do
     Map.new(map, fn

--- a/core/test/sykli/work/store_test.exs
+++ b/core/test/sykli/work/store_test.exs
@@ -1,0 +1,153 @@
+defmodule Sykli.Work.StoreTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.Work.Store
+  alias Sykli.WorkItem
+
+  @moduletag :tmp_dir
+
+  @now "2026-05-08T10:00:00Z"
+
+  describe "create/2 and get/2" do
+    test "persists work item under .sykli/work/items", %{tmp_dir: tmp_dir} do
+      assert {:ok, item} =
+               Store.create("Investigate failing checkout deploy",
+                 id: "work_001",
+                 intent: "Find the failing deploy step",
+                 created_by: "member:yair",
+                 now: @now,
+                 path: tmp_dir
+               )
+
+      path = Path.join([tmp_dir, ".sykli", "work", "items", "work_001.json"])
+      assert File.exists?(path)
+
+      assert {:ok, loaded} = Store.get("work_001", path: tmp_dir)
+      assert loaded == item
+
+      persisted = path |> File.read!() |> Jason.decode!()
+      assert persisted["version"] == "1"
+      assert persisted["title"] == "Investigate failing checkout deploy"
+      refute Map.has_key?(persisted, "logs")
+      refute Map.has_key?(persisted, "artifacts")
+      refute Map.has_key?(persisted, "secrets")
+    end
+
+    test "missing item returns structured not-found error", %{tmp_dir: tmp_dir} do
+      assert {:error, {:work_item_not_found, "missing"}} = Store.get("missing", path: tmp_dir)
+    end
+  end
+
+  describe "list/1" do
+    test "returns deterministic ID order", %{tmp_dir: tmp_dir} do
+      assert {:ok, _} = Store.create("Second", id: "work_b", now: @now, path: tmp_dir)
+      assert {:ok, _} = Store.create("First", id: "work_a", now: @now, path: tmp_dir)
+
+      assert {:ok, items} = Store.list(path: tmp_dir)
+      assert Enum.map(items, & &1.id) == ["work_a", "work_b"]
+    end
+
+    test "returns an empty list when no local work directory exists", %{tmp_dir: tmp_dir} do
+      assert {:ok, []} = Store.list(path: tmp_dir)
+    end
+  end
+
+  describe "updates" do
+    test "updates status and survives reload", %{tmp_dir: tmp_dir} do
+      assert {:ok, _} = Store.create("Review PR", id: "work_001", now: @now, path: tmp_dir)
+
+      assert {:ok, updated} =
+               Store.update_status("work_001", "running",
+                 now: "2026-05-08T10:01:00Z",
+                 path: tmp_dir
+               )
+
+      assert updated.status == "running"
+      assert updated.updated_at == "2026-05-08T10:01:00Z"
+
+      assert {:ok, reloaded} = Store.get("work_001", path: tmp_dir)
+      assert reloaded.status == "running"
+    end
+
+    test "claims a work item", %{tmp_dir: tmp_dir} do
+      assert {:ok, _} = Store.create("Review PR", id: "work_001", now: @now, path: tmp_dir)
+
+      assert {:ok, claimed} =
+               Store.claim("work_001", "daemon", "yair-mbp", now: @now, path: tmp_dir)
+
+      assert claimed.status == "claimed"
+      assert claimed.assigned_to_type == "daemon"
+      assert claimed.assigned_to_id == "yair-mbp"
+    end
+
+    test "appends a note", %{tmp_dir: tmp_dir} do
+      assert {:ok, _} = Store.create("Review PR", id: "work_001", now: @now, path: tmp_dir)
+
+      assert {:ok, note, updated} =
+               Store.append_note("work_001", "Found likely API breakage",
+                 note_id: "note_001",
+                 author_type: "member",
+                 author_id: "yair",
+                 now: @now,
+                 path: tmp_dir
+               )
+
+      assert note["id"] == "note_001"
+      assert length(updated.notes) == 1
+
+      assert {:ok, reloaded} = Store.get("work_001", path: tmp_dir)
+      assert hd(reloaded.notes)["body"] == "Found likely API breakage"
+    end
+  end
+
+  describe "validation and malformed state" do
+    test "invalid status and assignment type are rejected", %{tmp_dir: tmp_dir} do
+      assert {:ok, _} = Store.create("Review PR", id: "work_001", now: @now, path: tmp_dir)
+
+      assert {:error, {:invalid_work_item_status, "waiting"}} =
+               Store.update_status("work_001", "waiting", path: tmp_dir)
+
+      assert {:error, {:invalid_assignment_type, "robot"}} =
+               Store.claim("work_001", "robot", "r2d2", path: tmp_dir)
+    end
+
+    test "invalid IDs cannot escape the store", %{tmp_dir: tmp_dir} do
+      assert {:error, {:invalid_work_item_id, "../escape"}} =
+               Store.get("../escape", path: tmp_dir)
+
+      assert {:error, {:invalid_work_item_id, "/tmp/escape"}} =
+               Store.get("/tmp/escape", path: tmp_dir)
+    end
+
+    test "malformed persisted JSON is explicit", %{tmp_dir: tmp_dir} do
+      dir = Store.items_dir(path: tmp_dir)
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "work_001.json"), "{not json")
+
+      assert {:error, {:malformed_work_item_json, path, %Jason.DecodeError{}}} =
+               Store.get("work_001", path: tmp_dir)
+
+      assert String.ends_with?(path, ".sykli/work/items/work_001.json")
+    end
+
+    test "structurally invalid persisted JSON is explicit", %{tmp_dir: tmp_dir} do
+      dir = Store.items_dir(path: tmp_dir)
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "work_001.json"), Jason.encode!(%{"id" => "work_001"}))
+
+      assert {:error, {:invalid_title, nil}} = Store.get("work_001", path: tmp_dir)
+    end
+
+    test "save validates work item IDs", %{tmp_dir: tmp_dir} do
+      item = %WorkItem{
+        id: "../escape",
+        title: "Bad",
+        status: "open",
+        created_at: @now,
+        updated_at: @now
+      }
+
+      assert {:error, {:invalid_work_item_id, "../escape"}} = Store.save(item, path: tmp_dir)
+    end
+  end
+end

--- a/core/test/sykli/work/store_test.exs
+++ b/core/test/sykli/work/store_test.exs
@@ -14,7 +14,8 @@ defmodule Sykli.Work.StoreTest do
                Store.create("Investigate failing checkout deploy",
                  id: "work_001",
                  intent: "Find the failing deploy step",
-                 created_by: "member:yair",
+                 created_by_type: "member",
+                 created_by_id: "yair",
                  now: @now,
                  path: tmp_dir
                )
@@ -28,6 +29,8 @@ defmodule Sykli.Work.StoreTest do
       persisted = path |> File.read!() |> Jason.decode!()
       assert persisted["version"] == "1"
       assert persisted["title"] == "Investigate failing checkout deploy"
+      assert persisted["created_by_type"] == "member"
+      assert persisted["created_by_id"] == "yair"
       refute Map.has_key?(persisted, "logs")
       refute Map.has_key?(persisted, "artifacts")
       refute Map.has_key?(persisted, "secrets")
@@ -78,6 +81,19 @@ defmodule Sykli.Work.StoreTest do
       assert claimed.status == "claimed"
       assert claimed.assigned_to_type == "daemon"
       assert claimed.assigned_to_id == "yair-mbp"
+    end
+
+    test "does not overwrite an existing claim", %{tmp_dir: tmp_dir} do
+      assert {:ok, _} = Store.create("Review PR", id: "work_001", now: @now, path: tmp_dir)
+      assert {:ok, _} = Store.claim("work_001", "agent", "claude", now: @now, path: tmp_dir)
+
+      assert {:error,
+              {:work_item_already_claimed, "work_001",
+               %{
+                 "status" => "claimed",
+                 "assigned_to_type" => "agent",
+                 "assigned_to_id" => "claude"
+               }}} = Store.claim("work_001", "daemon", "yair-mbp", now: @now, path: tmp_dir)
     end
 
     test "appends a note", %{tmp_dir: tmp_dir} do
@@ -136,6 +152,25 @@ defmodule Sykli.Work.StoreTest do
       File.write!(Path.join(dir, "work_001.json"), Jason.encode!(%{"id" => "work_001"}))
 
       assert {:error, {:invalid_title, nil}} = Store.get("work_001", path: tmp_dir)
+    end
+
+    test "missing persisted version is explicit", %{tmp_dir: tmp_dir} do
+      dir = Store.items_dir(path: tmp_dir)
+      File.mkdir_p!(dir)
+
+      File.write!(
+        Path.join(dir, "work_001.json"),
+        Jason.encode!(%{
+          "id" => "work_001",
+          "title" => "Review PR",
+          "status" => "open",
+          "created_at" => @now,
+          "updated_at" => @now,
+          "notes" => []
+        })
+      )
+
+      assert {:error, {:missing_work_item_version, nil}} = Store.get("work_001", path: tmp_dir)
     end
 
     test "save validates work item IDs", %{tmp_dir: tmp_dir} do

--- a/core/test/sykli/work_item_test.exs
+++ b/core/test/sykli/work_item_test.exs
@@ -1,0 +1,128 @@
+defmodule Sykli.WorkItemTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.WorkItem
+
+  @now "2026-05-08T10:00:00Z"
+
+  describe "new/2" do
+    test "creates an open work item with versioned persisted shape" do
+      assert {:ok, item} =
+               WorkItem.new("Investigate failing checkout deploy",
+                 id: "work_001",
+                 intent: "Find the failing deploy step",
+                 created_by: "member:yair",
+                 now: @now
+               )
+
+      assert item.id == "work_001"
+      assert item.version == "1"
+      assert item.status == "open"
+      assert item.created_at == @now
+      assert item.updated_at == @now
+
+      assert WorkItem.to_map(item) == %{
+               "id" => "work_001",
+               "version" => "1",
+               "title" => "Investigate failing checkout deploy",
+               "intent" => "Find the failing deploy step",
+               "status" => "open",
+               "created_by" => "member:yair",
+               "assigned_to_type" => nil,
+               "assigned_to_id" => nil,
+               "created_at" => @now,
+               "updated_at" => @now,
+               "notes" => []
+             }
+    end
+
+    test "rejects empty titles" do
+      assert {:error, {:invalid_title, :empty}} = WorkItem.new("   ", id: "work_001")
+    end
+  end
+
+  describe "status validation" do
+    test "accepts only v0 work item statuses" do
+      assert WorkItem.statuses() == ~w(open claimed running blocked done failed cancelled)
+
+      assert {:ok, item} = WorkItem.new("Review PR", id: "work_001", now: @now)
+      assert {:ok, updated} = WorkItem.update_status(item, "blocked", now: @now)
+      assert updated.status == "blocked"
+
+      assert {:error, {:invalid_work_item_status, "waiting"}} =
+               WorkItem.update_status(item, "waiting")
+    end
+  end
+
+  describe "claim/4" do
+    test "claims a work item for a member, agent, or daemon" do
+      assert {:ok, item} = WorkItem.new("Review PR", id: "work_001", now: @now)
+
+      assert {:ok, claimed} = WorkItem.claim(item, "agent", "claude", now: @now)
+      assert claimed.status == "claimed"
+      assert claimed.assigned_to_type == "agent"
+      assert claimed.assigned_to_id == "claude"
+    end
+
+    test "rejects invalid assignment types" do
+      assert {:ok, item} = WorkItem.new("Review PR", id: "work_001", now: @now)
+
+      assert {:error, {:invalid_assignment_type, "robot"}} =
+               WorkItem.claim(item, "robot", "claude")
+    end
+  end
+
+  describe "append_note/3" do
+    test "appends a versioned local note" do
+      assert {:ok, item} = WorkItem.new("Review PR", id: "work_001", now: @now)
+
+      assert {:ok, noted} =
+               WorkItem.append_note(item, "Found likely API breakage",
+                 note_id: "note_001",
+                 author_type: "member",
+                 author_id: "yair",
+                 now: @now
+               )
+
+      assert noted.notes == [
+               %{
+                 "id" => "note_001",
+                 "author_type" => "member",
+                 "author_id" => "yair",
+                 "body" => "Found likely API breakage",
+                 "created_at" => @now
+               }
+             ]
+    end
+
+    test "rejects empty notes" do
+      assert {:ok, item} = WorkItem.new("Review PR", id: "work_001")
+      assert {:error, {:invalid_note, :empty_body}} = WorkItem.append_note(item, " ")
+    end
+  end
+
+  describe "from_map/1" do
+    test "loads persisted JSON-compatible maps" do
+      assert {:ok, item} =
+               WorkItem.from_map(%{
+                 "id" => "work_001",
+                 "version" => "1",
+                 "title" => "Review PR",
+                 "status" => "open",
+                 "created_at" => @now,
+                 "updated_at" => @now,
+                 "notes" => []
+               })
+
+      assert item.id == "work_001"
+    end
+
+    test "rejects invalid IDs and unsupported versions" do
+      assert {:error, {:invalid_work_item_id, "../escape"}} =
+               WorkItem.from_map(%{"id" => "../escape", "title" => "Bad"})
+
+      assert {:error, {:unsupported_work_item_version, "2"}} =
+               WorkItem.from_map(%{"id" => "work_001", "title" => "Bad", "version" => "2"})
+    end
+  end
+end

--- a/core/test/sykli/work_item_test.exs
+++ b/core/test/sykli/work_item_test.exs
@@ -11,7 +11,8 @@ defmodule Sykli.WorkItemTest do
                WorkItem.new("Investigate failing checkout deploy",
                  id: "work_001",
                  intent: "Find the failing deploy step",
-                 created_by: "member:yair",
+                 created_by_type: "member",
+                 created_by_id: "yair",
                  now: @now
                )
 
@@ -27,7 +28,8 @@ defmodule Sykli.WorkItemTest do
                "title" => "Investigate failing checkout deploy",
                "intent" => "Find the failing deploy step",
                "status" => "open",
-               "created_by" => "member:yair",
+               "created_by_type" => "member",
+               "created_by_id" => "yair",
                "assigned_to_type" => nil,
                "assigned_to_id" => nil,
                "created_at" => @now,
@@ -70,6 +72,19 @@ defmodule Sykli.WorkItemTest do
       assert {:error, {:invalid_assignment_type, "robot"}} =
                WorkItem.claim(item, "robot", "claude")
     end
+
+    test "does not silently overwrite an existing claim" do
+      assert {:ok, item} = WorkItem.new("Review PR", id: "work_001", now: @now)
+      assert {:ok, claimed} = WorkItem.claim(item, "agent", "claude", now: @now)
+
+      assert {:error,
+              {:work_item_already_claimed, "work_001",
+               %{
+                 "status" => "claimed",
+                 "assigned_to_type" => "agent",
+                 "assigned_to_id" => "claude"
+               }}} = WorkItem.claim(claimed, "daemon", "yair-mbp", now: @now)
+    end
   end
 
   describe "append_note/3" do
@@ -109,20 +124,73 @@ defmodule Sykli.WorkItemTest do
                  "version" => "1",
                  "title" => "Review PR",
                  "status" => "open",
+                 "created_by_type" => "member",
+                 "created_by_id" => "yair",
                  "created_at" => @now,
                  "updated_at" => @now,
                  "notes" => []
                })
 
       assert item.id == "work_001"
+      assert item.created_by_type == "member"
+      assert item.created_by_id == "yair"
     end
 
-    test "rejects invalid IDs and unsupported versions" do
+    test "rejects invalid IDs and missing or unsupported versions" do
       assert {:error, {:invalid_work_item_id, "../escape"}} =
                WorkItem.from_map(%{"id" => "../escape", "title" => "Bad"})
 
+      assert {:error, {:missing_work_item_version, nil}} =
+               WorkItem.from_map(%{"id" => "work_001", "title" => "Bad"})
+
       assert {:error, {:unsupported_work_item_version, "2"}} =
                WorkItem.from_map(%{"id" => "work_001", "title" => "Bad", "version" => "2"})
+    end
+
+    test "rejects malformed created_by actor refs" do
+      assert {:error, {:invalid_created_by, :missing_type}} =
+               WorkItem.from_map(%{
+                 "id" => "work_001",
+                 "version" => "1",
+                 "title" => "Bad",
+                 "created_by_id" => "yair"
+               })
+
+      assert {:error, {:invalid_actor_type, "robot"}} =
+               WorkItem.from_map(%{
+                 "id" => "work_001",
+                 "version" => "1",
+                 "title" => "Bad",
+                 "created_by_type" => "robot",
+                 "created_by_id" => "yair"
+               })
+    end
+
+    test "rejects malformed persisted notes" do
+      base = %{
+        "id" => "work_001",
+        "version" => "1",
+        "title" => "Review PR",
+        "status" => "open"
+      }
+
+      assert {:error, {:invalid_note, 1}} =
+               WorkItem.from_map(Map.put(base, "notes", [1]))
+
+      assert {:error, {:invalid_note, {:id, nil}}} =
+               WorkItem.from_map(Map.put(base, "notes", [%{"body" => "Missing id"}]))
+
+      assert {:error, {:invalid_note_author, :missing_type}} =
+               WorkItem.from_map(
+                 Map.put(base, "notes", [
+                   %{
+                     "id" => "note_001",
+                     "body" => "Bad author",
+                     "author_id" => "yair",
+                     "created_at" => @now
+                   }
+                 ])
+               )
     end
   end
 end

--- a/docs/local-state-plane.md
+++ b/docs/local-state-plane.md
@@ -55,8 +55,7 @@ Documented in detail in `docs/false-protocol-schema.md`. Summary:
   `sykli context`.
 - `.sykli/test-map.json` — file → tasks mapping.
 - `.sykli/runs/` — per-run manifests for history.
-- (Phase 1 of the roadmap) `.sykli/work/items/<id>.json` — local work
-  item state.
+- `.sykli/work/items/<id>.json` — local work item state.
 - (Phase 3 of the roadmap) `.sykli/gates/<gate-id>.json` — local gate
   decision state.
 
@@ -217,6 +216,35 @@ payload must carry a clear marker for which plane the answer came from
 (e.g. `"source": "local"` vs `"source": "coordinator"`).
 
 ## What the local plane gains in Phase 1+
+
+Phase 1 adds local work item files before any coordinator or network
+behavior. The persisted file is versioned and intentionally small:
+
+```json
+{
+  "id": "01KQPF7Q4W6J2M7V6YF2N0H6A2",
+  "version": "1",
+  "title": "Review PR #176",
+  "intent": "Check timeout and success criteria behavior",
+  "status": "open",
+  "created_by": "member:yair",
+  "assigned_to_type": null,
+  "assigned_to_id": null,
+  "created_at": "2026-05-08T10:00:00Z",
+  "updated_at": "2026-05-08T10:00:00Z",
+  "notes": []
+}
+```
+
+Allowed `status` values are `open`, `claimed`, `running`, `blocked`,
+`done`, `failed`, and `cancelled`.
+
+Allowed `assigned_to_type` values are `member`, `agent`, `daemon`, or
+`null` when unassigned.
+
+The local work item file must not contain logs, artifacts, secrets, source
+code, environment dumps, or full stdout/stderr. It is coordination state,
+not execution evidence.
 
 The roadmap adds local-only state for work items and gates **before**
 networking turns on. That is intentional: a user should be able to:

--- a/docs/local-state-plane.md
+++ b/docs/local-state-plane.md
@@ -227,7 +227,8 @@ behavior. The persisted file is versioned and intentionally small:
   "title": "Review PR #176",
   "intent": "Check timeout and success criteria behavior",
   "status": "open",
-  "created_by": "member:yair",
+  "created_by_type": "member",
+  "created_by_id": "yair",
   "assigned_to_type": null,
   "assigned_to_id": null,
   "created_at": "2026-05-08T10:00:00Z",
@@ -239,8 +240,8 @@ behavior. The persisted file is versioned and intentionally small:
 Allowed `status` values are `open`, `claimed`, `running`, `blocked`,
 `done`, `failed`, and `cancelled`.
 
-Allowed `assigned_to_type` values are `member`, `agent`, `daemon`, or
-`null` when unassigned.
+Allowed actor type values for `created_by_type` and `assigned_to_type` are
+`member`, `agent`, `daemon`, or `null` when the actor is not known.
 
 The local work item file must not contain logs, artifacts, secrets, source
 code, environment dumps, or full stdout/stderr. It is coordination state,


### PR DESCRIPTION
## Summary

Adds the local Work Item model and file-backed store for Team Mode Phase 1. Work Items are the local coordination unit for agentic work before any coordinator or network sync exists.

This PR intentionally stops at the local state model. It does not add CLI commands, coordinator endpoints, daemon join, run association, gate state, MCP tools, or remote execution.

## Why Work Item exists

Team Mode needs a durable unit of coordination before it can sync team state. A Work Item represents work such as reviewing a PR, investigating a failing deployment, generating a patch, or checking API breakage. This PR makes that state real locally under `.sykli/` while preserving local-first behavior.

## Local file path

Work items are persisted at:

```text
.sykli/work/items/<id>.json
```

The store validates IDs before path construction and rejects traversal-like IDs such as `../escape` or absolute paths.

## JSON shape

```json
{
  "id": "01KQPF7Q4W6J2M7V6YF2N0H6A2",
  "version": "1",
  "title": "Review PR #176",
  "intent": "Check timeout and success criteria behavior",
  "status": "open",
  "created_by": "member:yair",
  "assigned_to_type": null,
  "assigned_to_id": null,
  "created_at": "2026-05-08T10:00:00Z",
  "updated_at": "2026-05-08T10:00:00Z",
  "notes": []
}
```

Allowed statuses:

- `open`
- `claimed`
- `running`
- `blocked`
- `done`
- `failed`
- `cancelled`

Allowed assignment types:

- `member`
- `agent`
- `daemon`
- `null` when unassigned

## What changed

- Added `Sykli.WorkItem` with constructors, JSON map conversion, status validation, assignment validation, claim support, and note append support.
- Added `Sykli.Work.Store` for `.sykli/work/items/<id>.json` persistence.
- Store writes are atomic via temp file + rename.
- Store returns explicit structured error tuples for missing items, malformed JSON, invalid IDs, invalid statuses, invalid assignment types, and write/read failures.
- Updated `docs/local-state-plane.md` with the local work item path, JSON shape, enum values, and privacy boundary.

## Validation

Ran:

- `cd core && mix format lib/sykli/work_item.ex lib/sykli/work/store.ex test/sykli/work_item_test.exs test/sykli/work/store_test.exs` → passed
- `git diff --check` → passed
- `cd core && mix test test/sykli/work_item_test.exs test/sykli/work/store_test.exs` → 21 tests, 0 failures
- `cd core && mix test` → 1 property, 1539 tests, 0 failures, 1 skipped, 13 excluded

## Oracle / blackbox status

No oracle or blackbox cases were added in this PR because there is no user-facing CLI surface yet. PR 2 adds `sykli work ...` commands and should add CLI, blackbox, and oracle coverage for create/list/show/claim/note JSON behavior.

## Out of scope

- CLI commands
- coordinator service
- daemon join / heartbeat
- team sync
- run association
- gate state
- MCP tools
- Kubernetes deployment
- remote execution

## Next PR

Next: **Add local work item CLI commands**

Suggested scope:

- `sykli work create`
- `sykli work list`
- `sykli work show`
- `sykli work claim`
- `sykli work note`
- `--json` output for every command
- CLI tests, blackbox workflow, and oracle JSON expectations
