### PR TITLE
Associate runs with work items

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ sykli verify              # cross-platform verification via mesh
 sykli history             # recent runs
 sykli report              # show last run summary with task results
 sykli work list           # local Team Mode work items
+sykli run --work <id>     # associate a run with a local work item
+sykli work runs <id>      # list runs associated with a work item
 sykli cache stats         # cache hit rates
 sykli daemon start        # start a mesh node on this host
 sykli mcp                 # MCP server (Claude Code, Cursor, Copilot)

--- a/core/lib/sykli.ex
+++ b/core/lib/sykli.ex
@@ -34,7 +34,7 @@ defmodule Sykli do
     save_history = Keyword.get(opts, :save_history, true)
 
     with {:ok, sdk_file} <- Detector.find(path),
-         {:ok, json} <- Detector.emit(sdk_file),
+         {:ok, json} <- emit_contract_json(sdk_file, opts),
          {:ok, graph} <- Graph.parse(json) do
       # Expand matrix tasks into individual tasks
       expanded_graph = Graph.expand_matrix(graph)
@@ -143,6 +143,13 @@ defmodule Sykli do
       error ->
         IO.puts(:stderr, "\e[31m✗ Error: #{inspect(error)}\e[0m")
         error
+    end
+  end
+
+  defp emit_contract_json(sdk_file, opts) do
+    case Keyword.get(opts, :emitted_json) do
+      json when is_binary(json) -> {:ok, json}
+      _ -> Detector.emit(sdk_file)
     end
   end
 

--- a/core/lib/sykli.ex
+++ b/core/lib/sykli.ex
@@ -62,7 +62,7 @@ defmodule Sykli do
 
               # Save run history if enabled
               if save_history do
-                save_run_history(path, result, filtered_graph)
+                save_run_history(path, result, filtered_graph, opts)
               end
 
               result
@@ -186,7 +186,7 @@ defmodule Sykli do
   end
 
   # Save run history and generate AI context after execution
-  defp save_run_history(path, result, graph) do
+  defp save_run_history(path, result, graph, opts) do
     timestamp = DateTime.utc_now()
     run_id = generate_run_id()
 
@@ -206,7 +206,9 @@ defmodule Sykli do
       git_ref: get_git_ref(path),
       git_branch: get_git_branch(path),
       tasks: task_results_with_cause,
-      overall: overall
+      overall: overall,
+      work_item_id: Keyword.get(opts, :work_item_id),
+      contract_hash: Keyword.get(opts, :contract_hash)
     }
 
     # Write per-task logs

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -7,6 +7,7 @@ defmodule Sykli.CLI do
   alias Sykli.Delta
   alias Sykli.Error
   alias Sykli.Error.Formatter
+  alias Sykli.Work.Store, as: WorkStore
 
   @version Mix.Project.config()[:version]
   @subcommands ~w(cache graph delta watch report history daemon work init validate verify plan explain context fix query mcp run)
@@ -111,6 +112,7 @@ defmodule Sykli.CLI do
       --filter=NAME             Only run tasks matching NAME
       --timeout=DURATION        Per-task timeout (default: 5m). Use 10m, 30s, 2h, 1d, or 0 for no timeout
       --target=TARGET           Execution target: local (default), k8s
+      --work=WORK_ID            Associate this run with a local work item
       --allow-dirty             Allow running with uncommitted changes (K8s)
       --git-ssh-secret=NAME     K8s Secret for SSH git auth
       --git-token-secret=NAME   K8s Secret for HTTPS git auth
@@ -237,16 +239,35 @@ defmodule Sykli.CLI do
         run_opts
       end
 
-    result = Sykli.run(path, run_opts)
-    duration = System.monotonic_time(:millisecond) - start_time
+    case prepare_work_run_context(path, opts) do
+      {:ok, work_meta, work_run_opts} ->
+        run_opts = work_run_opts ++ run_opts
+        result = Sykli.run(path, run_opts)
+        duration = System.monotonic_time(:millisecond) - start_time
 
-    # Restore stdout before writing output
-    if original_gl, do: restore_stdout(original_gl)
+        # Restore stdout before writing output
+        if original_gl, do: restore_stdout(original_gl)
 
+        output_run_result(result, duration, path, opts, json_output, work_meta)
+
+      {:error, reason} ->
+        if original_gl, do: restore_stdout(original_gl)
+
+        if json_output do
+          IO.puts(JsonResponse.error(Error.wrap(reason)))
+        else
+          display_error(reason)
+        end
+
+        halt(1)
+    end
+  end
+
+  defp output_run_result(result, duration, path, opts, json_output, work_meta) do
     case result do
       {:ok, results} ->
         if json_output do
-          IO.puts(JsonResponse.ok(run_json_data("passed", results, duration, path)))
+          IO.puts(JsonResponse.ok(run_json_data("passed", results, duration, path, work_meta)))
         else
           IO.puts(
             Renderer.render_run(
@@ -264,7 +285,7 @@ defmodule Sykli.CLI do
 
       {:error, results} when is_list(results) ->
         if json_output do
-          IO.puts(JsonResponse.ok(run_json_data("failed", results, duration, path)))
+          IO.puts(JsonResponse.ok(run_json_data("failed", results, duration, path, work_meta)))
         else
           IO.puts(
             Renderer.render_run(
@@ -291,13 +312,42 @@ defmodule Sykli.CLI do
     end
   end
 
-  defp run_json_data(status, results, duration_ms, path) do
+  defp prepare_work_run_context(path, opts) do
+    case Keyword.get(opts, :work_item_id) do
+      nil ->
+        {:ok, %{}, []}
+
+      work_item_id ->
+        with {:ok, _item} <- WorkStore.get(work_item_id, path: path),
+             {:ok, {sdk_file, _runner}} <- Sykli.Detector.find(path),
+             {:ok, contract_hash} <- Sykli.ContractHash.from_sdk_file(sdk_file) do
+          work_meta = %{work_item_id: work_item_id, contract_hash: contract_hash}
+          {:ok, work_meta, [work_item_id: work_item_id, contract_hash: contract_hash]}
+        end
+    end
+  end
+
+  defp run_json_data(status, results, duration_ms, path, work_meta) do
     %{
       status: status,
       duration_ms: duration_ms,
       tasks: Enum.map(results, &task_result_to_map/1),
       occurrence_path: Path.join([path, ".sykli", "occurrence.json"])
     }
+    |> Map.merge(latest_run_json_meta(path, work_meta))
+  end
+
+  defp latest_run_json_meta(_path, work_meta) when map_size(work_meta) == 0, do: %{}
+
+  defp latest_run_json_meta(path, work_meta) do
+    case Sykli.RunHistory.load_latest(path: path) do
+      {:ok, run} ->
+        work_meta
+        |> Map.put(:run_id, run.id)
+
+      {:error, _} ->
+        work_meta
+    end
   end
 
   defp pipeline_label(path) do
@@ -446,6 +496,13 @@ defmodule Sykli.CLI do
   defp do_parse_run_args(["--target", value | tail], opts, rest)
        when is_binary(value) and binary_part(value, 0, 1) != "-",
        do: do_parse_run_args(tail, [{:target, parse_target(value)} | opts], rest)
+
+  defp do_parse_run_args(["--work=" <> work_item_id | tail], opts, rest),
+    do: do_parse_run_args(tail, [{:work_item_id, work_item_id} | opts], rest)
+
+  defp do_parse_run_args(["--work", work_item_id | tail], opts, rest)
+       when is_binary(work_item_id) and binary_part(work_item_id, 0, 1) != "-",
+       do: do_parse_run_args(tail, [{:work_item_id, work_item_id} | opts], rest)
 
   defp do_parse_run_args(["--" <> _ = arg | tail], opts, rest) do
     IO.puts(

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -319,10 +319,13 @@ defmodule Sykli.CLI do
 
       work_item_id ->
         with {:ok, _item} <- WorkStore.get(work_item_id, path: path),
-             {:ok, {sdk_file, _runner}} <- Sykli.Detector.find(path),
-             {:ok, contract_hash} <- Sykli.ContractHash.from_sdk_file(sdk_file) do
+             {:ok, sdk_file} <- Sykli.Detector.find(path),
+             {:ok, json} <- Sykli.Detector.emit(sdk_file),
+             {:ok, contract_hash} <- Sykli.ContractHash.from_json(json) do
           work_meta = %{work_item_id: work_item_id, contract_hash: contract_hash}
-          {:ok, work_meta, [work_item_id: work_item_id, contract_hash: contract_hash]}
+
+          {:ok, work_meta,
+           [work_item_id: work_item_id, contract_hash: contract_hash, emitted_json: json]}
         end
     end
   end
@@ -340,13 +343,16 @@ defmodule Sykli.CLI do
   defp latest_run_json_meta(_path, work_meta) when map_size(work_meta) == 0, do: %{}
 
   defp latest_run_json_meta(path, work_meta) do
+    # Local CLI compatibility: thread run_id through Sykli.run/2 when the
+    # executor result shape is normalized instead of reading latest.json back.
     case Sykli.RunHistory.load_latest(path: path) do
       {:ok, run} ->
         work_meta
+        |> Map.put(:source, "local")
         |> Map.put(:run_id, run.id)
 
       {:error, _} ->
-        work_meta
+        Map.put(work_meta, :source, "local")
     end
   end
 
@@ -503,6 +509,9 @@ defmodule Sykli.CLI do
   defp do_parse_run_args(["--work", work_item_id | tail], opts, rest)
        when is_binary(work_item_id) and binary_part(work_item_id, 0, 1) != "-",
        do: do_parse_run_args(tail, [{:work_item_id, work_item_id} | opts], rest)
+
+  defp do_parse_run_args(["--work" | tail], opts, rest),
+    do: do_parse_run_args(tail, [{:work_item_id, ""} | opts], rest)
 
   defp do_parse_run_args(["--" <> _ = arg | tail], opts, rest) do
     IO.puts(

--- a/core/lib/sykli/cli/work.ex
+++ b/core/lib/sykli/cli/work.ex
@@ -123,6 +123,33 @@ defmodule Sykli.CLI.Work do
     end
   end
 
+  defp execute({:runs, id}, opts, runtime_opts) do
+    store_opts = store_opts(runtime_opts)
+    history_opts = Keyword.merge(store_opts, Keyword.take(runtime_opts, [:limit]))
+
+    with {:ok, _item} <- Store.get(id, store_opts),
+         {:ok, runs} <- Sykli.RunHistory.list_by_work_item(id, history_opts) do
+      output_success(
+        %{source: "local", work_item_id: id, runs: Enum.map(runs, &run_map/1)},
+        opts,
+        fn ->
+          if runs == [] do
+            IO.puts("No runs for work item #{id}")
+          else
+            IO.puts("Runs for work item #{id}:")
+
+            Enum.each(runs, fn run ->
+              IO.puts("  #{run.id}  #{run.overall}  #{run.contract_hash}")
+            end)
+          end
+        end
+      )
+    else
+      {:error, reason} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
   defp execute(:help, _opts, _runtime_opts) do
     print_help()
     0
@@ -177,6 +204,13 @@ defmodule Sykli.CLI.Work do
 
       match?(["note"], positionals) or match?(["note", _], positionals) ->
         {:error, {:invalid_work_command, "note requires a work item id and body"}, opts}
+
+      match?(["runs", _], positionals) ->
+        ["runs", id] = positionals
+        {:ok, {:runs, id}, opts}
+
+      positionals == ["runs"] ->
+        {:error, {:invalid_work_command, "runs requires a work item id"}, opts}
 
       true ->
         {:error, {:invalid_work_command, Enum.join(positionals, " ")}, opts}
@@ -350,11 +384,25 @@ defmodule Sykli.CLI.Work do
       sykli work show <work-id>
       sykli work claim <work-id> [--actor TYPE:ID]
       sykli work note <work-id> "Body" [--actor TYPE:ID]
+      sykli work runs <work-id>
 
     Options:
       --json          Output as JSON
       --intent TEXT   Set work item intent when creating
       --actor TYPE:ID Set actor identity, e.g. member:yair, agent:claude, daemon:worker-1
     """)
+  end
+
+  defp run_map(run) do
+    %{
+      id: run.id,
+      work_item_id: run.work_item_id,
+      contract_hash: run.contract_hash,
+      status: Atom.to_string(run.overall),
+      timestamp: DateTime.to_iso8601(run.timestamp),
+      task_count: length(run.tasks),
+      passed_count: Enum.count(run.tasks, &(&1.status == :passed)),
+      failed_count: Enum.count(run.tasks, &(&1.status in [:failed, :errored]))
+    }
   end
 end

--- a/core/lib/sykli/contract_hash.ex
+++ b/core/lib/sykli/contract_hash.ex
@@ -1,0 +1,26 @@
+defmodule Sykli.ContractHash do
+  @moduledoc """
+  Deterministic hashes for emitted Sykli contracts.
+
+  Phase 1 Team Mode uses the SDK source file bytes as the local contract
+  identity. This keeps the hash stable and avoids including runtime data such
+  as timestamps, durations, or run ids.
+  """
+
+  @doc "Computes a sha256-prefixed hash for a detected SDK file."
+  def from_sdk_file(path) when is_binary(path) do
+    case File.read(path) do
+      {:ok, bytes} -> {:ok, from_bytes(bytes)}
+      {:error, reason} -> {:error, {:contract_hash_failed, path, reason}}
+    end
+  end
+
+  @doc "Computes a sha256-prefixed hash for raw bytes."
+  def from_bytes(bytes) when is_binary(bytes) do
+    digest =
+      :crypto.hash(:sha256, bytes)
+      |> Base.encode16(case: :lower)
+
+    "sha256:#{digest}"
+  end
+end

--- a/core/lib/sykli/contract_hash.ex
+++ b/core/lib/sykli/contract_hash.ex
@@ -2,16 +2,17 @@ defmodule Sykli.ContractHash do
   @moduledoc """
   Deterministic hashes for emitted Sykli contracts.
 
-  Phase 1 Team Mode uses the SDK source file bytes as the local contract
-  identity. This keeps the hash stable and avoids including runtime data such
-  as timestamps, durations, or run ids.
+  Team Mode uses canonicalized emitted JSON as the local contract identity.
+  This keeps formatting and comments in SDK source files out of the hash and
+  avoids including runtime data such as timestamps, durations, or run ids.
   """
 
-  @doc "Computes a sha256-prefixed hash for a detected SDK file."
-  def from_sdk_file(path) when is_binary(path) do
-    case File.read(path) do
-      {:ok, bytes} -> {:ok, from_bytes(bytes)}
-      {:error, reason} -> {:error, {:contract_hash_failed, path, reason}}
+  @doc "Computes a sha256-prefixed hash for emitted contract JSON."
+  def from_json(json) when is_binary(json) do
+    with {:ok, decoded} <- Jason.decode(json) do
+      {:ok, from_bytes(Jason.encode!(decoded))}
+    else
+      {:error, reason} -> {:error, {:contract_hash_failed, :emitted_json, reason}}
     end
   end
 

--- a/core/lib/sykli/error.ex
+++ b/core/lib/sykli/error.ex
@@ -661,6 +661,16 @@ defmodule Sykli.Error do
     }
   end
 
+  def contract_hash_failed(path, reason) do
+    %__MODULE__{
+      code: "contract_hash_failed",
+      type: :validation,
+      message: "failed to compute contract hash for #{path}: #{inspect(reason)}",
+      step: :validate,
+      hints: ["check that the detected Sykli SDK file is readable"]
+    }
+  end
+
   # ─────────────────────────────────────────────────────────────────────────────
   # INTERNAL ERRORS
   # ─────────────────────────────────────────────────────────────────────────────
@@ -763,6 +773,7 @@ defmodule Sykli.Error do
   def wrap({:invalid_notes, notes}), do: invalid_work_item({:invalid_notes, notes})
   def wrap({:invalid_note, reason}), do: invalid_work_item({:invalid_note, reason})
   def wrap({:invalid_note_author, reason}), do: invalid_work_item({:invalid_note_author, reason})
+  def wrap({:contract_hash_failed, path, reason}), do: contract_hash_failed(path, reason)
 
   # Validation errors
   def wrap({:cycle_detected, path}), do: cycle_detected(path)

--- a/core/lib/sykli/run_history.ex
+++ b/core/lib/sykli/run_history.ex
@@ -209,7 +209,7 @@ defmodule Sykli.RunHistory do
           # Only .json files, not symlinks
           |> Enum.filter(&String.match?(&1, ~r/^\d{4}-\d{2}-\d{2}.*\.json$/))
           |> Enum.sort(:desc)
-          |> Enum.take(limit)
+          |> maybe_take(limit)
           |> Enum.flat_map(fn file ->
             case File.read(Path.join(runs_dir, file)) do
               {:ok, json} -> [decode_run(json)]
@@ -229,16 +229,31 @@ defmodule Sykli.RunHistory do
 
   @doc """
   Lists recent runs associated with a local work item.
+
+  Filtering happens before applying `:limit`, so unrelated recent runs do not
+  hide older runs for the requested work item. Pagination is not implemented
+  yet; this scans local run manifests.
   """
   @spec list_by_work_item(String.t(), keyword()) :: {:ok, [Run.t()]} | {:error, term()}
   def list_by_work_item(work_item_id, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 10)
+    list_opts = Keyword.put(opts, :limit, :all)
+
     with :ok <- Sykli.WorkItem.validate_id(work_item_id),
-         {:ok, runs} <- list(opts) do
-      {:ok, Enum.filter(runs, &(&1.work_item_id == work_item_id))}
+         {:ok, runs} <- list(list_opts) do
+      runs =
+        runs
+        |> Enum.filter(&(&1.work_item_id == work_item_id))
+        |> maybe_take(limit)
+
+      {:ok, runs}
     end
   end
 
   # ----- PRIVATE -----
+
+  defp maybe_take(items, :all), do: items
+  defp maybe_take(items, limit), do: Enum.take(items, limit)
 
   defp timestamp_to_filename(%DateTime{} = dt) do
     dt

--- a/core/lib/sykli/run_history.ex
+++ b/core/lib/sykli/run_history.ex
@@ -58,6 +58,8 @@ defmodule Sykli.RunHistory do
       :git_branch,
       :tasks,
       :overall,
+      :work_item_id,
+      :contract_hash,
       :platform,
       :verification,
       verified: false
@@ -70,6 +72,8 @@ defmodule Sykli.RunHistory do
             git_branch: String.t(),
             tasks: [Sykli.RunHistory.TaskResult.t()],
             overall: :passed | :failed,
+            work_item_id: String.t() | nil,
+            contract_hash: String.t() | nil,
             platform: String.t() | nil,
             verified: boolean(),
             verification: map() | nil
@@ -223,6 +227,17 @@ defmodule Sykli.RunHistory do
     end
   end
 
+  @doc """
+  Lists recent runs associated with a local work item.
+  """
+  @spec list_by_work_item(String.t(), keyword()) :: {:ok, [Run.t()]} | {:error, term()}
+  def list_by_work_item(work_item_id, opts \\ []) do
+    with :ok <- Sykli.WorkItem.validate_id(work_item_id),
+         {:ok, runs} <- list(opts) do
+      {:ok, Enum.filter(runs, &(&1.work_item_id == work_item_id))}
+    end
+  end
+
   # ----- PRIVATE -----
 
   defp timestamp_to_filename(%DateTime{} = dt) do
@@ -263,6 +278,8 @@ defmodule Sykli.RunHistory do
       tasks: Enum.map(run.tasks, &encode_task_result/1),
       overall: Atom.to_string(run.overall)
     }
+    |> maybe_add(:work_item_id, run.work_item_id)
+    |> maybe_add(:contract_hash, run.contract_hash)
     |> maybe_add(:platform, run.platform)
     |> maybe_add(:verified, if(run.verified, do: true, else: nil))
     |> maybe_add(:verification, run.verification)
@@ -296,6 +313,8 @@ defmodule Sykli.RunHistory do
       git_branch: data["git_branch"],
       tasks: Enum.map(data["tasks"] || [], &decode_task_result/1),
       overall: String.to_existing_atom(data["overall"]),
+      work_item_id: data["work_item_id"],
+      contract_hash: data["contract_hash"],
       platform: data["platform"],
       verified: data["verified"] || false,
       verification: data["verification"]

--- a/core/test/sykli/cli/work_test.exs
+++ b/core/test/sykli/cli/work_test.exs
@@ -4,6 +4,7 @@ defmodule Sykli.CLI.WorkTest do
   import ExUnit.CaptureIO
 
   alias Sykli.CLI.Work
+  alias Sykli.RunHistory
 
   @moduletag :tmp_dir
 
@@ -133,6 +134,31 @@ defmodule Sykli.CLI.WorkTest do
       assert output =~ "Usage: sykli work <command>"
       assert output =~ "Unknown flags are rejected"
     end
+
+    test "runs --json lists associated runs", %{tmp_dir: tmp_dir} do
+      assert run_silent(["create", "Review PR"], path: tmp_dir, id: "work_001", now: @now) == 0
+
+      save_run(tmp_dir, %{
+        id: "run-1",
+        timestamp: ~U[2026-05-08 10:00:00Z],
+        work_item_id: "work_001",
+        contract_hash: "sha256:one"
+      })
+
+      save_run(tmp_dir, %{
+        id: "run-2",
+        timestamp: ~U[2026-05-08 11:00:00Z],
+        work_item_id: "work_001",
+        contract_hash: "sha256:two"
+      })
+
+      result = run_json(["runs", "work_001", "--json"], path: tmp_dir)
+
+      assert result["data"]["source"] == "local"
+      assert result["data"]["work_item_id"] == "work_001"
+      assert Enum.map(result["data"]["runs"], & &1["id"]) == ["run-2", "run-1"]
+      assert hd(result["data"]["runs"])["contract_hash"] == "sha256:two"
+    end
   end
 
   describe "errors" do
@@ -197,6 +223,11 @@ defmodule Sykli.CLI.WorkTest do
       result = run_json(["show", "work_001", "--json"], path: tmp_dir, expect: 1)
       assert result["error"]["code"] == "malformed_work_item_json"
     end
+
+    test "runs for missing work item returns structured JSON error", %{tmp_dir: tmp_dir} do
+      result = run_json(["runs", "missing", "--json"], path: tmp_dir, expect: 1)
+      assert result["error"]["code"] == "work_item_not_found"
+    end
   end
 
   defp run_json(args, opts) do
@@ -219,5 +250,20 @@ defmodule Sykli.CLI.WorkTest do
     end)
 
     0
+  end
+
+  defp save_run(tmp_dir, attrs) do
+    run = %RunHistory.Run{
+      id: attrs.id,
+      timestamp: attrs.timestamp,
+      git_ref: "abc123",
+      git_branch: "main",
+      work_item_id: attrs.work_item_id,
+      contract_hash: attrs.contract_hash,
+      tasks: [%RunHistory.TaskResult{name: "test", status: :passed, duration_ms: 10}],
+      overall: :passed
+    }
+
+    :ok = RunHistory.save(run, path: tmp_dir)
   end
 end

--- a/core/test/sykli/cli/work_test.exs
+++ b/core/test/sykli/cli/work_test.exs
@@ -158,6 +158,7 @@ defmodule Sykli.CLI.WorkTest do
       assert result["data"]["work_item_id"] == "work_001"
       assert Enum.map(result["data"]["runs"], & &1["id"]) == ["run-2", "run-1"]
       assert hd(result["data"]["runs"])["contract_hash"] == "sha256:two"
+      assert hd(result["data"]["runs"])["timestamp"] == "2026-05-08T11:00:00Z"
     end
   end
 

--- a/core/test/sykli/cli_test.exs
+++ b/core/test/sykli/cli_test.exs
@@ -146,6 +146,14 @@ defmodule Sykli.CLITest do
       assert path == "./my-project"
       assert opts[:work_item_id] == "work_001"
     end
+
+    test "missing --work value is preserved as an invalid id" do
+      {path, opts} = Sykli.CLI.parse_run_args(["--work", "--json", "./my-project"])
+
+      assert path == "./my-project"
+      assert opts[:json] == true
+      assert opts[:work_item_id] == ""
+    end
   end
 
   describe "global option normalization" do

--- a/core/test/sykli/cli_test.exs
+++ b/core/test/sykli/cli_test.exs
@@ -132,6 +132,20 @@ defmodule Sykli.CLITest do
       assert opts[:timeout] == 900_000
       assert opts[:target] == :k8s
     end
+
+    test "parses --work=ID" do
+      {path, opts} = Sykli.CLI.parse_run_args(["--work=work_001", "./my-project"])
+
+      assert path == "./my-project"
+      assert opts[:work_item_id] == "work_001"
+    end
+
+    test "parses --work ID" do
+      {path, opts} = Sykli.CLI.parse_run_args(["--work", "work_001", "./my-project"])
+
+      assert path == "./my-project"
+      assert opts[:work_item_id] == "work_001"
+    end
   end
 
   describe "global option normalization" do

--- a/core/test/sykli/contract_hash_test.exs
+++ b/core/test/sykli/contract_hash_test.exs
@@ -1,0 +1,29 @@
+defmodule Sykli.ContractHashTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :tmp_dir
+
+  test "same bytes produce the same sha256 contract hash" do
+    hash = Sykli.ContractHash.from_bytes(~s({"version":"1","tasks":[]}))
+
+    assert hash == Sykli.ContractHash.from_bytes(~s({"version":"1","tasks":[]}))
+    assert String.starts_with?(hash, "sha256:")
+    assert String.length(hash) == 71
+  end
+
+  test "changed bytes produce a different contract hash" do
+    hash_a = Sykli.ContractHash.from_bytes(~s({"version":"1","tasks":[]}))
+    hash_b = Sykli.ContractHash.from_bytes(~s({"version":"1","tasks":[{"name":"test"}]}))
+
+    refute hash_a == hash_b
+  end
+
+  test "hashes SDK file bytes", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "sykli.exs")
+    json = Jason.encode!(%{"version" => "1", "tasks" => []})
+    File.write!(path, "IO.puts(#{inspect(json)})")
+
+    assert {:ok, hash} = Sykli.ContractHash.from_sdk_file(path)
+    assert hash == Sykli.ContractHash.from_bytes(File.read!(path))
+  end
+end

--- a/core/test/sykli/contract_hash_test.exs
+++ b/core/test/sykli/contract_hash_test.exs
@@ -18,12 +18,23 @@ defmodule Sykli.ContractHashTest do
     refute hash_a == hash_b
   end
 
-  test "hashes SDK file bytes", %{tmp_dir: tmp_dir} do
-    path = Path.join(tmp_dir, "sykli.exs")
-    json = Jason.encode!(%{"version" => "1", "tasks" => []})
-    File.write!(path, "IO.puts(#{inspect(json)})")
+  test "canonicalizes emitted JSON before hashing" do
+    json_a = ~s({"version":"1","tasks":[{"name":"test","command":"echo ok"}]})
 
-    assert {:ok, hash} = Sykli.ContractHash.from_sdk_file(path)
-    assert hash == Sykli.ContractHash.from_bytes(File.read!(path))
+    json_b = """
+    {
+      "version": "1",
+      "tasks": [
+        {
+          "name": "test",
+          "command": "echo ok"
+        }
+      ]
+    }
+    """
+
+    assert {:ok, hash_a} = Sykli.ContractHash.from_json(json_a)
+    assert {:ok, hash_b} = Sykli.ContractHash.from_json(json_b)
+    assert hash_a == hash_b
   end
 end

--- a/core/test/sykli/run_history_test.exs
+++ b/core/test/sykli/run_history_test.exs
@@ -12,6 +12,8 @@ defmodule Sykli.RunHistoryTest do
         timestamp: ~U[2024-01-15 10:30:00Z],
         git_ref: "abc1234",
         git_branch: "main",
+        work_item_id: "work_001",
+        contract_hash: "sha256:abc",
         tasks: [
           %RunHistory.TaskResult{name: "test", status: :passed, duration_ms: 1234}
         ],
@@ -26,6 +28,10 @@ defmodule Sykli.RunHistoryTest do
 
       files = File.ls!(runs_dir)
       assert Enum.any?(files, &String.ends_with?(&1, ".json"))
+
+      assert {:ok, loaded} = RunHistory.load_latest(path: tmp_dir)
+      assert loaded.work_item_id == "work_001"
+      assert loaded.contract_hash == "sha256:abc"
     end
 
     test "creates latest.json symlink", %{tmp_dir: tmp_dir} do
@@ -257,6 +263,37 @@ defmodule Sykli.RunHistoryTest do
 
       assert {:ok, runs} = RunHistory.list(path: tmp_dir, limit: 2)
       assert length(runs) == 2
+    end
+  end
+
+  describe "list_by_work_item/2" do
+    test "returns associated runs in deterministic recent-first order", %{tmp_dir: tmp_dir} do
+      for {id, work_item_id, hour} <- [
+            {"run-1", "work_001", 1},
+            {"run-2", "work_002", 2},
+            {"run-3", "work_001", 3}
+          ] do
+        run = %RunHistory.Run{
+          id: id,
+          timestamp: DateTime.add(~U[2024-01-15 10:00:00Z], hour * 3600),
+          git_ref: "ref#{hour}",
+          git_branch: "main",
+          work_item_id: work_item_id,
+          contract_hash: "sha256:#{hour}",
+          tasks: [],
+          overall: :passed
+        }
+
+        :ok = RunHistory.save(run, path: tmp_dir)
+      end
+
+      assert {:ok, runs} = RunHistory.list_by_work_item("work_001", path: tmp_dir)
+      assert Enum.map(runs, & &1.id) == ["run-3", "run-1"]
+    end
+
+    test "rejects invalid work item id before listing", %{tmp_dir: tmp_dir} do
+      assert {:error, {:invalid_work_item_id, "../escape"}} =
+               RunHistory.list_by_work_item("../escape", path: tmp_dir)
     end
   end
 

--- a/core/test/sykli/run_history_test.exs
+++ b/core/test/sykli/run_history_test.exs
@@ -291,6 +291,31 @@ defmodule Sykli.RunHistoryTest do
       assert Enum.map(runs, & &1.id) == ["run-3", "run-1"]
     end
 
+    test "filters before applying limit", %{tmp_dir: tmp_dir} do
+      for {id, work_item_id, hour} <- [
+            {"run-1", "work_001", 1},
+            {"run-2", "work_002", 2},
+            {"run-3", "work_002", 3},
+            {"run-4", "work_001", 4}
+          ] do
+        run = %RunHistory.Run{
+          id: id,
+          timestamp: DateTime.add(~U[2024-01-15 10:00:00Z], hour * 3600),
+          git_ref: "ref#{hour}",
+          git_branch: "main",
+          work_item_id: work_item_id,
+          contract_hash: "sha256:#{hour}",
+          tasks: [],
+          overall: :passed
+        }
+
+        :ok = RunHistory.save(run, path: tmp_dir)
+      end
+
+      assert {:ok, runs} = RunHistory.list_by_work_item("work_001", path: tmp_dir, limit: 2)
+      assert Enum.map(runs, & &1.id) == ["run-4", "run-1"]
+    end
+
     test "rejects invalid work item id before listing", %{tmp_dir: tmp_dir} do
       assert {:error, {:invalid_work_item_id, "../escape"}} =
                RunHistory.list_by_work_item("../escape", path: tmp_dir)

--- a/core/test/sykli/work/run_association_test.exs
+++ b/core/test/sykli/work/run_association_test.exs
@@ -9,8 +9,7 @@ defmodule Sykli.Work.RunAssociationTest do
   test "Sykli.run persists work_item_id and contract_hash in run history", %{tmp_dir: tmp_dir} do
     write_pipeline(tmp_dir, "echo associated")
     {:ok, _item} = Store.create("Associated run", path: tmp_dir, id: "work_001")
-    {:ok, sdk_file} = detected_sdk_file(tmp_dir)
-    {:ok, contract_hash} = Sykli.ContractHash.from_sdk_file(sdk_file)
+    {:ok, contract_hash} = emitted_contract_hash(tmp_dir)
 
     assert {:ok, _results} =
              Sykli.run(tmp_dir, work_item_id: "work_001", contract_hash: contract_hash)
@@ -35,12 +34,11 @@ defmodule Sykli.Work.RunAssociationTest do
     tmp_dir: tmp_dir
   } do
     write_pipeline(tmp_dir, "echo one")
-    {:ok, sdk_file} = detected_sdk_file(tmp_dir)
-    {:ok, hash_a} = Sykli.ContractHash.from_sdk_file(sdk_file)
-    {:ok, hash_b} = Sykli.ContractHash.from_sdk_file(sdk_file)
+    {:ok, hash_a} = emitted_contract_hash(tmp_dir)
+    {:ok, hash_b} = emitted_contract_hash(tmp_dir)
 
     write_pipeline(tmp_dir, "echo two")
-    {:ok, hash_c} = Sykli.ContractHash.from_sdk_file(sdk_file)
+    {:ok, hash_c} = emitted_contract_hash(tmp_dir)
 
     assert hash_a == hash_b
     refute hash_a == hash_c
@@ -56,9 +54,11 @@ defmodule Sykli.Work.RunAssociationTest do
     )
   end
 
-  defp detected_sdk_file(tmp_dir) do
-    with {:ok, {sdk_file, _runner}} <- Sykli.Detector.find(tmp_dir) do
-      {:ok, sdk_file}
+  defp emitted_contract_hash(tmp_dir) do
+    with {:ok, sdk_file} <- Sykli.Detector.find(tmp_dir),
+         {:ok, json} <- Sykli.Detector.emit(sdk_file),
+         {:ok, hash} <- Sykli.ContractHash.from_json(json) do
+      {:ok, hash}
     end
   end
 end

--- a/core/test/sykli/work/run_association_test.exs
+++ b/core/test/sykli/work/run_association_test.exs
@@ -1,0 +1,64 @@
+defmodule Sykli.Work.RunAssociationTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.RunHistory
+  alias Sykli.Work.Store
+
+  @moduletag :tmp_dir
+
+  test "Sykli.run persists work_item_id and contract_hash in run history", %{tmp_dir: tmp_dir} do
+    write_pipeline(tmp_dir, "echo associated")
+    {:ok, _item} = Store.create("Associated run", path: tmp_dir, id: "work_001")
+    {:ok, sdk_file} = detected_sdk_file(tmp_dir)
+    {:ok, contract_hash} = Sykli.ContractHash.from_sdk_file(sdk_file)
+
+    assert {:ok, _results} =
+             Sykli.run(tmp_dir, work_item_id: "work_001", contract_hash: contract_hash)
+
+    assert {:ok, run} = RunHistory.load_latest(path: tmp_dir)
+    assert run.work_item_id == "work_001"
+    assert run.contract_hash == contract_hash
+    assert run.overall == :passed
+  end
+
+  test "normal runs without work metadata preserve previous history shape", %{tmp_dir: tmp_dir} do
+    write_pipeline(tmp_dir, "echo plain")
+
+    assert {:ok, _results} = Sykli.run(tmp_dir)
+
+    assert {:ok, run} = RunHistory.load_latest(path: tmp_dir)
+    assert run.work_item_id == nil
+    assert run.contract_hash == nil
+  end
+
+  test "same contract gets the same hash and changed contract gets a different hash", %{
+    tmp_dir: tmp_dir
+  } do
+    write_pipeline(tmp_dir, "echo one")
+    {:ok, sdk_file} = detected_sdk_file(tmp_dir)
+    {:ok, hash_a} = Sykli.ContractHash.from_sdk_file(sdk_file)
+    {:ok, hash_b} = Sykli.ContractHash.from_sdk_file(sdk_file)
+
+    write_pipeline(tmp_dir, "echo two")
+    {:ok, hash_c} = Sykli.ContractHash.from_sdk_file(sdk_file)
+
+    assert hash_a == hash_b
+    refute hash_a == hash_c
+  end
+
+  defp write_pipeline(tmp_dir, command) do
+    json =
+      Jason.encode!(%{"version" => "1", "tasks" => [%{"name" => "test", "command" => command}]})
+
+    File.write!(
+      Path.join(tmp_dir, "sykli.exs"),
+      "IO.puts(#{inspect(json)})"
+    )
+  end
+
+  defp detected_sdk_file(tmp_dir) do
+    with {:ok, {sdk_file, _runner}} <- Sykli.Detector.find(tmp_dir) do
+      {:ok, sdk_file}
+    end
+  end
+end

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -105,7 +105,7 @@ No cache-prefixed `Sykli.Error` codes are emitted today. Cache failures currentl
 
 | Code | Description | Tier | Emitted from |
 |------|-------------|------|--------------|
-| `contract_hash_failed` | Sykli could not read the detected SDK file to compute a local work/run contract hash. | public-unstable | `core/lib/sykli/error.ex:664` |
+| `contract_hash_failed` | Sykli could not canonicalize emitted contract JSON to compute a local work/run contract hash. | public-unstable | `core/lib/sykli/error.ex:664` |
 | `invalid_work_item` | A local work item command encountered structurally invalid work item data or arguments. | public-unstable | `core/lib/sykli/error.ex:654` |
 | `invalid_work_item_id` | A local work item id failed validation, including path traversal attempts. | public-unstable | `core/lib/sykli/error.ex:622` |
 | `malformed_work_item_json` | A persisted `.sykli/work/items/<id>.json` file is not valid JSON. | public-unstable | `core/lib/sykli/error.ex:643` |

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -105,6 +105,7 @@ No cache-prefixed `Sykli.Error` codes are emitted today. Cache failures currentl
 
 | Code | Description | Tier | Emitted from |
 |------|-------------|------|--------------|
+| `contract_hash_failed` | Sykli could not read the detected SDK file to compute a local work/run contract hash. | public-unstable | `core/lib/sykli/error.ex:664` |
 | `invalid_work_item` | A local work item command encountered structurally invalid work item data or arguments. | public-unstable | `core/lib/sykli/error.ex:654` |
 | `invalid_work_item_id` | A local work item id failed validation, including path traversal attempts. | public-unstable | `core/lib/sykli/error.ex:622` |
 | `malformed_work_item_json` | A persisted `.sykli/work/items/<id>.json` file is not valid JSON. | public-unstable | `core/lib/sykli/error.ex:643` |

--- a/docs/local-state-plane.md
+++ b/docs/local-state-plane.md
@@ -265,7 +265,7 @@ Each command supports `--json` and returns the shared CLI JSON envelope.
 
 `--work` validates the local work item before execution starts. The run
 manifest records the work item id and a deterministic `sha256:` contract
-hash computed from the detected SDK file bytes. Detailed evidence remains in
+hash computed from canonicalized emitted contract JSON. Detailed evidence remains in
 the normal `.sykli/` run, occurrence, log, and attestation stores; work state
 only points at the run summary.
 

--- a/docs/local-state-plane.md
+++ b/docs/local-state-plane.md
@@ -56,6 +56,8 @@ Documented in detail in `docs/false-protocol-schema.md`. Summary:
 - `.sykli/test-map.json` — file → tasks mapping.
 - `.sykli/runs/` — per-run manifests for history.
 - `.sykli/work/items/<id>.json` — local work item state.
+- Work/run links are stored on existing `.sykli/runs/*.json` manifests as
+  `work_item_id` and `contract_hash`; work item files do not copy run logs.
 - (Phase 3 of the roadmap) `.sykli/gates/<gate-id>.json` — local gate
   decision state.
 
@@ -255,9 +257,17 @@ sykli work list
 sykli work show <work-id>
 sykli work claim <work-id>
 sykli work note <work-id> "Found likely API breakage"
+sykli run <contract-or-dir> --work <work-id>
+sykli work runs <work-id>
 ```
 
 Each command supports `--json` and returns the shared CLI JSON envelope.
+
+`--work` validates the local work item before execution starts. The run
+manifest records the work item id and a deterministic `sha256:` contract
+hash computed from the detected SDK file bytes. Detailed evidence remains in
+the normal `.sykli/` run, occurrence, log, and attestation stores; work state
+only points at the run summary.
 
 The roadmap adds local-only state for work items and gates **before**
 networking turns on. That is intentional: a user should be able to:

--- a/docs/team-mode-roadmap.md
+++ b/docs/team-mode-roadmap.md
@@ -94,6 +94,12 @@ Exit criteria:
 
 A run can belong to a work item. The local store gains a join.
 
+Status:
+
+- PR #189 adds `sykli run --work <work-id>`, stores `work_item_id` and a
+  deterministic `sha256:` `contract_hash` in existing run manifests, and
+  adds `sykli work runs <work-id>`.
+
 Suggested CLI:
 
 ```bash
@@ -115,8 +121,9 @@ Exit criteria:
 
 - The summary block in `.sykli/runs/<run_id>.json` carries the new fields
   when a `--work` flag was supplied.
-- `sykli explain` and `sykli fix` surface the work item id when
-  available.
+- `sykli work runs <work-id>` lists associated run summaries.
+- `sykli explain` and `sykli fix` surfacing the work item id remains a
+  follow-up once those renderers consume work metadata.
 - Conformance cases unchanged (no SDK contract change in this phase).
 
 ## Phase 3 — Local gate decision state

--- a/docs/team-mode-roadmap.md
+++ b/docs/team-mode-roadmap.md
@@ -97,8 +97,8 @@ A run can belong to a work item. The local store gains a join.
 Status:
 
 - PR #189 adds `sykli run --work <work-id>`, stores `work_item_id` and a
-  deterministic `sha256:` `contract_hash` in existing run manifests, and
-  adds `sykli work runs <work-id>`.
+  deterministic `sha256:` `contract_hash` over canonicalized emitted JSON in
+  existing run manifests, and adds `sykli work runs <work-id>`.
 
 Suggested CLI:
 

--- a/eval/oracle/run.sh
+++ b/eval/oracle/run.sh
@@ -1227,8 +1227,11 @@ if begin_case "060" "Work: run with work item returns JSON metadata"; then
     if assert_json_field "$LAST_OUTPUT" '.data.work_item_id' "$id" "work id"; then
       hash=$(echo "$LAST_OUTPUT" | jq -r '.data.contract_hash' 2>/dev/null)
       status=$(echo "$LAST_OUTPUT" | jq -r '.data.status' 2>/dev/null)
+      source=$(echo "$LAST_OUTPUT" | jq -r '.data.source' 2>/dev/null)
 
-      if [[ "$status" != "passed" ]]; then
+      if [[ "$source" != "local" ]]; then
+        fail "run source was $source"
+      elif [[ "$status" != "passed" ]]; then
         fail "run status was $status"
       elif [[ ! "$hash" =~ ^sha256:[0-9a-f]{64}$ ]]; then
         fail "contract_hash has invalid format: $hash"

--- a/eval/oracle/run.sh
+++ b/eval/oracle/run.sh
@@ -1215,6 +1215,73 @@ if begin_case "059" "Work: invalid work item id returns JSON error"; then
   rm -rf "$dir"
 fi
 
+# --- case_060: run with --work returns work metadata in JSON ---
+if begin_case "060" "Work: run with work item returns JSON metadata"; then
+  dir=$(tmp_workdir)
+  make_pipeline "$dir" "pass.exs"
+  create_output=$(run_sykli "$dir" work create "Associated run" --json 2>&1)
+  id=$(echo "$create_output" | jq -r '.data.item.id' 2>/dev/null)
+
+  LAST_OUTPUT=$(run_sykli "$dir" run --work "$id" --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 0 "$exit_code"; then
+    if assert_json_field "$LAST_OUTPUT" '.data.work_item_id' "$id" "work id"; then
+      hash=$(echo "$LAST_OUTPUT" | jq -r '.data.contract_hash' 2>/dev/null)
+      status=$(echo "$LAST_OUTPUT" | jq -r '.data.status' 2>/dev/null)
+
+      if [[ "$status" != "passed" ]]; then
+        fail "run status was $status"
+      elif [[ ! "$hash" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+        fail "contract_hash has invalid format: $hash"
+      else
+        pass 0
+      fi
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
+# --- case_061: work runs lists associated runs ---
+if begin_case "061" "Work: work runs JSON lists associated run"; then
+  dir=$(tmp_workdir)
+  make_pipeline "$dir" "pass.exs"
+  create_output=$(run_sykli "$dir" work create "Associated run" --json 2>&1)
+  id=$(echo "$create_output" | jq -r '.data.item.id' 2>/dev/null)
+  run_sykli "$dir" run --work "$id" --json >/dev/null 2>&1 || true
+
+  LAST_OUTPUT=$(run_sykli "$dir" work runs "$id" --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 0 "$exit_code"; then
+    if assert_json_field "$LAST_OUTPUT" '.data.work_item_id' "$id" "work id"; then
+      count=$(echo "$LAST_OUTPUT" | jq '.data.runs | length' 2>/dev/null)
+      hash=$(echo "$LAST_OUTPUT" | jq -r '.data.runs[0].contract_hash' 2>/dev/null)
+
+      if [[ "$count" != "1" ]]; then
+        fail "expected one associated run, got $count"
+      elif [[ ! "$hash" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+        fail "associated run contract_hash has invalid format: $hash"
+      else
+        pass 0
+      fi
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
+# --- case_062: missing work item fails before execution ---
+if begin_case "062" "Work: run with missing work item returns JSON error"; then
+  dir=$(tmp_workdir)
+  make_pipeline "$dir" "pass.exs"
+
+  LAST_OUTPUT=$(run_sykli "$dir" run --work missing --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 1 "$exit_code"; then
+    if assert_json_field "$LAST_OUTPUT" '.ok' "false"; then
+      if assert_json_field "$LAST_OUTPUT" '.error.code' "work_item_not_found"; then
+        pass 0
+      fi
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
 # ============================================================================
 # Summary
 # ============================================================================

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -1574,7 +1574,7 @@
       "id": "WORK-003",
       "name": "run with work item records local run association",
       "fixture": "single_task",
-      "command": "id=$(sykli work create \"Run associated with work item\" --json | jq -r '.data.item.id') && sykli run --work \"$id\" --json | jq -e --arg id \"$id\" '.ok == true and .data.work_item_id == $id and (.data.contract_hash | startswith(\"sha256:\")) and .data.status == \"passed\"' >/dev/null && sykli work runs \"$id\" --json | jq -e --arg id \"$id\" '.ok == true and .data.work_item_id == $id and (.data.runs | length) == 1 and .data.runs[0].work_item_id == $id and (.data.runs[0].contract_hash | startswith(\"sha256:\")) and .data.runs[0].status == \"passed\"' >/dev/null && ! grep -q \"hello\" \".sykli/work/items/$id.json\" && sykli work runs \"$id\" --json",
+      "command": "id=$(sykli work create \"Run associated with work item\" --json | jq -r '.data.item.id') && sykli run --work \"$id\" --json | jq -e --arg id \"$id\" '.ok == true and .data.source == \"local\" and .data.work_item_id == $id and (.data.contract_hash | startswith(\"sha256:\")) and .data.status == \"passed\"' >/dev/null && sykli work runs \"$id\" --json | jq -e --arg id \"$id\" '.ok == true and .data.work_item_id == $id and (.data.runs | length) == 1 and .data.runs[0].work_item_id == $id and (.data.runs[0].contract_hash | startswith(\"sha256:\")) and .data.runs[0].status == \"passed\"' >/dev/null && ! grep -q \"hello\" \".sykli/work/items/$id.json\" && sykli work runs \"$id\" --json",
       "shell": true,
       "expect_exit": 0,
       "expect_json_jq": [

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -1571,6 +1571,49 @@
       "validated_by": "Injected bug: pass raw ids into file path construction; traversal id is not rejected."
     },
     {
+      "id": "WORK-003",
+      "name": "run with work item records local run association",
+      "fixture": "single_task",
+      "command": "id=$(sykli work create \"Run associated with work item\" --json | jq -r '.data.item.id') && sykli run --work \"$id\" --json | jq -e --arg id \"$id\" '.ok == true and .data.work_item_id == $id and (.data.contract_hash | startswith(\"sha256:\")) and .data.status == \"passed\"' >/dev/null && sykli work runs \"$id\" --json | jq -e --arg id \"$id\" '.ok == true and .data.work_item_id == $id and (.data.runs | length) == 1 and .data.runs[0].work_item_id == $id and (.data.runs[0].contract_hash | startswith(\"sha256:\")) and .data.runs[0].status == \"passed\"' >/dev/null && ! grep -q \"hello\" \".sykli/work/items/$id.json\" && sykli work runs \"$id\" --json",
+      "shell": true,
+      "expect_exit": 0,
+      "expect_json_jq": [
+        ".ok == true",
+        ".data.source == \"local\"",
+        "(.data.runs | length) == 1",
+        "(.data.runs[0].contract_hash | startswith(\"sha256:\"))",
+        ".data.runs[0].status == \"passed\""
+      ],
+      "source": "docs/team-mode-roadmap.md Phase 2; docs/local-state-plane.md work/run association",
+      "validated_by": "Injected bug: omit work_item_id or contract_hash from run history; work runs jq assertions fail."
+    },
+    {
+      "id": "WORK-004",
+      "name": "run with missing work item fails before execution",
+      "fixture": "single_task",
+      "command": "sykli run --work missing --json",
+      "expect_exit": 1,
+      "expect_json_jq": [
+        ".ok == false",
+        ".error.code == \"work_item_not_found\""
+      ],
+      "source": "docs/team-mode-roadmap.md Phase 2; missing work item must fail before execution",
+      "validated_by": "Injected bug: run executes even when --work points at missing local work item."
+    },
+    {
+      "id": "WORK-005",
+      "name": "run with invalid work item id fails before execution",
+      "fixture": "single_task",
+      "command": "sykli run --work ../escape --json",
+      "expect_exit": 1,
+      "expect_json_jq": [
+        ".ok == false",
+        ".error.code == \"invalid_work_item_id\""
+      ],
+      "source": "docs/local-state-plane.md; work ids must not escape local state paths",
+      "validated_by": "Injected bug: pass --work id into local state path without validation."
+    },
+    {
       "id": "GH-001",
       "name": "Receiver refuses to start without webhook role",
       "fixture": "single_task",


### PR DESCRIPTION
## Summary

This PR connects local Team Mode work items to actual Sykli runs. A local run can now be associated with a work item using `sykli run --work <work-id>`, and associated runs can be listed with `sykli work runs <work-id>`.

The implementation stays local-first: it stores the relationship in existing `.sykli/runs/*.json` run manifests and does not introduce coordinator, network sync, daemon join, MCP, or remote execution behavior.

## Why

A Work Item is the team-level coordination unit. A Run is one execution of one contract. A work item needs durable run references before coordinator sync can exist, and the local `.sykli/` state needs to remain the detailed source of truth.

## What changed

- Added deterministic `Sykli.ContractHash` helpers using `sha256:` over the detected SDK file bytes.
- Added optional `work_item_id` and `contract_hash` fields to run history manifests.
- Added `Sykli.RunHistory.list_by_work_item/2` for deterministic recent-first listing.
- Added `sykli run --work <work-id>` validation before execution starts.
- Added `work_item_id`, `contract_hash`, and `run_id` to run JSON output when `--work` is used.
- Added `sykli work runs <work-id>` with human and `--json` output.
- Added `contract_hash_failed` to the public error catalog.
- Updated README and Team Mode docs for the local work/run flow.

## Validation

- `python3 -m json.tool test/blackbox/dataset.json >/dev/null` — passed
- `git diff --check` — passed
- `cd core && mix format --check-formatted` — passed
- `cd core && mix test test/sykli/contract_hash_test.exs test/sykli/run_history_test.exs test/sykli/cli/work_test.exs test/sykli/cli_test.exs test/sykli/work/run_association_test.exs` — passed, 71 tests, 0 failures
- `cd core && mix escript.build` — passed
- `eval/oracle/run.sh --case=060` — passed
- `eval/oracle/run.sh --case=061` — passed
- `eval/oracle/run.sh --case=062` — passed
- `test/blackbox/run.sh --filter=WORK` — passed, 5 passed, 0 failed, 150 skipped
- `cd core && mix test` — passed, 1 property, 1574 tests, 0 failures, 1 skipped, 13 excluded

Full conformance was not run because this PR does not change contract schemas, SDK emitters, or conformance JSON output.

## Oracle coverage

Added oracle cases:

- `060` — `sykli run --work <id> --json` includes `work_item_id`, `contract_hash`, and `status`.
- `061` — `sykli work runs <id> --json` lists the associated run with a stable `sha256:` hash.
- `062` — missing work item returns structured JSON error `work_item_not_found` before execution.

## Blackbox coverage

Added blackbox cases:

- `WORK-003` — create work item, run with `--work`, list associated runs, and verify work item state does not copy task output.
- `WORK-004` — missing work item fails before execution.
- `WORK-005` — invalid/traversal-like work item id fails before execution.

## Out of scope

- No coordinator
- No networking
- No daemon join or heartbeat
- No local gate decision state
- No MCP tools
- No Kubernetes deployment
- No remote execution
- No SaaS or web UI

## Next PR

Add local gate decision state:

- local gate model/store
- `sykli gates list`
- `sykli gate show`
- `sykli gate approve`
- `sykli gate reject`
- `--json` output
- gate oracle coverage
- gate blackbox workflow
