### PR TITLE
Add local work item CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ sykli graph               # mermaid / DOT diagram of the DAG
 sykli verify              # cross-platform verification via mesh
 sykli history             # recent runs
 sykli report              # show last run summary with task results
+sykli work list           # local Team Mode work items
 sykli cache stats         # cache hit rates
 sykli daemon start        # start a mesh node on this host
 sykli mcp                 # MCP server (Claude Code, Cursor, Copilot)
@@ -399,6 +400,7 @@ Selection priority and how to add a new runtime: [docs/runtimes.md](docs/runtime
 ├── attestations/         # per-task DSSE envelopes (for artifact registries)
 ├── occurrences_json/     # per-run JSON archive (last 20)
 ├── context.json          # pipeline structure + health (via `sykli context`)
+├── work/items/           # local Team Mode work item state
 └── runs/                 # run history manifests
 ```
 

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -9,7 +9,7 @@ defmodule Sykli.CLI do
   alias Sykli.Error.Formatter
 
   @version Mix.Project.config()[:version]
-  @subcommands ~w(cache graph delta watch report history daemon init validate verify plan explain context fix query mcp run)
+  @subcommands ~w(cache graph delta watch report history daemon work init validate verify plan explain context fix query mcp run)
 
   def main(args \\ []) do
     args = normalize_global_json(args)
@@ -44,6 +44,11 @@ defmodule Sykli.CLI do
 
       ["daemon" | daemon_args] ->
         handle_daemon(daemon_args)
+
+      ["work" | work_args] ->
+        work_args
+        |> Sykli.CLI.Work.run()
+        |> halt()
 
       ["init" | init_args] ->
         handle_init(init_args)
@@ -128,6 +133,7 @@ defmodule Sykli.CLI do
       sykli report     Show last run summary with task results
       sykli history    List recent runs
       sykli daemon     Manage daemon (see: sykli daemon --help)
+      sykli work       Manage local work items (see: sykli work --help)
       sykli cache      Manage cache (see: sykli cache --help)
       sykli mcp        Start MCP server (for AI assistants)
 

--- a/core/lib/sykli/cli/work.ex
+++ b/core/lib/sykli/cli/work.ex
@@ -13,10 +13,12 @@ defmodule Sykli.CLI.Work do
   alias Sykli.WorkItem
 
   @default_actor_type "member"
-  @default_actor_id "local"
 
   @doc """
   Runs a `sykli work ...` command and returns the intended process exit code.
+
+  `runtime_opts` are internal test hooks for store path, clocks, ids, and
+  default actor attribution. Parsed CLI flags are kept separate in `opts`.
   """
   def run(args, runtime_opts \\ []) do
     case parse(args) do
@@ -29,7 +31,7 @@ defmodule Sykli.CLI.Work do
   end
 
   defp execute({:create, title}, opts, runtime_opts) do
-    {actor_type, actor_id} = actor(opts)
+    {actor_type, actor_id} = actor(opts, runtime_opts)
 
     create_opts =
       runtime_opts
@@ -83,7 +85,7 @@ defmodule Sykli.CLI.Work do
   end
 
   defp execute({:claim, id}, opts, runtime_opts) do
-    {actor_type, actor_id} = actor(opts)
+    {actor_type, actor_id} = actor(opts, runtime_opts)
 
     claim_opts =
       runtime_opts
@@ -102,7 +104,7 @@ defmodule Sykli.CLI.Work do
   end
 
   defp execute({:note, id, body}, opts, runtime_opts) do
-    {actor_type, actor_id} = actor(opts)
+    {actor_type, actor_id} = actor(opts, runtime_opts)
 
     note_opts =
       runtime_opts
@@ -188,6 +190,14 @@ defmodule Sykli.CLI.Work do
     parse_flags(rest, [{:json, true} | opts], positionals)
   end
 
+  defp parse_flags(["--help" | rest], opts, positionals) do
+    parse_flags(rest, opts, ["--help" | positionals])
+  end
+
+  defp parse_flags(["-h" | rest], opts, positionals) do
+    parse_flags(rest, opts, ["-h" | positionals])
+  end
+
   defp parse_flags(["--intent", value | rest], opts, positionals) do
     parse_flags(rest, [{:intent, value} | opts], positionals)
   end
@@ -202,7 +212,7 @@ defmodule Sykli.CLI.Work do
         parse_flags(rest, [{:actor_type, actor_type}, {:actor_id, actor_id} | opts], positionals)
 
       {:error, reason} ->
-        {Enum.reverse(opts), Enum.reverse(positionals), reason}
+        finalize_parse_error(opts, positionals, rest, reason)
     end
   end
 
@@ -212,16 +222,27 @@ defmodule Sykli.CLI.Work do
         parse_flags(rest, [{:actor_type, actor_type}, {:actor_id, actor_id} | opts], positionals)
 
       {:error, reason} ->
-        {Enum.reverse(opts), Enum.reverse(positionals), reason}
+        finalize_parse_error(opts, positionals, rest, reason)
     end
   end
 
-  defp parse_flags([<<"--", _::binary>> = flag | _rest], opts, positionals) do
-    {Enum.reverse(opts), Enum.reverse(positionals), {:unknown_work_flag, flag}}
+  defp parse_flags([<<"--", _::binary>> = flag | rest], opts, positionals) do
+    finalize_parse_error(opts, positionals, rest, {:unknown_work_flag, flag})
   end
 
   defp parse_flags([arg | rest], opts, positionals) do
     parse_flags(rest, opts, [arg | positionals])
+  end
+
+  defp finalize_parse_error(opts, positionals, rest, reason) do
+    opts =
+      if "--json" in rest do
+        [{:json, true} | opts]
+      else
+        opts
+      end
+
+    {Enum.reverse(opts), Enum.reverse(positionals), reason}
   end
 
   defp parse_actor(value) when is_binary(value) do
@@ -243,11 +264,34 @@ defmodule Sykli.CLI.Work do
   defp validate_cli_actor_id(""), do: {:error, {:invalid_work_actor, :empty_id}}
   defp validate_cli_actor_id(_actor_id), do: :ok
 
-  defp actor(opts) do
+  defp actor(opts, runtime_opts) do
+    {default_type, default_id} = default_actor(runtime_opts)
+
     {
-      Keyword.get(opts, :actor_type, @default_actor_type),
-      Keyword.get(opts, :actor_id, @default_actor_id)
+      Keyword.get(opts, :actor_type, default_type),
+      Keyword.get(opts, :actor_id, default_id)
     }
+  end
+
+  defp default_actor(runtime_opts) do
+    {
+      Keyword.get(runtime_opts, :default_actor_type, @default_actor_type),
+      Keyword.get_lazy(runtime_opts, :default_actor_id, &default_actor_id/0)
+    }
+  end
+
+  defp default_actor_id do
+    ["SYKLI_ACTOR_ID", "USER", "USERNAME"]
+    |> Enum.find_value(fn name ->
+      case System.get_env(name) do
+        value when is_binary(value) and value != "" -> value
+        _ -> nil
+      end
+    end)
+    |> case do
+      nil -> "local"
+      value -> value
+    end
   end
 
   defp store_opts(runtime_opts), do: Keyword.take(runtime_opts, [:path])
@@ -297,6 +341,8 @@ defmodule Sykli.CLI.Work do
     Usage: sykli work <command>
 
     Local work item commands.
+
+    Unquoted title/body words are joined with spaces. Unknown flags are rejected.
 
     Commands:
       sykli work create "Title" [--intent TEXT] [--actor TYPE:ID]

--- a/core/lib/sykli/cli/work.ex
+++ b/core/lib/sykli/cli/work.ex
@@ -1,0 +1,314 @@
+defmodule Sykli.CLI.Work do
+  @moduledoc """
+  Local work item CLI commands.
+
+  This module is intentionally local-only. Team/coordinator routing is added in
+  later Team Mode phases.
+  """
+
+  alias Sykli.CLI.JsonResponse
+  alias Sykli.Error
+  alias Sykli.Error.Formatter
+  alias Sykli.Work.Store
+  alias Sykli.WorkItem
+
+  @default_actor_type "member"
+  @default_actor_id "local"
+
+  @doc """
+  Runs a `sykli work ...` command and returns the intended process exit code.
+  """
+  def run(args, runtime_opts \\ []) do
+    case parse(args) do
+      {:ok, command, opts} ->
+        execute(command, opts, runtime_opts)
+
+      {:error, reason, opts} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute({:create, title}, opts, runtime_opts) do
+    {actor_type, actor_id} = actor(opts)
+
+    create_opts =
+      runtime_opts
+      |> Keyword.take([:path, :now, :id])
+      |> Keyword.put(:intent, Keyword.get(opts, :intent))
+      |> Keyword.put(:created_by_type, actor_type)
+      |> Keyword.put(:created_by_id, actor_id)
+
+    case Store.create(title, create_opts) do
+      {:ok, item} ->
+        output_success(%{source: "local", item: item_map(item)}, opts, fn ->
+          IO.puts("Created work item #{item.id}")
+          IO.puts(item.title)
+        end)
+
+      {:error, reason} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute(:list, opts, runtime_opts) do
+    case Store.list(store_opts(runtime_opts)) do
+      {:ok, items} ->
+        output_success(%{source: "local", items: Enum.map(items, &item_map/1)}, opts, fn ->
+          if items == [] do
+            IO.puts("No work items")
+          else
+            IO.puts("Work items:")
+
+            Enum.each(items, fn item ->
+              IO.puts("  #{item.id}  #{item.status}  #{item.title}")
+            end)
+          end
+        end)
+
+      {:error, reason} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute({:show, id}, opts, runtime_opts) do
+    case Store.get(id, store_opts(runtime_opts)) do
+      {:ok, item} ->
+        output_success(%{source: "local", item: item_map(item)}, opts, fn ->
+          print_item(item)
+        end)
+
+      {:error, reason} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute({:claim, id}, opts, runtime_opts) do
+    {actor_type, actor_id} = actor(opts)
+
+    claim_opts =
+      runtime_opts
+      |> Keyword.take([:path, :now])
+
+    case Store.claim(id, actor_type, actor_id, claim_opts) do
+      {:ok, item} ->
+        output_success(%{source: "local", item: item_map(item)}, opts, fn ->
+          IO.puts("Claimed work item #{item.id}")
+          IO.puts("#{item.assigned_to_type}:#{item.assigned_to_id}")
+        end)
+
+      {:error, reason} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute({:note, id, body}, opts, runtime_opts) do
+    {actor_type, actor_id} = actor(opts)
+
+    note_opts =
+      runtime_opts
+      |> Keyword.take([:path, :now, :note_id])
+      |> Keyword.put(:author_type, actor_type)
+      |> Keyword.put(:author_id, actor_id)
+
+    case Store.append_note(id, body, note_opts) do
+      {:ok, note, item} ->
+        output_success(%{source: "local", note: note, item: item_map(item)}, opts, fn ->
+          IO.puts("Added note #{note["id"]} to work item #{item.id}")
+        end)
+
+      {:error, reason} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute(:help, _opts, _runtime_opts) do
+    print_help()
+    0
+  end
+
+  defp parse(args) do
+    {opts, positionals, error} = parse_flags(args, [], [])
+
+    cond do
+      error != nil ->
+        {:error, error, opts}
+
+      positionals in [[], ["--help"], ["-h"]] ->
+        {:ok, :help, opts}
+
+      positionals == ["create"] ->
+        {:error, :work_item_missing_title, opts}
+
+      match?(["create" | _], positionals) ->
+        ["create" | title_parts] = positionals
+        title = title_parts |> Enum.join(" ") |> String.trim()
+
+        if title == "" do
+          {:error, :work_item_missing_title, opts}
+        else
+          {:ok, {:create, title}, opts}
+        end
+
+      positionals == ["list"] ->
+        {:ok, :list, opts}
+
+      match?(["show", _], positionals) ->
+        ["show", id] = positionals
+        {:ok, {:show, id}, opts}
+
+      match?(["claim", _], positionals) ->
+        ["claim", id] = positionals
+        {:ok, {:claim, id}, opts}
+
+      positionals == ["claim"] ->
+        {:error, {:invalid_work_command, "claim requires a work item id"}, opts}
+
+      match?(["note", _, _ | _], positionals) ->
+        ["note", id | body_parts] = positionals
+        body = body_parts |> Enum.join(" ") |> String.trim()
+
+        if body == "" do
+          {:error, {:invalid_work_command, "note requires a non-empty body"}, opts}
+        else
+          {:ok, {:note, id, body}, opts}
+        end
+
+      match?(["note"], positionals) or match?(["note", _], positionals) ->
+        {:error, {:invalid_work_command, "note requires a work item id and body"}, opts}
+
+      true ->
+        {:error, {:invalid_work_command, Enum.join(positionals, " ")}, opts}
+    end
+  end
+
+  defp parse_flags([], opts, positionals),
+    do: {Enum.reverse(opts), Enum.reverse(positionals), nil}
+
+  defp parse_flags(["--json" | rest], opts, positionals) do
+    parse_flags(rest, [{:json, true} | opts], positionals)
+  end
+
+  defp parse_flags(["--intent", value | rest], opts, positionals) do
+    parse_flags(rest, [{:intent, value} | opts], positionals)
+  end
+
+  defp parse_flags([<<"--intent=", value::binary>> | rest], opts, positionals) do
+    parse_flags(rest, [{:intent, value} | opts], positionals)
+  end
+
+  defp parse_flags(["--actor", value | rest], opts, positionals) do
+    case parse_actor(value) do
+      {:ok, actor_type, actor_id} ->
+        parse_flags(rest, [{:actor_type, actor_type}, {:actor_id, actor_id} | opts], positionals)
+
+      {:error, reason} ->
+        {Enum.reverse(opts), Enum.reverse(positionals), reason}
+    end
+  end
+
+  defp parse_flags([<<"--actor=", value::binary>> | rest], opts, positionals) do
+    case parse_actor(value) do
+      {:ok, actor_type, actor_id} ->
+        parse_flags(rest, [{:actor_type, actor_type}, {:actor_id, actor_id} | opts], positionals)
+
+      {:error, reason} ->
+        {Enum.reverse(opts), Enum.reverse(positionals), reason}
+    end
+  end
+
+  defp parse_flags([<<"--", _::binary>> = flag | _rest], opts, positionals) do
+    {Enum.reverse(opts), Enum.reverse(positionals), {:unknown_work_flag, flag}}
+  end
+
+  defp parse_flags([arg | rest], opts, positionals) do
+    parse_flags(rest, opts, [arg | positionals])
+  end
+
+  defp parse_actor(value) when is_binary(value) do
+    case String.split(value, ":", parts: 2) do
+      [actor_type, actor_id] ->
+        actor_type = String.trim(actor_type)
+        actor_id = String.trim(actor_id)
+
+        with :ok <- WorkItem.validate_actor_type(actor_type),
+             :ok <- validate_cli_actor_id(actor_id) do
+          {:ok, actor_type, actor_id}
+        end
+
+      _ ->
+        {:error, {:invalid_work_actor, value}}
+    end
+  end
+
+  defp validate_cli_actor_id(""), do: {:error, {:invalid_work_actor, :empty_id}}
+  defp validate_cli_actor_id(_actor_id), do: :ok
+
+  defp actor(opts) do
+    {
+      Keyword.get(opts, :actor_type, @default_actor_type),
+      Keyword.get(opts, :actor_id, @default_actor_id)
+    }
+  end
+
+  defp store_opts(runtime_opts), do: Keyword.take(runtime_opts, [:path])
+
+  defp output_success(data, opts, human_fun) do
+    if Keyword.get(opts, :json, false) do
+      IO.puts(JsonResponse.ok(data))
+    else
+      human_fun.()
+    end
+
+    0
+  end
+
+  defp output_error(reason, json_output) do
+    error = Error.wrap(reason)
+
+    if json_output do
+      IO.puts(JsonResponse.error(error))
+    else
+      IO.puts(:stderr, Formatter.format(error))
+    end
+
+    1
+  end
+
+  defp item_map(%WorkItem{} = item), do: WorkItem.to_map(item)
+
+  defp print_item(%WorkItem{} = item) do
+    IO.puts("#{item.id}  #{item.status}  #{item.title}")
+
+    if item.intent do
+      IO.puts("intent: #{item.intent}")
+    end
+
+    if item.assigned_to_type && item.assigned_to_id do
+      IO.puts("assigned: #{item.assigned_to_type}:#{item.assigned_to_id}")
+    end
+
+    if item.notes != [] do
+      IO.puts("notes: #{length(item.notes)}")
+    end
+  end
+
+  defp print_help do
+    IO.puts("""
+    Usage: sykli work <command>
+
+    Local work item commands.
+
+    Commands:
+      sykli work create "Title" [--intent TEXT] [--actor TYPE:ID]
+      sykli work list
+      sykli work show <work-id>
+      sykli work claim <work-id> [--actor TYPE:ID]
+      sykli work note <work-id> "Body" [--actor TYPE:ID]
+
+    Options:
+      --json          Output as JSON
+      --intent TEXT   Set work item intent when creating
+      --actor TYPE:ID Set actor identity, e.g. member:yair, agent:claude, daemon:worker-1
+    """)
+  end
+end

--- a/core/lib/sykli/error.ex
+++ b/core/lib/sykli/error.ex
@@ -983,6 +983,39 @@ defmodule Sykli.Error do
     do: "invalid work command #{inspect(command)}"
 
   defp format_work_item_reason({:invalid_actor, actor}), do: "invalid actor #{inspect(actor)}"
+
+  defp format_work_item_reason({:invalid_status, status}),
+    do: "invalid status #{inspect(status)}"
+
+  defp format_work_item_reason({:invalid_assignment_type, type}),
+    do: "invalid assignment type #{inspect(type)}"
+
+  defp format_work_item_reason({:invalid_assignment_id, id}),
+    do: "invalid assignment id #{inspect(id)}"
+
+  defp format_work_item_reason({:invalid_actor_type, type}),
+    do: "invalid actor type #{inspect(type)}"
+
+  defp format_work_item_reason({:invalid_actor_id, field, id}),
+    do: "invalid #{field} actor id #{inspect(id)}"
+
+  defp format_work_item_reason({:invalid_created_by, reason}),
+    do: "invalid created_by fields: #{format_work_item_reason(reason)}"
+
+  defp format_work_item_reason({:invalid_notes, notes}),
+    do: "invalid notes #{inspect(notes)}"
+
+  defp format_work_item_reason({:invalid_note, reason}),
+    do: "invalid note: #{format_work_item_reason(reason)}"
+
+  defp format_work_item_reason({:invalid_note_author, reason}),
+    do: "invalid note author: #{format_work_item_reason(reason)}"
+
+  defp format_work_item_reason(:empty_id), do: "empty actor id"
+  defp format_work_item_reason(:empty_body), do: "empty note body"
+  defp format_work_item_reason(:not_string), do: "expected string"
+  defp format_work_item_reason(:missing_type), do: "missing actor type"
+
   defp format_work_item_reason(reason), do: inspect(reason)
 
   defp format_duration(ms) when ms < 1000, do: "#{ms}ms"

--- a/core/lib/sykli/error.ex
+++ b/core/lib/sykli/error.ex
@@ -32,9 +32,15 @@ defmodule Sykli.Error do
   | image_not_found | runtime | Docker image not found |
   | cluster_unreachable | runtime | K8s connection failed |
   | resource_failed | runtime | K8s resource creation failed |
-  | not_a_git_repo | runtime | Not a git repository |
-  | uncommitted_changes | runtime | Uncommitted changes |
-  | internal_error | internal | Unexpected error (with report link) |
+   | not_a_git_repo | runtime | Not a git repository |
+   | uncommitted_changes | runtime | Uncommitted changes |
+   | invalid_work_item | work | Invalid local work item data |
+   | invalid_work_item_id | work | Invalid local work item id |
+   | malformed_work_item_json | work | Local work item file is not valid JSON |
+   | work_item_already_claimed | work | Local work item is already claimed |
+   | work_item_missing_title | work | Work item create command is missing a title |
+   | work_item_not_found | work | Local work item was not found |
+   | internal_error | internal | Unexpected error (with report link) |
 
   ## Usage
 
@@ -590,6 +596,72 @@ defmodule Sykli.Error do
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
+  # WORK ITEM ERRORS
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  def work_item_missing_title do
+    %__MODULE__{
+      code: "work_item_missing_title",
+      type: :validation,
+      message: "work item title is required",
+      step: :validate,
+      hints: ["use: sykli work create \"Title\""]
+    }
+  end
+
+  def work_item_not_found(id) do
+    %__MODULE__{
+      code: "work_item_not_found",
+      type: :validation,
+      message: "work item '#{id}' was not found",
+      step: :validate,
+      hints: ["run `sykli work list` to see local work items"]
+    }
+  end
+
+  def invalid_work_item_id(id) do
+    %__MODULE__{
+      code: "invalid_work_item_id",
+      type: :validation,
+      message: "invalid work item id: #{inspect(id)}",
+      step: :validate,
+      hints: ["work item ids may contain letters, numbers, underscores, dashes, and dots"]
+    }
+  end
+
+  def work_item_already_claimed(id, assignment) do
+    %__MODULE__{
+      code: "work_item_already_claimed",
+      type: :validation,
+      message: "work item '#{id}' is already claimed",
+      step: :validate,
+      hints: ["choose another work item or inspect it with `sykli work show #{id}`"],
+      notes: [format_assignment_note(assignment)]
+    }
+  end
+
+  def malformed_work_item_json(path) do
+    %__MODULE__{
+      code: "malformed_work_item_json",
+      type: :validation,
+      message: "local work item file is not valid JSON",
+      step: :parse,
+      hints: ["inspect or remove the malformed file before retrying"],
+      notes: ["path: #{path}"]
+    }
+  end
+
+  def invalid_work_item(reason) do
+    %__MODULE__{
+      code: "invalid_work_item",
+      type: :validation,
+      message: "invalid local work item: #{format_work_item_reason(reason)}",
+      step: :validate,
+      hints: ["inspect the work item file under .sykli/work/items"]
+    }
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
   # INTERNAL ERRORS
   # ─────────────────────────────────────────────────────────────────────────────
 
@@ -661,6 +733,36 @@ defmodule Sykli.Error do
   def wrap({:python_failed, output}), do: sdk_failed(:python, output)
   def wrap({:python_timeout, msg}), do: sdk_timeout(:python, 120_000) |> add_note(msg)
   def wrap({:missing_tool, tool, hint}), do: missing_tool(tool, hint)
+
+  # Work item errors
+  def wrap(:work_item_missing_title), do: work_item_missing_title()
+  def wrap({:work_item_not_found, id}), do: work_item_not_found(id)
+  def wrap({:invalid_work_item_id, id}), do: invalid_work_item_id(id)
+
+  def wrap({:work_item_already_claimed, id, assignment}),
+    do: work_item_already_claimed(id, assignment)
+
+  def wrap({:malformed_work_item_json, path, _error}), do: malformed_work_item_json(path)
+  def wrap({:unknown_work_flag, flag}), do: invalid_work_item({:unknown_flag, flag})
+  def wrap({:invalid_work_command, command}), do: invalid_work_item({:invalid_command, command})
+  def wrap({:invalid_work_actor, actor}), do: invalid_work_item({:invalid_actor, actor})
+  def wrap({:missing_work_item_version, _}), do: invalid_work_item(:missing_version)
+
+  def wrap({:unsupported_work_item_version, version}),
+    do: invalid_work_item({:unsupported_version, version})
+
+  def wrap({:invalid_work_item_status, status}), do: invalid_work_item({:invalid_status, status})
+
+  def wrap({:invalid_assignment_type, type}),
+    do: invalid_work_item({:invalid_assignment_type, type})
+
+  def wrap({:invalid_assignment_id, id}), do: invalid_work_item({:invalid_assignment_id, id})
+  def wrap({:invalid_actor_type, type}), do: invalid_work_item({:invalid_actor_type, type})
+  def wrap({:invalid_actor_id, field, id}), do: invalid_work_item({:invalid_actor_id, field, id})
+  def wrap({:invalid_created_by, reason}), do: invalid_work_item({:invalid_created_by, reason})
+  def wrap({:invalid_notes, notes}), do: invalid_work_item({:invalid_notes, notes})
+  def wrap({:invalid_note, reason}), do: invalid_work_item({:invalid_note, reason})
+  def wrap({:invalid_note_author, reason}), do: invalid_work_item({:invalid_note_author, reason})
 
   # Validation errors
   def wrap({:cycle_detected, path}), do: cycle_detected(path)
@@ -859,6 +961,29 @@ defmodule Sykli.Error do
   defp build_duration_note(ms) do
     ["task ran for #{format_duration(ms)} before failing"]
   end
+
+  defp format_assignment_note(%{} = assignment) do
+    type = Map.get(assignment, "assigned_to_type") || "unknown"
+    id = Map.get(assignment, "assigned_to_id") || "unknown"
+    status = Map.get(assignment, "status") || "unknown"
+    "current assignment: #{type}:#{id} (status: #{status})"
+  end
+
+  defp format_assignment_note(_assignment), do: "current assignment is unavailable"
+
+  defp format_work_item_reason(:missing_version), do: "missing version"
+
+  defp format_work_item_reason({:unsupported_version, version}),
+    do: "unsupported version #{inspect(version)}"
+
+  defp format_work_item_reason({:unknown_flag, flag}), do: "unknown flag #{flag}"
+  defp format_work_item_reason({:invalid_command, ""}), do: "missing work command"
+
+  defp format_work_item_reason({:invalid_command, command}),
+    do: "invalid work command #{inspect(command)}"
+
+  defp format_work_item_reason({:invalid_actor, actor}), do: "invalid actor #{inspect(actor)}"
+  defp format_work_item_reason(reason), do: inspect(reason)
 
   defp format_duration(ms) when ms < 1000, do: "#{ms}ms"
   defp format_duration(ms) when ms < 60_000, do: "#{Float.round(ms / 1000, 1)}s"

--- a/core/test/sykli/cli/work_test.exs
+++ b/core/test/sykli/cli/work_test.exs
@@ -1,0 +1,158 @@
+defmodule Sykli.CLI.WorkTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias Sykli.CLI.Work
+
+  @moduletag :tmp_dir
+
+  @now "2026-05-08T10:00:00Z"
+
+  describe "local work commands" do
+    test "create prints human output and persists item", %{tmp_dir: tmp_dir} do
+      output =
+        capture_io(fn ->
+          assert Work.run(["create", "Investigate deploy"],
+                   path: tmp_dir,
+                   id: "work_001",
+                   now: @now
+                 ) == 0
+        end)
+
+      assert output =~ "Created work item work_001"
+      assert File.exists?(Path.join([tmp_dir, ".sykli", "work", "items", "work_001.json"]))
+    end
+
+    test "create --json returns shared envelope", %{tmp_dir: tmp_dir} do
+      result =
+        run_json(["create", "Investigate deploy", "--intent", "Find failure", "--json"],
+          path: tmp_dir,
+          id: "work_001",
+          now: @now
+        )
+
+      assert result["ok"] == true
+      assert result["data"]["source"] == "local"
+      assert result["data"]["item"]["id"] == "work_001"
+      assert result["data"]["item"]["title"] == "Investigate deploy"
+      assert result["data"]["item"]["intent"] == "Find failure"
+      assert result["data"]["item"]["created_by_type"] == "member"
+      assert result["data"]["item"]["created_by_id"] == "local"
+    end
+
+    test "list --json handles empty and deterministic lists", %{tmp_dir: tmp_dir} do
+      assert run_json(["list", "--json"], path: tmp_dir)["data"]["items"] == []
+
+      assert run_silent(["create", "Second"], path: tmp_dir, id: "work_b", now: @now) == 0
+      assert run_silent(["create", "First"], path: tmp_dir, id: "work_a", now: @now) == 0
+
+      result = run_json(["list", "--json"], path: tmp_dir)
+      assert Enum.map(result["data"]["items"], & &1["id"]) == ["work_a", "work_b"]
+    end
+
+    test "show --json returns one work item", %{tmp_dir: tmp_dir} do
+      assert run_silent(["create", "Review PR"], path: tmp_dir, id: "work_001", now: @now) == 0
+
+      result = run_json(["show", "work_001", "--json"], path: tmp_dir)
+      assert result["data"]["item"]["id"] == "work_001"
+      assert result["data"]["item"]["status"] == "open"
+    end
+
+    test "claim --json updates assignment with default actor", %{tmp_dir: tmp_dir} do
+      assert run_silent(["create", "Review PR"], path: tmp_dir, id: "work_001", now: @now) == 0
+
+      result = run_json(["claim", "work_001", "--json"], path: tmp_dir, now: @now)
+      item = result["data"]["item"]
+      assert item["status"] == "claimed"
+      assert item["assigned_to_type"] == "member"
+      assert item["assigned_to_id"] == "local"
+    end
+
+    test "claim supports explicit actor", %{tmp_dir: tmp_dir} do
+      assert run_silent(["create", "Review PR"], path: tmp_dir, id: "work_001", now: @now) == 0
+
+      result =
+        run_json(["claim", "work_001", "--actor", "agent:claude", "--json"],
+          path: tmp_dir,
+          now: @now
+        )
+
+      item = result["data"]["item"]
+      assert item["assigned_to_type"] == "agent"
+      assert item["assigned_to_id"] == "claude"
+    end
+
+    test "note --json appends note and returns note plus item", %{tmp_dir: tmp_dir} do
+      assert run_silent(["create", "Review PR"], path: tmp_dir, id: "work_001", now: @now) == 0
+
+      result =
+        run_json(["note", "work_001", "Found likely API breakage", "--json"],
+          path: tmp_dir,
+          note_id: "note_001",
+          now: @now
+        )
+
+      assert result["data"]["note"]["id"] == "note_001"
+      assert result["data"]["note"]["body"] == "Found likely API breakage"
+      assert [note] = result["data"]["item"]["notes"]
+      assert note["id"] == "note_001"
+    end
+  end
+
+  describe "errors" do
+    test "create without title returns structured JSON error", %{tmp_dir: tmp_dir} do
+      result = run_json(["create", "--json"], path: tmp_dir, expect: 1)
+      assert result["ok"] == false
+      assert result["error"]["code"] == "work_item_missing_title"
+    end
+
+    test "invalid id returns structured JSON error", %{tmp_dir: tmp_dir} do
+      result = run_json(["show", "../escape", "--json"], path: tmp_dir, expect: 1)
+      assert result["ok"] == false
+      assert result["error"]["code"] == "invalid_work_item_id"
+    end
+
+    test "not found returns structured JSON error", %{tmp_dir: tmp_dir} do
+      result = run_json(["show", "missing", "--json"], path: tmp_dir, expect: 1)
+      assert result["ok"] == false
+      assert result["error"]["code"] == "work_item_not_found"
+    end
+
+    test "already claimed returns structured JSON error", %{tmp_dir: tmp_dir} do
+      assert run_silent(["create", "Review PR"], path: tmp_dir, id: "work_001", now: @now) == 0
+      assert run_silent(["claim", "work_001"], path: tmp_dir, now: @now) == 0
+
+      result = run_json(["claim", "work_001", "--json"], path: tmp_dir, expect: 1)
+      assert result["error"]["code"] == "work_item_already_claimed"
+    end
+
+    test "malformed persisted JSON returns structured JSON error", %{tmp_dir: tmp_dir} do
+      dir = Path.join([tmp_dir, ".sykli", "work", "items"])
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "work_001.json"), "{bad json")
+
+      result = run_json(["show", "work_001", "--json"], path: tmp_dir, expect: 1)
+      assert result["error"]["code"] == "malformed_work_item_json"
+    end
+  end
+
+  defp run_json(args, opts) do
+    expected_code = Keyword.get(opts, :expect, 0)
+
+    output =
+      capture_io(fn ->
+        assert Work.run(args, opts) == expected_code
+      end)
+
+    Jason.decode!(output)
+  end
+
+  defp run_silent(args, opts) do
+    capture_io(fn ->
+      assert Work.run(args, opts) == 0
+    end)
+
+    0
+  end
+end

--- a/core/test/sykli/cli/work_test.exs
+++ b/core/test/sykli/cli/work_test.exs
@@ -38,7 +38,19 @@ defmodule Sykli.CLI.WorkTest do
       assert result["data"]["item"]["title"] == "Investigate deploy"
       assert result["data"]["item"]["intent"] == "Find failure"
       assert result["data"]["item"]["created_by_type"] == "member"
-      assert result["data"]["item"]["created_by_id"] == "local"
+      assert result["data"]["item"]["created_by_id"] == "test-user"
+    end
+
+    test "create supports equals-form flags and joins unquoted title words", %{tmp_dir: tmp_dir} do
+      result =
+        run_json(["create", "Investigate", "deploy", "--intent=Find failure", "--json"],
+          path: tmp_dir,
+          id: "work_001",
+          now: @now
+        )
+
+      assert result["data"]["item"]["title"] == "Investigate deploy"
+      assert result["data"]["item"]["intent"] == "Find failure"
     end
 
     test "list --json handles empty and deterministic lists", %{tmp_dir: tmp_dir} do
@@ -66,14 +78,14 @@ defmodule Sykli.CLI.WorkTest do
       item = result["data"]["item"]
       assert item["status"] == "claimed"
       assert item["assigned_to_type"] == "member"
-      assert item["assigned_to_id"] == "local"
+      assert item["assigned_to_id"] == "test-user"
     end
 
-    test "claim supports explicit actor", %{tmp_dir: tmp_dir} do
+    test "claim supports explicit actor with equals-form flag", %{tmp_dir: tmp_dir} do
       assert run_silent(["create", "Review PR"], path: tmp_dir, id: "work_001", now: @now) == 0
 
       result =
-        run_json(["claim", "work_001", "--actor", "agent:claude", "--json"],
+        run_json(["claim", "work_001", "--actor=agent:claude", "--json"],
           path: tmp_dir,
           now: @now
         )
@@ -98,6 +110,29 @@ defmodule Sykli.CLI.WorkTest do
       assert [note] = result["data"]["item"]["notes"]
       assert note["id"] == "note_001"
     end
+
+    test "note joins unquoted body words", %{tmp_dir: tmp_dir} do
+      assert run_silent(["create", "Review PR"], path: tmp_dir, id: "work_001", now: @now) == 0
+
+      result =
+        run_json(["note", "work_001", "Found", "likely", "API", "breakage", "--json"],
+          path: tmp_dir,
+          note_id: "note_001",
+          now: @now
+        )
+
+      assert result["data"]["note"]["body"] == "Found likely API breakage"
+    end
+
+    test "help exits successfully", %{tmp_dir: tmp_dir} do
+      output =
+        capture_io(fn ->
+          assert Work.run(["--help"], path: tmp_dir) == 0
+        end)
+
+      assert output =~ "Usage: sykli work <command>"
+      assert output =~ "Unknown flags are rejected"
+    end
   end
 
   describe "errors" do
@@ -105,6 +140,33 @@ defmodule Sykli.CLI.WorkTest do
       result = run_json(["create", "--json"], path: tmp_dir, expect: 1)
       assert result["ok"] == false
       assert result["error"]["code"] == "work_item_missing_title"
+    end
+
+    test "unknown command returns clear JSON error", %{tmp_dir: tmp_dir} do
+      result = run_json(["wat", "--json"], path: tmp_dir, expect: 1)
+      assert result["ok"] == false
+      assert result["error"]["code"] == "invalid_work_item"
+      assert result["error"]["message"] == "invalid local work item: invalid work command \"wat\""
+    end
+
+    test "unknown flag returns clear JSON error", %{tmp_dir: tmp_dir} do
+      result = run_json(["list", "--bogus", "--json"], path: tmp_dir, expect: 1)
+      assert result["ok"] == false
+      assert result["error"]["code"] == "invalid_work_item"
+      assert result["error"]["message"] == "invalid local work item: unknown flag --bogus"
+    end
+
+    test "invalid actor type returns clear JSON error without raw tuple text", %{tmp_dir: tmp_dir} do
+      result =
+        run_json(["claim", "work_001", "--actor", "robot:r2d2", "--json"],
+          path: tmp_dir,
+          expect: 1
+        )
+
+      assert result["ok"] == false
+      assert result["error"]["code"] == "invalid_work_item"
+      assert result["error"]["message"] == "invalid local work item: invalid actor type \"robot\""
+      refute result["error"]["message"] =~ "{:"
     end
 
     test "invalid id returns structured JSON error", %{tmp_dir: tmp_dir} do
@@ -138,6 +200,7 @@ defmodule Sykli.CLI.WorkTest do
   end
 
   defp run_json(args, opts) do
+    opts = Keyword.put_new(opts, :default_actor_id, "test-user")
     expected_code = Keyword.get(opts, :expect, 0)
 
     output =
@@ -149,6 +212,8 @@ defmodule Sykli.CLI.WorkTest do
   end
 
   defp run_silent(args, opts) do
+    opts = Keyword.put_new(opts, :default_actor_id, "test-user")
+
     capture_io(fn ->
       assert Work.run(args, opts) == 0
     end)

--- a/core/test/sykli/cli_test.exs
+++ b/core/test/sykli/cli_test.exs
@@ -137,6 +137,7 @@ defmodule Sykli.CLITest do
   describe "global option normalization" do
     test "moves leading --json after JSON-supporting subcommand" do
       assert Sykli.CLI.normalize_global_json(["--json", "validate"]) == ["validate", "--json"]
+      assert Sykli.CLI.normalize_global_json(["--json", "work", "list"]) == ["work", "--json", "list"]
     end
 
     test "leaves default run JSON form unchanged" do

--- a/core/test/sykli/cli_test.exs
+++ b/core/test/sykli/cli_test.exs
@@ -137,7 +137,12 @@ defmodule Sykli.CLITest do
   describe "global option normalization" do
     test "moves leading --json after JSON-supporting subcommand" do
       assert Sykli.CLI.normalize_global_json(["--json", "validate"]) == ["validate", "--json"]
-      assert Sykli.CLI.normalize_global_json(["--json", "work", "list"]) == ["work", "--json", "list"]
+
+      assert Sykli.CLI.normalize_global_json(["--json", "work", "list"]) == [
+               "work",
+               "--json",
+               "list"
+             ]
     end
 
     test "leaves default run JSON form unchanged" do

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -105,12 +105,12 @@ No cache-prefixed `Sykli.Error` codes are emitted today. Cache failures currentl
 
 | Code | Description | Tier | Emitted from |
 |------|-------------|------|--------------|
-| `invalid_work_item` | A local work item command encountered structurally invalid work item data or arguments. | public-unstable | `core/lib/sykli/error.ex` |
-| `invalid_work_item_id` | A local work item id failed validation, including path traversal attempts. | public-unstable | `core/lib/sykli/error.ex` |
-| `malformed_work_item_json` | A persisted `.sykli/work/items/<id>.json` file is not valid JSON. | public-unstable | `core/lib/sykli/error.ex` |
-| `work_item_already_claimed` | A local work item claim was rejected because the item is no longer open. | public-unstable | `core/lib/sykli/error.ex` |
-| `work_item_missing_title` | `sykli work create` was called without a title. | public-unstable | `core/lib/sykli/error.ex` |
-| `work_item_not_found` | A requested local work item does not exist. | public-unstable | `core/lib/sykli/error.ex` |
+| `invalid_work_item` | A local work item command encountered structurally invalid work item data or arguments. | public-unstable | `core/lib/sykli/error.ex:654` |
+| `invalid_work_item_id` | A local work item id failed validation, including path traversal attempts. | public-unstable | `core/lib/sykli/error.ex:622` |
+| `malformed_work_item_json` | A persisted `.sykli/work/items/<id>.json` file is not valid JSON. | public-unstable | `core/lib/sykli/error.ex:643` |
+| `work_item_already_claimed` | A local work item claim was rejected because the item is no longer open. | public-unstable | `core/lib/sykli/error.ex:632` |
+| `work_item_missing_title` | `sykli work create` was called without a title. | public-unstable | `core/lib/sykli/error.ex:602` |
+| `work_item_not_found` | A requested local work item does not exist. | public-unstable | `core/lib/sykli/error.ex:612` |
 
 ### sdk
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -101,6 +101,17 @@ No cache-prefixed `Sykli.Error` codes are emitted today. Cache failures currentl
 | `resource_failed` | Kubernetes target setup could not create a required cluster resource. | public-stable | `core/lib/sykli/error.ex:468` |
 | `uncommitted_changes` | A target requires reproducible Git state, but the working tree has uncommitted changes. | public-stable | `core/lib/sykli/error.ex:503` |
 
+### work
+
+| Code | Description | Tier | Emitted from |
+|------|-------------|------|--------------|
+| `invalid_work_item` | A local work item command encountered structurally invalid work item data or arguments. | public-unstable | `core/lib/sykli/error.ex` |
+| `invalid_work_item_id` | A local work item id failed validation, including path traversal attempts. | public-unstable | `core/lib/sykli/error.ex` |
+| `malformed_work_item_json` | A persisted `.sykli/work/items/<id>.json` file is not valid JSON. | public-unstable | `core/lib/sykli/error.ex` |
+| `work_item_already_claimed` | A local work item claim was rejected because the item is no longer open. | public-unstable | `core/lib/sykli/error.ex` |
+| `work_item_missing_title` | `sykli work create` was called without a title. | public-unstable | `core/lib/sykli/error.ex` |
+| `work_item_not_found` | A requested local work item does not exist. | public-unstable | `core/lib/sykli/error.ex` |
+
 ### sdk
 
 | Code | Description | Tier | Emitted from |

--- a/docs/local-state-plane.md
+++ b/docs/local-state-plane.md
@@ -247,6 +247,18 @@ The local work item file must not contain logs, artifacts, secrets, source
 code, environment dumps, or full stdout/stderr. It is coordination state,
 not execution evidence.
 
+Local work items are exposed through:
+
+```bash
+sykli work create "Review PR #176"
+sykli work list
+sykli work show <work-id>
+sykli work claim <work-id>
+sykli work note <work-id> "Found likely API breakage"
+```
+
+Each command supports `--json` and returns the shared CLI JSON envelope.
+
 The roadmap adds local-only state for work items and gates **before**
 networking turns on. That is intentional: a user should be able to:
 

--- a/docs/team-mode-roadmap.md
+++ b/docs/team-mode-roadmap.md
@@ -48,10 +48,16 @@ The roadmap below holds that sentence true at every step.
 Exit criteria: docs land. Definition of done: `docs/done.md` aligned for
 future phases; `git diff --check` passes; PR description complete.
 
-## Phase 1 — Local work item model
+## Phase 1 — Local work item model and CLI
 
 Add local work item state **before** any networking. A team-less user
 must benefit from work items the day they ship.
+
+Status:
+
+- PR #187 added `Sykli.WorkItem`, `Sykli.Work.Store`, and
+  `.sykli/work/items/<id>.json` persistence.
+- PR #188 adds the local `sykli work ...` CLI commands and JSON output.
 
 Suggested modules:
 

--- a/eval/oracle/run.sh
+++ b/eval/oracle/run.sh
@@ -1167,6 +1167,55 @@ if begin_case "057" "Concurrent: env vars set in task config"; then
 fi
 
 # ============================================================================
+# WORK ITEMS (058-059)
+# ============================================================================
+
+printf "\n${BOLD}Work Items${RESET}\n"
+
+# --- case_058: work create/list/show/claim/note JSON workflow ---
+if begin_case "058" "Work: local work item JSON workflow"; then
+  dir=$(tmp_workdir)
+  LAST_OUTPUT=$(run_sykli "$dir" work create "Review PR #176" --intent "Check timeout behavior" --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 0 "$exit_code"; then
+    id=$(echo "$LAST_OUTPUT" | jq -r '.data.item.id' 2>/dev/null)
+
+    if [[ -z "$id" || "$id" == "null" ]]; then
+      fail "work create --json did not return data.item.id"
+    elif assert_file_exists "$dir/.sykli/work/items/$id.json"; then
+      list_output=$(run_sykli "$dir" work list --json 2>&1)
+      show_output=$(run_sykli "$dir" work show "$id" --json 2>&1)
+      claim_output=$(run_sykli "$dir" work claim "$id" --json 2>&1)
+      note_output=$(run_sykli "$dir" work note "$id" "Found likely API breakage" --json 2>&1)
+
+      if assert_json_field "$list_output" '.ok' "true" "list"; then
+        if assert_json_field "$show_output" '.data.item.id' "$id" "show"; then
+          if assert_json_field "$claim_output" '.data.item.status' "claimed" "claim"; then
+            if assert_json_field "$note_output" '.data.note.body' "Found likely API breakage" "note"; then
+              pass 0
+            fi
+          fi
+        fi
+      fi
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
+# --- case_059: invalid work item id returns a stable JSON error ---
+if begin_case "059" "Work: invalid work item id returns JSON error"; then
+  dir=$(tmp_workdir)
+  LAST_OUTPUT=$(run_sykli "$dir" work show "../escape" --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 1 "$exit_code"; then
+    if assert_json_field "$LAST_OUTPUT" '.ok' "false"; then
+      if assert_json_field "$LAST_OUTPUT" '.error.code' "invalid_work_item_id"; then
+        pass 0
+      fi
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
+# ============================================================================
 # Summary
 # ============================================================================
 

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -15,7 +15,8 @@
     "DET": "Determinism - replay and wall-clock contract",
     "SDK": "SDK - cross-language parity contract",
     "UI": "UI - visual reset contract",
-    "GH": "GitHub - native receiver security contract"
+    "GH": "GitHub - native receiver security contract",
+    "WORK": "Work items - local Team Mode workflow"
   },
   "cases": [
     {
@@ -1538,6 +1539,36 @@
       "expect_exit": 0,
       "source": "CLAUDE.md §Definition of done; agent surface supports --json in any flag position",
       "validated_by": "Injected bug: leading --json is parsed as a run flag and validate becomes a path."
+    },
+    {
+      "id": "WORK-001",
+      "name": "local work item CLI workflow persists state",
+      "fixture": "empty_dir",
+      "command": "id=$(sykli work create \"Investigate failing checkout deploy\" --intent \"Find failing step\" --json | jq -r '.data.item.id') && sykli work list --json | jq -e --arg id \"$id\" '.ok == true and (.data.items | length) == 1 and .data.items[0].id == $id' >/dev/null && sykli work show \"$id\" --json | jq -e --arg id \"$id\" '.data.item.id == $id and .data.item.status == \"open\"' >/dev/null && sykli work claim \"$id\" --json | jq -e '.data.item.status == \"claimed\" and .data.item.assigned_to_type == \"member\"' >/dev/null && sykli work note \"$id\" \"Found likely API breakage\" --json | tee work-note.json >/dev/null && test -f \".sykli/work/items/$id.json\" && cat work-note.json",
+      "shell": true,
+      "expect_exit": 0,
+      "expect_json_jq": [
+        ".ok == true",
+        ".data.source == \"local\"",
+        ".data.note.body == \"Found likely API breakage\"",
+        ".data.item.status == \"claimed\"",
+        "(.data.item.notes | length) == 1"
+      ],
+      "source": "docs/team-mode-roadmap.md Phase 1; docs/local-state-plane.md local work item state",
+      "validated_by": "Injected bug: omit work CLI persistence or JSON envelope; workflow jq/file assertions fail."
+    },
+    {
+      "id": "WORK-002",
+      "name": "work show rejects path traversal ids with JSON error",
+      "fixture": "empty_dir",
+      "command": "sykli work show ../escape --json",
+      "expect_exit": 1,
+      "expect_json_jq": [
+        ".ok == false",
+        ".error.code == \"invalid_work_item_id\""
+      ],
+      "source": "docs/local-state-plane.md; local work items must not escape .sykli/work/items",
+      "validated_by": "Injected bug: pass raw ids into file path construction; traversal id is not rejected."
     },
     {
       "id": "GH-001",

--- a/test/blackbox/run.sh
+++ b/test/blackbox/run.sh
@@ -429,7 +429,7 @@ echo -e "${DIM}Dataset: $(jq '.cases | length' "$DATASET") test cases${RESET}"
 echo ""
 
 # Run categories in order
-for category in POS NEG SYS INT PERF LOAD ABN CACHE JSON DET SDK UI GH; do
+for category in POS NEG SYS INT PERF LOAD ABN CACHE JSON DET SDK UI GH WORK; do
   cases=$(jq -c ".cases[] | select(.id | startswith(\"$category\"))" "$DATASET")
   if [ -z "$cases" ]; then continue; fi
 


### PR DESCRIPTION
## Summary

Adds the local Work Item CLI layer on top of the WorkItem/Store model from PR #187. This is local-only Team Mode: commands read and write `.sykli/work/items/<id>.json` through `Sykli.Work.Store` and do not introduce coordinator, network, daemon join, remote execution, or MCP behavior.

## Commands Added

- `sykli work create "Title" [--intent TEXT] [--actor TYPE:ID] [--json]`
- `sykli work list [--json]`
- `sykli work show <work-id> [--json]`
- `sykli work claim <work-id> [--actor TYPE:ID] [--json]`
- `sykli work note <work-id> "Body" [--actor TYPE:ID] [--json]`

All commands support `--json` using the existing CLI JSON envelope.

## JSON Output Shape

Successful object responses return `ok: true` and a local source marker, for example:

```json
{
  "ok": true,
  "data": {
    "source": "local",
    "item": {
      "id": "work_...",
      "version": "1",
      "title": "Investigate failing checkout deploy",
      "status": "open"
    }
  }
}
```

`work list --json` returns `data.items`; `work note --json` returns both `data.note` and the updated `data.item`. Errors use the existing structured error envelope.

## Oracle Coverage

Added oracle cases:

- `058` local work item JSON workflow: create, list, show, claim, note, persisted file check
- `059` invalid work item ID JSON error

## Blackbox Coverage

Added blackbox category `WORK` with:

- `WORK-001` full local workflow: create/list/show/claim/note plus persisted `.sykli/work/items/<id>.json` verification
- `WORK-002` invalid ID rejection through `sykli work show ../escape --json`

## What Changed

- Added `Sykli.CLI.Work`
- Routed `sykli work` from the main CLI
- Added public work item error wrapping/formatting
- Added focused CLI tests for local work commands and JSON output
- Added blackbox and oracle coverage
- Documented commands, local state, roadmap status, and public work error codes

## Validation

- `cd core && mix format lib/sykli/cli.ex lib/sykli/cli/work.ex lib/sykli/error.ex test/sykli/cli/work_test.exs` passed
- `python3 -m json.tool test/blackbox/dataset.json >/dev/null` passed
- `cd core && mix test test/sykli/cli/work_test.exs test/sykli/work_item_test.exs test/sykli/work/store_test.exs test/sykli/cli_test.exs test/sykli/cli/json_response_test.exs` passed: 69 tests, 0 failures
- `cd core && mix escript.build` passed
- `test/blackbox/run.sh --filter=WORK` passed: 2 passed, 0 failed, 150 skipped
- `eval/oracle/run.sh --case=058` passed
- `eval/oracle/run.sh --case=059` passed
- `cd core && mix credo --strict` passed: found no issues
- `cd core && mix test` passed: 1 property, 1556 tests, 0 failures, 1 skipped, 13 excluded
- `git diff --check` passed

Full conformance was not run because this PR does not change contract schema, SDK emission, or conformance fixtures.

## Out of Scope

- No coordinator
- No network sync
- No daemon join or heartbeat
- No run/work association yet
- No gate state
- No MCP tools
- No remote execution
- No changes to mesh behavior

## Next PR

Next layer: **Associate runs with work items**.
