### PR TITLE
Add local gate decision state

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ sykli report              # show last run summary with task results
 sykli work list           # local Team Mode work items
 sykli run --work <id>     # associate a run with a local work item
 sykli work runs <id>      # list runs associated with a work item
+sykli gates list          # local gate decisions
+sykli gate approve <id>   # approve a local gate with --reason
 sykli cache stats         # cache hit rates
 sykli daemon start        # start a mesh node on this host
 sykli mcp                 # MCP server (Claude Code, Cursor, Copilot)

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -106,11 +106,17 @@ defmodule Sykli.CLI do
 
   def normalize_global_json(args), do: args
 
-  defp normalize_gates_args([]), do: ["list"]
-  defp normalize_gates_args(["list" | _] = args), do: args
+  @doc false
+  def normalize_gates_args([]), do: ["list"]
 
-  defp normalize_gates_args(args) do
-    if "list" in args, do: args, else: ["list" | args]
+  def normalize_gates_args([first | _] = args)
+      when first in ~w(list show approve reject --help -h),
+      do: args
+
+  def normalize_gates_args([<<"--", _::binary>> | _] = args), do: ["list" | args]
+
+  def normalize_gates_args(args) do
+    args
   end
 
   defp print_help do

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -10,7 +10,7 @@ defmodule Sykli.CLI do
   alias Sykli.Work.Store, as: WorkStore
 
   @version Mix.Project.config()[:version]
-  @subcommands ~w(cache graph delta watch report history daemon work init validate verify plan explain context fix query mcp run)
+  @subcommands ~w(cache graph delta watch report history daemon work gates gate init validate verify plan explain context fix query mcp run)
 
   def main(args \\ []) do
     args = normalize_global_json(args)
@@ -49,6 +49,17 @@ defmodule Sykli.CLI do
       ["work" | work_args] ->
         work_args
         |> Sykli.CLI.Work.run()
+        |> halt()
+
+      ["gates" | gate_args] ->
+        gate_args
+        |> normalize_gates_args()
+        |> Sykli.CLI.Gate.run()
+        |> halt()
+
+      ["gate" | gate_args] ->
+        gate_args
+        |> Sykli.CLI.Gate.run()
         |> halt()
 
       ["init" | init_args] ->
@@ -95,6 +106,13 @@ defmodule Sykli.CLI do
 
   def normalize_global_json(args), do: args
 
+  defp normalize_gates_args([]), do: ["list"]
+  defp normalize_gates_args(["list" | _] = args), do: args
+
+  defp normalize_gates_args(args) do
+    if "list" in args, do: args, else: ["list" | args]
+  end
+
   defp print_help do
     IO.puts("""
     sykli - CI pipelines in your language
@@ -136,6 +154,8 @@ defmodule Sykli.CLI do
       sykli history    List recent runs
       sykli daemon     Manage daemon (see: sykli daemon --help)
       sykli work       Manage local work items (see: sykli work --help)
+      sykli gates      List local gate decisions
+      sykli gate       Manage local gate decisions (see: sykli gate --help)
       sykli cache      Manage cache (see: sykli cache --help)
       sykli mcp        Start MCP server (for AI assistants)
 

--- a/core/lib/sykli/cli/gate.ex
+++ b/core/lib/sykli/cli/gate.ex
@@ -86,12 +86,12 @@ defmodule Sykli.CLI.Gate do
 
   defp decide(action, id, opts, runtime_opts) do
     reason = Keyword.get(opts, :reason)
-    {_actor_type, actor_id} = actor(opts, runtime_opts)
+    {actor_type, actor_id} = actor(opts, runtime_opts)
 
     decision_opts =
       runtime_opts
       |> Keyword.take([:path, :now])
-      |> Keyword.put(:decided_by, actor_id)
+      |> Keyword.put(:decided_by, "#{actor_type}:#{actor_id}")
 
     result =
       case action do

--- a/core/lib/sykli/cli/gate.ex
+++ b/core/lib/sykli/cli/gate.ex
@@ -1,0 +1,334 @@
+defmodule Sykli.CLI.Gate do
+  @moduledoc """
+  Local gate decision CLI commands.
+
+  This module is intentionally local-only. Coordinator gate sync is added in a
+  later Team Mode phase.
+  """
+
+  alias Sykli.CLI.JsonResponse
+  alias Sykli.Error
+  alias Sykli.Error.Formatter
+  alias Sykli.Gate.Store
+  alias Sykli.GateDecision
+
+  @default_actor_type "member"
+
+  @doc """
+  Runs a `sykli gate ...` or `sykli gates ...` command and returns the intended
+  process exit code.
+
+  `runtime_opts` are internal test hooks for store path, clocks, ids, and
+  default actor attribution. Parsed CLI flags are kept separate in `opts`.
+  """
+  def run(args, runtime_opts \\ []) do
+    case parse(args) do
+      {:ok, command, opts} ->
+        execute(command, opts, runtime_opts)
+
+      {:error, reason, opts} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute(:list, opts, runtime_opts) do
+    store_opts = store_opts(runtime_opts)
+
+    result =
+      case Keyword.get(opts, :status) do
+        nil -> Store.list(store_opts)
+        status -> Store.list_by_status(status, store_opts)
+      end
+
+    case result do
+      {:ok, gates} ->
+        output_success(%{source: "local", gates: Enum.map(gates, &gate_map/1)}, opts, fn ->
+          if gates == [] do
+            IO.puts("No gates")
+          else
+            IO.puts("Gates:")
+
+            Enum.each(gates, fn gate ->
+              IO.puts("  #{gate.id}  #{gate.status}  #{gate.node_id || "-"}")
+            end)
+          end
+        end)
+
+      {:error, reason} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute({:show, id}, opts, runtime_opts) do
+    case Store.get(id, store_opts(runtime_opts)) do
+      {:ok, gate} ->
+        output_success(%{source: "local", gate: gate_map(gate)}, opts, fn ->
+          print_gate(gate)
+        end)
+
+      {:error, reason} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute({:approve, id}, opts, runtime_opts) do
+    decide(:approve, id, opts, runtime_opts)
+  end
+
+  defp execute({:reject, id}, opts, runtime_opts) do
+    decide(:reject, id, opts, runtime_opts)
+  end
+
+  defp execute(:help, _opts, _runtime_opts) do
+    print_help()
+    0
+  end
+
+  defp decide(action, id, opts, runtime_opts) do
+    reason = Keyword.get(opts, :reason)
+    {_actor_type, actor_id} = actor(opts, runtime_opts)
+
+    decision_opts =
+      runtime_opts
+      |> Keyword.take([:path, :now])
+      |> Keyword.put(:decided_by, actor_id)
+
+    result =
+      case action do
+        :approve -> Store.approve(id, reason, decision_opts)
+        :reject -> Store.reject(id, reason, decision_opts)
+      end
+
+    case result do
+      {:ok, gate} ->
+        verb = if action == :approve, do: "Approved", else: "Rejected"
+
+        output_success(%{source: "local", gate: gate_map(gate)}, opts, fn ->
+          IO.puts("#{verb} gate #{gate.id}")
+        end)
+
+      {:error, reason} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp parse(args) do
+    {opts, positionals, error} = parse_flags(args, [], [])
+
+    cond do
+      error != nil ->
+        {:error, error, opts}
+
+      positionals in [[], ["--help"], ["-h"]] ->
+        {:ok, :help, opts}
+
+      positionals == ["list"] ->
+        {:ok, :list, opts}
+
+      match?(["show", _], positionals) ->
+        ["show", id] = positionals
+        {:ok, {:show, id}, opts}
+
+      positionals == ["show"] ->
+        {:error, {:invalid_gate_command, "show requires a gate id"}, opts}
+
+      match?(["approve", _], positionals) ->
+        ["approve", id] = positionals
+        {:ok, {:approve, id}, opts}
+
+      positionals == ["approve"] ->
+        {:error, {:invalid_gate_command, "approve requires a gate id"}, opts}
+
+      match?(["reject", _], positionals) ->
+        ["reject", id] = positionals
+        {:ok, {:reject, id}, opts}
+
+      positionals == ["reject"] ->
+        {:error, {:invalid_gate_command, "reject requires a gate id"}, opts}
+
+      true ->
+        {:error, {:invalid_gate_command, Enum.join(positionals, " ")}, opts}
+    end
+  end
+
+  defp parse_flags([], opts, positionals),
+    do: {Enum.reverse(opts), Enum.reverse(positionals), nil}
+
+  defp parse_flags(["--json" | rest], opts, positionals) do
+    parse_flags(rest, [{:json, true} | opts], positionals)
+  end
+
+  defp parse_flags(["--help" | rest], opts, positionals) do
+    parse_flags(rest, opts, ["--help" | positionals])
+  end
+
+  defp parse_flags(["-h" | rest], opts, positionals) do
+    parse_flags(rest, opts, ["-h" | positionals])
+  end
+
+  defp parse_flags(["--reason", value | rest], opts, positionals) do
+    parse_flags(rest, [{:reason, value} | opts], positionals)
+  end
+
+  defp parse_flags([<<"--reason=", value::binary>> | rest], opts, positionals) do
+    parse_flags(rest, [{:reason, value} | opts], positionals)
+  end
+
+  defp parse_flags(["--status", value | rest], opts, positionals) do
+    parse_flags(rest, [{:status, value} | opts], positionals)
+  end
+
+  defp parse_flags([<<"--status=", value::binary>> | rest], opts, positionals) do
+    parse_flags(rest, [{:status, value} | opts], positionals)
+  end
+
+  defp parse_flags(["--actor", value | rest], opts, positionals) do
+    case parse_actor(value) do
+      {:ok, actor_type, actor_id} ->
+        parse_flags(rest, [{:actor_type, actor_type}, {:actor_id, actor_id} | opts], positionals)
+
+      {:error, reason} ->
+        finalize_parse_error(opts, positionals, rest, reason)
+    end
+  end
+
+  defp parse_flags([<<"--actor=", value::binary>> | rest], opts, positionals) do
+    case parse_actor(value) do
+      {:ok, actor_type, actor_id} ->
+        parse_flags(rest, [{:actor_type, actor_type}, {:actor_id, actor_id} | opts], positionals)
+
+      {:error, reason} ->
+        finalize_parse_error(opts, positionals, rest, reason)
+    end
+  end
+
+  defp parse_flags([<<"--", _::binary>> = flag | rest], opts, positionals) do
+    finalize_parse_error(opts, positionals, rest, {:unknown_gate_flag, flag})
+  end
+
+  defp parse_flags([arg | rest], opts, positionals) do
+    parse_flags(rest, opts, [arg | positionals])
+  end
+
+  defp finalize_parse_error(opts, positionals, rest, reason) do
+    opts =
+      if "--json" in rest do
+        [{:json, true} | opts]
+      else
+        opts
+      end
+
+    {Enum.reverse(opts), Enum.reverse(positionals), reason}
+  end
+
+  defp parse_actor(value) when is_binary(value) do
+    case String.split(value, ":", parts: 2) do
+      [actor_type, actor_id] ->
+        actor_type = String.trim(actor_type)
+        actor_id = String.trim(actor_id)
+
+        with :ok <- validate_actor_type(actor_type),
+             :ok <- validate_cli_actor_id(actor_id) do
+          {:ok, actor_type, actor_id}
+        end
+
+      _ ->
+        {:error, {:invalid_gate_actor, value}}
+    end
+  end
+
+  defp validate_actor_type(type) when type in ~w(member agent daemon system), do: :ok
+  defp validate_actor_type(type), do: {:error, {:invalid_gate_requester_type, type}}
+
+  defp validate_cli_actor_id(""), do: {:error, {:invalid_gate_actor, :empty_id}}
+  defp validate_cli_actor_id(_actor_id), do: :ok
+
+  defp actor(opts, runtime_opts) do
+    {default_type, default_id} = default_actor(runtime_opts)
+
+    {
+      Keyword.get(opts, :actor_type, default_type),
+      Keyword.get(opts, :actor_id, default_id)
+    }
+  end
+
+  defp default_actor(runtime_opts) do
+    {
+      Keyword.get(runtime_opts, :default_actor_type, @default_actor_type),
+      Keyword.get_lazy(runtime_opts, :default_actor_id, &default_actor_id/0)
+    }
+  end
+
+  defp default_actor_id do
+    ["SYKLI_ACTOR_ID", "USER", "USERNAME"]
+    |> Enum.find_value(fn name ->
+      case System.get_env(name) do
+        value when is_binary(value) and value != "" -> value
+        _ -> nil
+      end
+    end)
+    |> case do
+      nil -> "local"
+      value -> value
+    end
+  end
+
+  defp store_opts(runtime_opts), do: Keyword.take(runtime_opts, [:path])
+
+  defp output_success(data, opts, human_fun) do
+    if Keyword.get(opts, :json, false) do
+      IO.puts(JsonResponse.ok(data))
+    else
+      human_fun.()
+    end
+
+    0
+  end
+
+  defp output_error(reason, json_output) do
+    error = Error.wrap(reason)
+
+    if json_output do
+      IO.puts(JsonResponse.error(error))
+    else
+      IO.puts(:stderr, Formatter.format(error))
+    end
+
+    1
+  end
+
+  defp gate_map(%GateDecision{} = gate), do: GateDecision.to_map(gate)
+
+  defp print_gate(%GateDecision{} = gate) do
+    IO.puts("#{gate.id}  #{gate.status}")
+
+    if gate.work_item_id, do: IO.puts("work_item_id: #{gate.work_item_id}")
+    if gate.run_id, do: IO.puts("run_id: #{gate.run_id}")
+    if gate.node_id, do: IO.puts("node_id: #{gate.node_id}")
+    if gate.reason, do: IO.puts("reason: #{gate.reason}")
+    if gate.decided_by, do: IO.puts("decided_by: #{gate.decided_by}")
+  end
+
+  defp print_help do
+    IO.puts("""
+    Usage: sykli gate <command>
+           sykli gates list
+
+    Local gate decision commands.
+
+    Unknown flags are rejected. Approval and rejection require --reason.
+
+    Commands:
+      sykli gates list [--status STATUS]
+      sykli gate show <gate-id>
+      sykli gate approve <gate-id> --reason TEXT [--actor TYPE:ID]
+      sykli gate reject <gate-id> --reason TEXT [--actor TYPE:ID]
+
+    Options:
+      --json          Output as JSON
+      --status STATUS Filter list output by gate status
+      --reason TEXT   Decision reason for approve/reject
+      --actor TYPE:ID Set actor identity, e.g. member:yair, agent:claude, daemon:worker-1
+    """)
+  end
+end

--- a/core/lib/sykli/error.ex
+++ b/core/lib/sykli/error.ex
@@ -672,6 +672,71 @@ defmodule Sykli.Error do
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
+  # GATE DECISION ERRORS
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  def gate_not_found(id) do
+    %__MODULE__{
+      code: "gate_not_found",
+      type: :validation,
+      message: "gate '#{id}' was not found",
+      step: :validate,
+      hints: ["run `sykli gates list` to see local gates"]
+    }
+  end
+
+  def invalid_gate_id(id) do
+    %__MODULE__{
+      code: "invalid_gate_id",
+      type: :validation,
+      message: "invalid gate id: #{inspect(id)}",
+      step: :validate,
+      hints: ["gate ids may contain letters, numbers, underscores, dashes, and dots"]
+    }
+  end
+
+  def malformed_gate_json(path) do
+    %__MODULE__{
+      code: "malformed_gate_json",
+      type: :validation,
+      message: "local gate file is not valid JSON",
+      step: :parse,
+      hints: ["inspect or remove the malformed file before retrying"],
+      notes: ["path: #{path}"]
+    }
+  end
+
+  def invalid_gate_transition(from, to) do
+    %__MODULE__{
+      code: "invalid_gate_transition",
+      type: :validation,
+      message: "invalid gate transition: #{from} -> #{to}",
+      step: :validate,
+      hints: ["only waiting or blocked gates can be approved or rejected"]
+    }
+  end
+
+  def gate_decision_missing_reason do
+    %__MODULE__{
+      code: "gate_decision_missing_reason",
+      type: :validation,
+      message: "gate approval or rejection requires a reason",
+      step: :validate,
+      hints: ["use --reason \"...\""]
+    }
+  end
+
+  def invalid_gate_decision(reason) do
+    %__MODULE__{
+      code: "invalid_gate_decision",
+      type: :validation,
+      message: "invalid local gate decision: #{format_gate_reason(reason)}",
+      step: :validate,
+      hints: ["inspect the gate file under .sykli/gates"]
+    }
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
   # INTERNAL ERRORS
   # ─────────────────────────────────────────────────────────────────────────────
 
@@ -774,6 +839,44 @@ defmodule Sykli.Error do
   def wrap({:invalid_note, reason}), do: invalid_work_item({:invalid_note, reason})
   def wrap({:invalid_note_author, reason}), do: invalid_work_item({:invalid_note_author, reason})
   def wrap({:contract_hash_failed, path, reason}), do: contract_hash_failed(path, reason)
+
+  # Gate decision errors
+  def wrap({:gate_not_found, id}), do: gate_not_found(id)
+  def wrap({:invalid_gate_id, id}), do: invalid_gate_id(id)
+  def wrap({:malformed_gate_json, path, _error}), do: malformed_gate_json(path)
+  def wrap({:invalid_gate_transition, from, to}), do: invalid_gate_transition(from, to)
+  def wrap(:gate_decision_missing_reason), do: gate_decision_missing_reason()
+  def wrap({:unknown_gate_flag, flag}), do: invalid_gate_decision({:unknown_flag, flag})
+
+  def wrap({:invalid_gate_command, command}),
+    do: invalid_gate_decision({:invalid_command, command})
+
+  def wrap({:invalid_gate_actor, actor}), do: invalid_gate_decision({:invalid_actor, actor})
+  def wrap({:missing_gate_version, _}), do: invalid_gate_decision(:missing_version)
+
+  def wrap({:unsupported_gate_version, version}),
+    do: invalid_gate_decision({:unsupported_version, version})
+
+  def wrap({:invalid_gate_status, status}), do: invalid_gate_decision({:invalid_status, status})
+  def wrap({:invalid_gate_decision, reason}), do: invalid_gate_decision(reason)
+
+  def wrap({:invalid_gate_field, field, value}),
+    do: invalid_gate_decision({:invalid_field, field, value})
+
+  def wrap({:invalid_gate_requester, reason}),
+    do: invalid_gate_decision({:invalid_requester, reason})
+
+  def wrap({:invalid_gate_requester_type, type}),
+    do: invalid_gate_decision({:invalid_requester_type, type})
+
+  def wrap({:invalid_gate_requester_id, id}),
+    do: invalid_gate_decision({:invalid_requester_id, id})
+
+  def wrap({:invalid_gate_evidence_ref, ref}),
+    do: invalid_gate_decision({:invalid_evidence_ref, ref})
+
+  def wrap({:invalid_gate_evidence_refs, refs}),
+    do: invalid_gate_decision({:invalid_evidence_refs, refs})
 
   # Validation errors
   def wrap({:cycle_detected, path}), do: cycle_detected(path)
@@ -1028,6 +1131,47 @@ defmodule Sykli.Error do
   defp format_work_item_reason(:missing_type), do: "missing actor type"
 
   defp format_work_item_reason(reason), do: inspect(reason)
+
+  defp format_gate_reason(:missing_version), do: "missing version"
+
+  defp format_gate_reason({:unsupported_version, version}),
+    do: "unsupported version #{inspect(version)}"
+
+  defp format_gate_reason({:unknown_flag, flag}), do: "unknown flag #{flag}"
+  defp format_gate_reason({:invalid_command, ""}), do: "missing gate command"
+
+  defp format_gate_reason({:invalid_command, command}),
+    do: "invalid gate command #{inspect(command)}"
+
+  defp format_gate_reason({:invalid_actor, actor}), do: "invalid actor #{inspect(actor)}"
+
+  defp format_gate_reason({:invalid_status, status}),
+    do: "invalid status #{inspect(status)}"
+
+  defp format_gate_reason({:invalid_field, field, value}),
+    do: "invalid #{field} #{inspect(value)}"
+
+  defp format_gate_reason({:invalid_requester, reason}),
+    do: "invalid requester: #{format_gate_reason(reason)}"
+
+  defp format_gate_reason({:invalid_requester_type, type}),
+    do: "invalid requester type #{inspect(type)}"
+
+  defp format_gate_reason({:invalid_requester_id, id}),
+    do: "invalid requester id #{inspect(id)}"
+
+  defp format_gate_reason({:invalid_evidence_ref, ref}),
+    do: "invalid evidence ref #{inspect(ref)}"
+
+  defp format_gate_reason({:invalid_evidence_refs, refs}),
+    do: "invalid evidence refs #{inspect(refs)}"
+
+  defp format_gate_reason(:empty_id), do: "empty actor id"
+  defp format_gate_reason(:empty), do: "empty value"
+  defp format_gate_reason(:not_object), do: "expected object"
+  defp format_gate_reason(:missing_type), do: "missing requester type"
+
+  defp format_gate_reason(reason), do: inspect(reason)
 
   defp format_duration(ms) when ms < 1000, do: "#{ms}ms"
   defp format_duration(ms) when ms < 60_000, do: "#{Float.round(ms / 1000, 1)}s"

--- a/core/lib/sykli/gate/store.ex
+++ b/core/lib/sykli/gate/store.ex
@@ -1,0 +1,159 @@
+defmodule Sykli.Gate.Store do
+  @moduledoc """
+  File-backed local gate decision store.
+
+  The store persists gate decisions under `.sykli/gates/<id>.json` in the
+  requested project path. It is intentionally local-only; coordinator sync and
+  runtime gate lifecycle integration are later Team Mode phases.
+  """
+
+  alias Sykli.GateDecision
+
+  @gates_dir ".sykli/gates"
+
+  @doc "Returns the gate storage directory for a base path."
+  def gates_dir(opts \\ []) do
+    opts
+    |> base_path()
+    |> Path.join(@gates_dir)
+  end
+
+  @doc "Creates and persists a new gate request."
+  def create(opts \\ []) do
+    with {:ok, gate} <- GateDecision.new(opts),
+         :ok <- save(gate, opts) do
+      {:ok, gate}
+    end
+  end
+
+  @doc "Persists an existing gate decision."
+  def save(%GateDecision{} = gate, opts \\ []) do
+    with :ok <- GateDecision.validate_id(gate.id),
+         {:ok, path} <- gate_path(gate.id, opts),
+         :ok <- File.mkdir_p(Path.dirname(path)),
+         {:ok, json} <- encode(gate),
+         :ok <- atomic_write(path, json) do
+      :ok
+    end
+  end
+
+  @doc "Loads a gate decision by id."
+  def get(id, opts \\ []) do
+    with {:ok, path} <- gate_path(id, opts) do
+      case File.read(path) do
+        {:ok, json} -> decode(json, path)
+        {:error, :enoent} -> {:error, {:gate_not_found, id}}
+        {:error, reason} -> {:error, {:gate_read_failed, id, reason}}
+      end
+    end
+  end
+
+  @doc "Lists all persisted gate decisions in deterministic id order."
+  def list(opts \\ []) do
+    dir = gates_dir(opts)
+
+    case File.ls(dir) do
+      {:ok, files} ->
+        files
+        |> Enum.filter(&String.ends_with?(&1, ".json"))
+        |> Enum.sort()
+        |> Enum.reduce_while({:ok, []}, fn file, {:ok, gates} ->
+          id = String.trim_trailing(file, ".json")
+
+          case get(id, opts) do
+            {:ok, gate} -> {:cont, {:ok, [gate | gates]}}
+            {:error, reason} -> {:halt, {:error, reason}}
+          end
+        end)
+        |> case do
+          {:ok, gates} -> {:ok, Enum.reverse(gates)}
+          error -> error
+        end
+
+      {:error, :enoent} ->
+        {:ok, []}
+
+      {:error, reason} ->
+        {:error, {:gate_list_failed, reason}}
+    end
+  end
+
+  @doc "Lists persisted gate decisions matching a status."
+  def list_by_status(status, opts \\ []) do
+    with :ok <- GateDecision.validate_status(status),
+         {:ok, gates} <- list(opts) do
+      {:ok, Enum.filter(gates, &(&1.status == status))}
+    end
+  end
+
+  @doc "Approves a persisted gate decision."
+  def approve(id, reason, opts \\ []) do
+    with {:ok, gate} <- get(id, opts),
+         {:ok, updated} <- GateDecision.approve(gate, reason, opts),
+         :ok <- save(updated, opts) do
+      {:ok, updated}
+    end
+  end
+
+  @doc "Rejects a persisted gate decision."
+  def reject(id, reason, opts \\ []) do
+    with {:ok, gate} <- get(id, opts),
+         {:ok, updated} <- GateDecision.reject(gate, reason, opts),
+         :ok <- save(updated, opts) do
+      {:ok, updated}
+    end
+  end
+
+  defp gate_path(id, opts) do
+    with :ok <- GateDecision.validate_id(id) do
+      dir = gates_dir(opts)
+      path = Path.expand(Path.join(dir, "#{id}.json"))
+      expanded_dir = Path.expand(dir)
+
+      if path_within?(path, expanded_dir) do
+        {:ok, path}
+      else
+        {:error, {:gate_path_escape, id}}
+      end
+    end
+  end
+
+  defp encode(%GateDecision{} = gate) do
+    case Jason.encode(GateDecision.to_map(gate), pretty: true) do
+      {:ok, json} -> {:ok, json}
+      {:error, error} -> {:error, {:gate_encode_failed, error}}
+    end
+  end
+
+  defp decode(json, path) do
+    with {:ok, data} <- Jason.decode(json),
+         {:ok, gate} <- GateDecision.from_map(data) do
+      {:ok, gate}
+    else
+      {:error, %Jason.DecodeError{} = error} -> {:error, {:malformed_gate_json, path, error}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp atomic_write(path, json) do
+    tmp_path = "#{path}.tmp-#{System.unique_integer([:positive])}"
+
+    with :ok <- File.write(tmp_path, json),
+         :ok <- File.rename(tmp_path, path) do
+      :ok
+    else
+      {:error, reason} ->
+        File.rm(tmp_path)
+        {:error, {:gate_write_failed, path, reason}}
+    end
+  end
+
+  defp base_path(opts), do: Keyword.get(opts, :path, ".")
+
+  defp path_within?(path, base) do
+    expanded_path = Path.expand(path)
+    expanded_base = Path.expand(base)
+
+    expanded_path == expanded_base or String.starts_with?(expanded_path, expanded_base <> "/")
+  end
+end

--- a/core/lib/sykli/gate_decision.ex
+++ b/core/lib/sykli/gate_decision.ex
@@ -6,6 +6,13 @@ defmodule Sykli.GateDecision do
   `.sykli/gates/<id>.json`. It records a waiting or blocked decision boundary and
   the later approval or rejection. Coordinator sync and runtime gate hookup are
   later Team Mode layers.
+
+  `decided_by` is stored as a compact actor reference string, e.g.
+  `"member:yair"`, `"agent:claude"`, or `"daemon:worker-1"`.
+
+  `evidence_refs` is stored as an opaque list of maps in this local v0 shape.
+  Consumers should treat unknown keys conservatively and validate the inner
+  reference shape they need before rendering or syncing it.
   """
 
   @version "1"
@@ -85,6 +92,16 @@ defmodule Sykli.GateDecision do
   @doc "Rejects a waiting or blocked gate."
   def reject(%__MODULE__{} = gate, reason, opts \\ []) do
     decide(gate, "rejected", reason, opts)
+  end
+
+  @doc "Marks a waiting gate as blocked for future runtime integration."
+  def block(%__MODULE__{} = gate, opts \\ []) do
+    transition(gate, "blocked", opts)
+  end
+
+  @doc "Marks a waiting or blocked gate as expired for future expirer integration."
+  def expire(%__MODULE__{} = gate, opts \\ []) do
+    transition(gate, "expired", opts)
   end
 
   @doc "Converts a gate decision to the persisted JSON map shape."
@@ -173,9 +190,20 @@ defmodule Sykli.GateDecision do
     end
   end
 
+  defp transition(%__MODULE__{} = gate, target_status, opts) do
+    with :ok <- validate_transition(gate.status, target_status) do
+      now = Keyword.get_lazy(opts, :now, &now_iso8601/0)
+
+      {:ok, %__MODULE__{gate | status: target_status, updated_at: now}}
+    end
+  end
+
   defp validate_transition(from, to)
        when from in ["waiting", "blocked"] and to in ["approved", "rejected"],
        do: :ok
+
+  defp validate_transition("waiting", "blocked"), do: :ok
+  defp validate_transition(from, "expired") when from in ["waiting", "blocked"], do: :ok
 
   defp validate_transition(from, to) when from in @terminal_statuses,
     do: {:error, {:invalid_gate_transition, from, to}}

--- a/core/lib/sykli/gate_decision.ex
+++ b/core/lib/sykli/gate_decision.ex
@@ -1,0 +1,257 @@
+defmodule Sykli.GateDecision do
+  @moduledoc """
+  Local gate decision model for Team Mode.
+
+  A gate decision is a local coordination record stored under
+  `.sykli/gates/<id>.json`. It records a waiting or blocked decision boundary and
+  the later approval or rejection. Coordinator sync and runtime gate hookup are
+  later Team Mode layers.
+  """
+
+  @version "1"
+  @statuses ~w(waiting approved rejected blocked expired)
+  @requester_types ~w(member agent daemon system)
+  @terminal_statuses ~w(approved rejected expired)
+
+  @enforce_keys [:id, :status, :created_at, :updated_at]
+  defstruct [
+    :id,
+    version: @version,
+    work_item_id: nil,
+    run_id: nil,
+    node_id: nil,
+    status: "waiting",
+    reason: nil,
+    requested_by_type: nil,
+    requested_by_id: nil,
+    decided_by: nil,
+    decided_at: nil,
+    created_at: nil,
+    updated_at: nil,
+    evidence_refs: []
+  ]
+
+  @type status :: String.t()
+  @type t :: %__MODULE__{
+          id: String.t(),
+          version: String.t(),
+          work_item_id: String.t() | nil,
+          run_id: String.t() | nil,
+          node_id: String.t() | nil,
+          status: status(),
+          reason: String.t() | nil,
+          requested_by_type: String.t() | nil,
+          requested_by_id: String.t() | nil,
+          decided_by: String.t() | nil,
+          decided_at: String.t() | nil,
+          created_at: String.t(),
+          updated_at: String.t(),
+          evidence_refs: [map()]
+        }
+
+  def version, do: @version
+  def statuses, do: @statuses
+  def requester_types, do: @requester_types
+
+  @doc "Builds a new local gate request."
+  def new(opts \\ []) do
+    now = Keyword.get_lazy(opts, :now, &now_iso8601/0)
+
+    attrs = %{
+      id: Keyword.get_lazy(opts, :id, &Sykli.ULID.generate/0),
+      version: @version,
+      work_item_id: blank_to_nil(Keyword.get(opts, :work_item_id)),
+      run_id: blank_to_nil(Keyword.get(opts, :run_id)),
+      node_id: blank_to_nil(Keyword.get(opts, :node_id)),
+      status: Keyword.get(opts, :status, "waiting"),
+      reason: blank_to_nil(Keyword.get(opts, :reason)),
+      requested_by_type: Keyword.get(opts, :requested_by_type),
+      requested_by_id: blank_to_nil(Keyword.get(opts, :requested_by_id)),
+      decided_by: blank_to_nil(Keyword.get(opts, :decided_by)),
+      decided_at: blank_to_nil(Keyword.get(opts, :decided_at)),
+      created_at: now,
+      updated_at: now,
+      evidence_refs: Keyword.get(opts, :evidence_refs, [])
+    }
+
+    from_map(attrs)
+  end
+
+  @doc "Approves a waiting or blocked gate."
+  def approve(%__MODULE__{} = gate, reason, opts \\ []) do
+    decide(gate, "approved", reason, opts)
+  end
+
+  @doc "Rejects a waiting or blocked gate."
+  def reject(%__MODULE__{} = gate, reason, opts \\ []) do
+    decide(gate, "rejected", reason, opts)
+  end
+
+  @doc "Converts a gate decision to the persisted JSON map shape."
+  def to_map(%__MODULE__{} = gate) do
+    %{
+      "id" => gate.id,
+      "version" => gate.version,
+      "work_item_id" => gate.work_item_id,
+      "run_id" => gate.run_id,
+      "node_id" => gate.node_id,
+      "status" => gate.status,
+      "reason" => gate.reason,
+      "requested_by_type" => gate.requested_by_type,
+      "requested_by_id" => gate.requested_by_id,
+      "decided_by" => gate.decided_by,
+      "decided_at" => gate.decided_at,
+      "created_at" => gate.created_at,
+      "updated_at" => gate.updated_at,
+      "evidence_refs" => gate.evidence_refs
+    }
+  end
+
+  @doc "Builds a gate decision from a persisted JSON map."
+  def from_map(map) when is_map(map) do
+    attrs = normalize_keys(map)
+
+    with :ok <- validate_id(attrs["id"]),
+         :ok <- validate_version(attrs["version"]),
+         :ok <- validate_status(attrs["status"] || "waiting"),
+         :ok <- validate_optional_id(attrs["work_item_id"], :work_item_id),
+         :ok <- validate_optional_string(attrs["run_id"], :run_id),
+         :ok <- validate_optional_string(attrs["node_id"], :node_id),
+         :ok <- validate_requested_by(attrs["requested_by_type"], attrs["requested_by_id"]),
+         :ok <- validate_optional_string(attrs["decided_by"], :decided_by),
+         :ok <- validate_optional_string(attrs["decided_at"], :decided_at),
+         :ok <- validate_evidence_refs(attrs["evidence_refs"] || []) do
+      {:ok,
+       %__MODULE__{
+         id: attrs["id"],
+         version: attrs["version"],
+         work_item_id: blank_to_nil(attrs["work_item_id"]),
+         run_id: blank_to_nil(attrs["run_id"]),
+         node_id: blank_to_nil(attrs["node_id"]),
+         status: attrs["status"] || "waiting",
+         reason: blank_to_nil(attrs["reason"]),
+         requested_by_type: attrs["requested_by_type"],
+         requested_by_id: blank_to_nil(attrs["requested_by_id"]),
+         decided_by: blank_to_nil(attrs["decided_by"]),
+         decided_at: blank_to_nil(attrs["decided_at"]),
+         created_at: attrs["created_at"] || now_iso8601(),
+         updated_at: attrs["updated_at"] || attrs["created_at"] || now_iso8601(),
+         evidence_refs: Enum.map(attrs["evidence_refs"] || [], &normalize_keys/1)
+       }}
+    end
+  end
+
+  def from_map(_), do: {:error, {:invalid_gate_decision, :not_object}}
+
+  def validate_id(id) when is_binary(id) do
+    if Regex.match?(~r/^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/, id) do
+      :ok
+    else
+      {:error, {:invalid_gate_id, id}}
+    end
+  end
+
+  def validate_id(id), do: {:error, {:invalid_gate_id, id}}
+
+  def validate_status(status) when status in @statuses, do: :ok
+  def validate_status(status), do: {:error, {:invalid_gate_status, status}}
+
+  defp decide(%__MODULE__{} = gate, target_status, reason, opts) do
+    with :ok <- validate_transition(gate.status, target_status),
+         :ok <- validate_decision_reason(reason) do
+      now = Keyword.get_lazy(opts, :now, &now_iso8601/0)
+
+      {:ok,
+       %__MODULE__{
+         gate
+         | status: target_status,
+           reason: String.trim(reason),
+           decided_by: blank_to_nil(Keyword.get(opts, :decided_by)),
+           decided_at: now,
+           updated_at: now
+       }}
+    end
+  end
+
+  defp validate_transition(from, to)
+       when from in ["waiting", "blocked"] and to in ["approved", "rejected"],
+       do: :ok
+
+  defp validate_transition(from, to) when from in @terminal_statuses,
+    do: {:error, {:invalid_gate_transition, from, to}}
+
+  defp validate_transition(from, to), do: {:error, {:invalid_gate_transition, from, to}}
+
+  defp validate_decision_reason(reason) when is_binary(reason) do
+    if String.trim(reason) == "", do: {:error, :gate_decision_missing_reason}, else: :ok
+  end
+
+  defp validate_decision_reason(_), do: {:error, :gate_decision_missing_reason}
+
+  defp validate_version(nil), do: {:error, {:missing_gate_version, nil}}
+  defp validate_version(@version), do: :ok
+  defp validate_version(version), do: {:error, {:unsupported_gate_version, version}}
+
+  defp validate_optional_id(nil, _field), do: :ok
+  defp validate_optional_id("", _field), do: :ok
+  defp validate_optional_id(id, _field), do: Sykli.WorkItem.validate_id(id)
+
+  defp validate_optional_string(nil, _field), do: :ok
+  defp validate_optional_string("", _field), do: :ok
+
+  defp validate_optional_string(value, field) when is_binary(value) do
+    if String.trim(value) == "", do: {:error, {:invalid_gate_field, field, :empty}}, else: :ok
+  end
+
+  defp validate_optional_string(value, field), do: {:error, {:invalid_gate_field, field, value}}
+
+  defp validate_requested_by(nil, nil), do: :ok
+  defp validate_requested_by(nil, requester_id) when requester_id in [nil, ""], do: :ok
+
+  defp validate_requested_by(nil, _requester_id),
+    do: {:error, {:invalid_gate_requester, :missing_type}}
+
+  defp validate_requested_by(type, requester_id) when type in @requester_types do
+    validate_requester_id(requester_id)
+  end
+
+  defp validate_requested_by(type, _requester_id),
+    do: {:error, {:invalid_gate_requester_type, type}}
+
+  defp validate_requester_id(nil), do: {:error, {:invalid_gate_requester_id, :empty}}
+
+  defp validate_requester_id(id) when is_binary(id) do
+    if String.trim(id) == "", do: {:error, {:invalid_gate_requester_id, :empty}}, else: :ok
+  end
+
+  defp validate_requester_id(id), do: {:error, {:invalid_gate_requester_id, id}}
+
+  defp validate_evidence_refs(refs) when is_list(refs) do
+    Enum.reduce_while(refs, :ok, fn
+      ref, :ok when is_map(ref) -> {:cont, :ok}
+      ref, :ok -> {:halt, {:error, {:invalid_gate_evidence_ref, ref}}}
+    end)
+  end
+
+  defp validate_evidence_refs(refs), do: {:error, {:invalid_gate_evidence_refs, refs}}
+
+  defp normalize_keys(map) do
+    Map.new(map, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+      {key, value} -> {key, value}
+    end)
+  end
+
+  defp blank_to_nil(value) when is_binary(value) do
+    value = String.trim(value)
+    if value == "", do: nil, else: value
+  end
+
+  defp blank_to_nil(value), do: value
+
+  defp now_iso8601 do
+    DateTime.utc_now()
+    |> DateTime.truncate(:second)
+    |> DateTime.to_iso8601()
+  end
+end

--- a/core/test/sykli/cli/gate_test.exs
+++ b/core/test/sykli/cli/gate_test.exs
@@ -51,8 +51,21 @@ defmodule Sykli.CLI.GateTest do
       gate = result["data"]["gate"]
       assert gate["status"] == "approved"
       assert gate["reason"] == "Evidence reviewed"
-      assert gate["decided_by"] == "test-user"
+      assert gate["decided_by"] == "member:test-user"
       assert gate["decided_at"] == @later
+    end
+
+    test "approve preserves explicit actor type in decided_by", %{tmp_dir: tmp_dir} do
+      create_gate(tmp_dir, id: "gate_001", status: "waiting")
+
+      result =
+        run_json(
+          ["approve", "gate_001", "--actor=agent:claude", "--reason", "Agent review", "--json"],
+          path: tmp_dir,
+          now: @later
+        )
+
+      assert result["data"]["gate"]["decided_by"] == "agent:claude"
     end
 
     test "reject --json records decision", %{tmp_dir: tmp_dir} do
@@ -94,6 +107,15 @@ defmodule Sykli.CLI.GateTest do
     test "missing reason returns structured JSON error", %{tmp_dir: tmp_dir} do
       create_gate(tmp_dir, id: "gate_001", status: "waiting")
       result = run_json(["approve", "gate_001", "--json"], path: tmp_dir, expect: 1)
+      assert result["error"]["code"] == "gate_decision_missing_reason"
+    end
+
+    test "blank reason returns structured JSON error", %{tmp_dir: tmp_dir} do
+      create_gate(tmp_dir, id: "gate_001", status: "waiting")
+
+      result =
+        run_json(["approve", "gate_001", "--reason", "   ", "--json"], path: tmp_dir, expect: 1)
+
       assert result["error"]["code"] == "gate_decision_missing_reason"
     end
 

--- a/core/test/sykli/cli/gate_test.exs
+++ b/core/test/sykli/cli/gate_test.exs
@@ -1,0 +1,149 @@
+defmodule Sykli.CLI.GateTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias Sykli.CLI.Gate
+  alias Sykli.Gate.Store
+
+  @moduletag :tmp_dir
+
+  @now "2026-05-09T10:00:00Z"
+  @later "2026-05-09T10:05:00Z"
+
+  describe "local gate commands" do
+    test "list --json handles empty and deterministic lists", %{tmp_dir: tmp_dir} do
+      assert run_json(["list", "--json"], path: tmp_dir)["data"]["gates"] == []
+
+      create_gate(tmp_dir, id: "gate_b", status: "waiting")
+      create_gate(tmp_dir, id: "gate_a", status: "approved")
+
+      result = run_json(["list", "--json"], path: tmp_dir)
+      assert Enum.map(result["data"]["gates"], & &1["id"]) == ["gate_a", "gate_b"]
+    end
+
+    test "list can filter by status", %{tmp_dir: tmp_dir} do
+      create_gate(tmp_dir, id: "gate_a", status: "approved")
+      create_gate(tmp_dir, id: "gate_b", status: "waiting")
+
+      result = run_json(["list", "--status", "waiting", "--json"], path: tmp_dir)
+      assert Enum.map(result["data"]["gates"], & &1["id"]) == ["gate_b"]
+    end
+
+    test "show --json returns one gate", %{tmp_dir: tmp_dir} do
+      create_gate(tmp_dir, id: "gate_001", status: "waiting", node_id: "approve")
+
+      result = run_json(["show", "gate_001", "--json"], path: tmp_dir)
+      assert result["data"]["source"] == "local"
+      assert result["data"]["gate"]["id"] == "gate_001"
+      assert result["data"]["gate"]["node_id"] == "approve"
+    end
+
+    test "approve --json records decision", %{tmp_dir: tmp_dir} do
+      create_gate(tmp_dir, id: "gate_001", status: "waiting")
+
+      result =
+        run_json(["approve", "gate_001", "--reason", "Evidence reviewed", "--json"],
+          path: tmp_dir,
+          now: @later
+        )
+
+      gate = result["data"]["gate"]
+      assert gate["status"] == "approved"
+      assert gate["reason"] == "Evidence reviewed"
+      assert gate["decided_by"] == "test-user"
+      assert gate["decided_at"] == @later
+    end
+
+    test "reject --json records decision", %{tmp_dir: tmp_dir} do
+      create_gate(tmp_dir, id: "gate_001", status: "waiting")
+
+      result =
+        run_json(["reject", "gate_001", "--reason=Not safe", "--json"],
+          path: tmp_dir,
+          now: @later
+        )
+
+      gate = result["data"]["gate"]
+      assert gate["status"] == "rejected"
+      assert gate["reason"] == "Not safe"
+    end
+
+    test "help exits successfully", %{tmp_dir: tmp_dir} do
+      output =
+        capture_io(fn ->
+          assert Gate.run(["--help"], path: tmp_dir) == 0
+        end)
+
+      assert output =~ "Usage: sykli gate <command>"
+      assert output =~ "Approval and rejection require --reason"
+    end
+  end
+
+  describe "errors" do
+    test "not-found gate returns structured JSON error", %{tmp_dir: tmp_dir} do
+      result = run_json(["show", "missing", "--json"], path: tmp_dir, expect: 1)
+      assert result["error"]["code"] == "gate_not_found"
+    end
+
+    test "invalid gate ID returns structured JSON error", %{tmp_dir: tmp_dir} do
+      result = run_json(["show", "../escape", "--json"], path: tmp_dir, expect: 1)
+      assert result["error"]["code"] == "invalid_gate_id"
+    end
+
+    test "missing reason returns structured JSON error", %{tmp_dir: tmp_dir} do
+      create_gate(tmp_dir, id: "gate_001", status: "waiting")
+      result = run_json(["approve", "gate_001", "--json"], path: tmp_dir, expect: 1)
+      assert result["error"]["code"] == "gate_decision_missing_reason"
+    end
+
+    test "invalid transition returns structured JSON error", %{tmp_dir: tmp_dir} do
+      create_gate(tmp_dir, id: "gate_001", status: "approved")
+
+      result =
+        run_json(["reject", "gate_001", "--reason", "No", "--json"],
+          path: tmp_dir,
+          expect: 1
+        )
+
+      assert result["error"]["code"] == "invalid_gate_transition"
+      assert result["error"]["message"] == "invalid gate transition: approved -> rejected"
+    end
+
+    test "unknown flag returns clear JSON error", %{tmp_dir: tmp_dir} do
+      result = run_json(["list", "--bogus", "--json"], path: tmp_dir, expect: 1)
+      assert result["error"]["code"] == "invalid_gate_decision"
+      assert result["error"]["message"] == "invalid local gate decision: unknown flag --bogus"
+    end
+
+    test "malformed persisted JSON returns structured JSON error", %{tmp_dir: tmp_dir} do
+      dir = Store.gates_dir(path: tmp_dir)
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "gate_001.json"), "{bad json")
+
+      result = run_json(["show", "gate_001", "--json"], path: tmp_dir, expect: 1)
+      assert result["error"]["code"] == "malformed_gate_json"
+    end
+  end
+
+  defp run_json(args, opts) do
+    opts = Keyword.put_new(opts, :default_actor_id, "test-user")
+    expected_code = Keyword.get(opts, :expect, 0)
+
+    output =
+      capture_io(fn ->
+        assert Gate.run(args, opts) == expected_code
+      end)
+
+    Jason.decode!(output)
+  end
+
+  defp create_gate(tmp_dir, opts) do
+    opts =
+      opts
+      |> Keyword.put_new(:now, @now)
+      |> Keyword.put(:path, tmp_dir)
+
+    assert {:ok, _gate} = Store.create(opts)
+  end
+end

--- a/core/test/sykli/cli_test.exs
+++ b/core/test/sykli/cli_test.exs
@@ -180,6 +180,15 @@ defmodule Sykli.CLITest do
              ]
     end
 
+    test "normalizes plural gates command without corrupting explicit subcommands" do
+      assert Sykli.CLI.normalize_gates_args([]) == ["list"]
+      assert Sykli.CLI.normalize_gates_args(["--json"]) == ["list", "--json"]
+      assert Sykli.CLI.normalize_gates_args(["--status=waiting"]) == ["list", "--status=waiting"]
+      assert Sykli.CLI.normalize_gates_args(["show", "gate_001"]) == ["show", "gate_001"]
+      assert Sykli.CLI.normalize_gates_args(["approve", "gate_001"]) == ["approve", "gate_001"]
+      assert Sykli.CLI.normalize_gates_args(["wat", "gate_001"]) == ["wat", "gate_001"]
+    end
+
     test "leaves default run JSON form unchanged" do
       assert Sykli.CLI.normalize_global_json(["--json"]) == ["--json"]
     end

--- a/core/test/sykli/cli_test.exs
+++ b/core/test/sykli/cli_test.exs
@@ -165,6 +165,19 @@ defmodule Sykli.CLITest do
                "--json",
                "list"
              ]
+
+      assert Sykli.CLI.normalize_global_json(["--json", "gates", "list"]) == [
+               "gates",
+               "--json",
+               "list"
+             ]
+
+      assert Sykli.CLI.normalize_global_json(["--json", "gate", "show", "gate_001"]) == [
+               "gate",
+               "--json",
+               "show",
+               "gate_001"
+             ]
     end
 
     test "leaves default run JSON form unchanged" do

--- a/core/test/sykli/gate/store_test.exs
+++ b/core/test/sykli/gate/store_test.exs
@@ -1,0 +1,135 @@
+defmodule Sykli.Gate.StoreTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.Gate.Store
+  alias Sykli.GateDecision
+
+  @moduletag :tmp_dir
+
+  @now "2026-05-09T10:00:00Z"
+  @later "2026-05-09T10:05:00Z"
+
+  describe "create/1 and get/2" do
+    test "persists gate decision under .sykli/gates", %{tmp_dir: tmp_dir} do
+      assert {:ok, gate} =
+               Store.create(
+                 id: "gate_001",
+                 work_item_id: "work_001",
+                 run_id: "run-001",
+                 node_id: "approve",
+                 requested_by_type: "system",
+                 requested_by_id: "executor",
+                 evidence_refs: [%{"type" => "occurrence", "uri" => "occ://1"}],
+                 now: @now,
+                 path: tmp_dir
+               )
+
+      path = Path.join([tmp_dir, ".sykli", "gates", "gate_001.json"])
+      assert File.exists?(path)
+
+      assert {:ok, loaded} = Store.get("gate_001", path: tmp_dir)
+      assert loaded == gate
+
+      persisted = path |> File.read!() |> Jason.decode!()
+      assert persisted["version"] == "1"
+      assert persisted["status"] == "waiting"
+      refute Map.has_key?(persisted, "logs")
+      refute Map.has_key?(persisted, "artifacts")
+      refute Map.has_key?(persisted, "secrets")
+    end
+
+    test "missing gate returns structured not-found error", %{tmp_dir: tmp_dir} do
+      assert {:error, {:gate_not_found, "missing"}} = Store.get("missing", path: tmp_dir)
+    end
+  end
+
+  describe "list/1" do
+    test "returns deterministic id order and supports status filtering", %{tmp_dir: tmp_dir} do
+      assert {:ok, _} = Store.create(id: "gate_b", status: "approved", now: @now, path: tmp_dir)
+      assert {:ok, _} = Store.create(id: "gate_a", status: "waiting", now: @now, path: tmp_dir)
+
+      assert {:ok, gates} = Store.list(path: tmp_dir)
+      assert Enum.map(gates, & &1.id) == ["gate_a", "gate_b"]
+
+      assert {:ok, waiting} = Store.list_by_status("waiting", path: tmp_dir)
+      assert Enum.map(waiting, & &1.id) == ["gate_a"]
+    end
+
+    test "returns an empty list when no local gate directory exists", %{tmp_dir: tmp_dir} do
+      assert {:ok, []} = Store.list(path: tmp_dir)
+    end
+  end
+
+  describe "decisions" do
+    test "approves and rejects persisted gates", %{tmp_dir: tmp_dir} do
+      assert {:ok, _} = Store.create(id: "gate_001", now: @now, path: tmp_dir)
+      assert {:ok, _} = Store.create(id: "gate_002", now: @now, path: tmp_dir)
+
+      assert {:ok, approved} =
+               Store.approve("gate_001", "Looks safe",
+                 decided_by: "member:yair",
+                 now: @later,
+                 path: tmp_dir
+               )
+
+      assert approved.status == "approved"
+      assert approved.reason == "Looks safe"
+      assert approved.decided_by == "member:yair"
+      assert approved.decided_at == @later
+
+      assert {:ok, rejected} = Store.reject("gate_002", "Not safe", now: @later, path: tmp_dir)
+      assert rejected.status == "rejected"
+
+      assert {:ok, reloaded} = Store.get("gate_001", path: tmp_dir)
+      assert reloaded.status == "approved"
+    end
+
+    test "rejects invalid transitions", %{tmp_dir: tmp_dir} do
+      assert {:ok, _} = Store.create(id: "gate_001", now: @now, path: tmp_dir)
+      assert {:ok, _} = Store.approve("gate_001", "Reviewed", now: @later, path: tmp_dir)
+
+      assert {:error, {:invalid_gate_transition, "approved", "rejected"}} =
+               Store.reject("gate_001", "No", path: tmp_dir)
+    end
+  end
+
+  describe "validation and malformed state" do
+    test "invalid status and invalid ids are rejected", %{tmp_dir: tmp_dir} do
+      assert {:error, {:invalid_gate_status, "done"}} =
+               Store.create(id: "gate_001", status: "done", path: tmp_dir)
+
+      assert {:error, {:invalid_gate_id, "../escape"}} = Store.get("../escape", path: tmp_dir)
+      assert {:error, {:invalid_gate_id, "/tmp/escape"}} = Store.get("/tmp/escape", path: tmp_dir)
+    end
+
+    test "malformed persisted JSON is explicit", %{tmp_dir: tmp_dir} do
+      dir = Store.gates_dir(path: tmp_dir)
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "gate_001.json"), "{not json")
+
+      assert {:error, {:malformed_gate_json, path, %Jason.DecodeError{}}} =
+               Store.get("gate_001", path: tmp_dir)
+
+      assert String.ends_with?(path, ".sykli/gates/gate_001.json")
+    end
+
+    test "structurally invalid persisted JSON is explicit", %{tmp_dir: tmp_dir} do
+      dir = Store.gates_dir(path: tmp_dir)
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "gate_001.json"), Jason.encode!(%{"id" => "gate_001"}))
+
+      assert {:error, {:missing_gate_version, nil}} = Store.get("gate_001", path: tmp_dir)
+    end
+
+    test "save validates gate IDs", %{tmp_dir: tmp_dir} do
+      gate = %GateDecision{
+        id: "../escape",
+        status: "waiting",
+        created_at: @now,
+        updated_at: @now
+      }
+
+      assert {:error, {:invalid_gate_id, "../escape"}} = Store.save(gate, path: tmp_dir)
+    end
+  end
+end

--- a/core/test/sykli/gate_decision_test.exs
+++ b/core/test/sykli/gate_decision_test.exs
@@ -75,6 +75,19 @@ defmodule Sykli.GateDecisionTest do
       assert approved.status == "approved"
     end
 
+    test "supports block and expire transitions for future runtime hooks" do
+      assert {:ok, gate} = GateDecision.new(id: "gate_001", now: @now)
+      assert {:ok, blocked} = GateDecision.block(gate, now: @later)
+      assert blocked.status == "blocked"
+      assert blocked.updated_at == @later
+
+      assert {:ok, expired} = GateDecision.expire(blocked, now: "2026-05-09T10:10:00Z")
+      assert expired.status == "expired"
+
+      assert {:error, {:invalid_gate_transition, "expired", "approved"}} =
+               GateDecision.approve(expired, "Too late")
+    end
+
     test "rejects terminal transitions" do
       assert {:ok, gate} = GateDecision.new(id: "gate_001", now: @now)
       assert {:ok, approved} = GateDecision.approve(gate, "Reviewed", now: @later)

--- a/core/test/sykli/gate_decision_test.exs
+++ b/core/test/sykli/gate_decision_test.exs
@@ -1,0 +1,152 @@
+defmodule Sykli.GateDecisionTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.GateDecision
+
+  @now "2026-05-09T10:00:00Z"
+  @later "2026-05-09T10:05:00Z"
+
+  describe "new/1" do
+    test "creates a waiting gate with versioned persisted shape" do
+      assert {:ok, gate} =
+               GateDecision.new(
+                 id: "gate_001",
+                 work_item_id: "work_001",
+                 run_id: "run-001",
+                 node_id: "approve-deploy",
+                 requested_by_type: "system",
+                 requested_by_id: "executor",
+                 evidence_refs: [%{"type" => "occurrence", "uri" => "occ://1"}],
+                 now: @now
+               )
+
+      assert gate.id == "gate_001"
+      assert gate.version == "1"
+      assert gate.status == "waiting"
+      assert gate.created_at == @now
+      assert gate.updated_at == @now
+
+      assert GateDecision.to_map(gate) == %{
+               "id" => "gate_001",
+               "version" => "1",
+               "work_item_id" => "work_001",
+               "run_id" => "run-001",
+               "node_id" => "approve-deploy",
+               "status" => "waiting",
+               "reason" => nil,
+               "requested_by_type" => "system",
+               "requested_by_id" => "executor",
+               "decided_by" => nil,
+               "decided_at" => nil,
+               "created_at" => @now,
+               "updated_at" => @now,
+               "evidence_refs" => [%{"type" => "occurrence", "uri" => "occ://1"}]
+             }
+    end
+  end
+
+  describe "decision transitions" do
+    test "approves a waiting gate" do
+      assert {:ok, gate} = GateDecision.new(id: "gate_001", now: @now)
+
+      assert {:ok, approved} =
+               GateDecision.approve(gate, "Evidence reviewed",
+                 decided_by: "member:yair",
+                 now: @later
+               )
+
+      assert approved.status == "approved"
+      assert approved.reason == "Evidence reviewed"
+      assert approved.decided_by == "member:yair"
+      assert approved.decided_at == @later
+      assert approved.updated_at == @later
+    end
+
+    test "rejects a waiting gate" do
+      assert {:ok, gate} = GateDecision.new(id: "gate_001", now: @now)
+      assert {:ok, rejected} = GateDecision.reject(gate, "Not safe", now: @later)
+      assert rejected.status == "rejected"
+      assert rejected.reason == "Not safe"
+    end
+
+    test "allows blocked gates to be resolved explicitly" do
+      assert {:ok, gate} = GateDecision.new(id: "gate_001", status: "blocked", now: @now)
+      assert {:ok, approved} = GateDecision.approve(gate, "Unblocked", now: @later)
+      assert approved.status == "approved"
+    end
+
+    test "rejects terminal transitions" do
+      assert {:ok, gate} = GateDecision.new(id: "gate_001", now: @now)
+      assert {:ok, approved} = GateDecision.approve(gate, "Reviewed", now: @later)
+
+      assert {:error, {:invalid_gate_transition, "approved", "rejected"}} =
+               GateDecision.reject(approved, "Changed mind")
+
+      assert {:ok, expired} = GateDecision.new(id: "gate_002", status: "expired", now: @now)
+
+      assert {:error, {:invalid_gate_transition, "expired", "approved"}} =
+               GateDecision.approve(expired, "Too late")
+    end
+
+    test "requires a non-empty reason" do
+      assert {:ok, gate} = GateDecision.new(id: "gate_001", now: @now)
+      assert {:error, :gate_decision_missing_reason} = GateDecision.approve(gate, "")
+      assert {:error, :gate_decision_missing_reason} = GateDecision.reject(gate, nil)
+    end
+  end
+
+  describe "from_map/1" do
+    test "loads persisted JSON-compatible maps" do
+      assert {:ok, gate} =
+               GateDecision.from_map(%{
+                 "id" => "gate_001",
+                 "version" => "1",
+                 "status" => "approved",
+                 "work_item_id" => "work_001",
+                 "run_id" => "run-001",
+                 "node_id" => "approve",
+                 "reason" => "Looks safe",
+                 "requested_by_type" => "daemon",
+                 "requested_by_id" => "worker-1",
+                 "decided_by" => "member:yair",
+                 "decided_at" => @later,
+                 "created_at" => @now,
+                 "updated_at" => @later,
+                 "evidence_refs" => [%{"type" => "attestation", "uri" => "local://att"}]
+               })
+
+      assert gate.id == "gate_001"
+      assert gate.work_item_id == "work_001"
+      assert gate.status == "approved"
+      assert gate.evidence_refs == [%{"type" => "attestation", "uri" => "local://att"}]
+    end
+
+    test "rejects invalid ids, versions, statuses, requesters, and evidence refs" do
+      assert {:error, {:invalid_gate_id, "../escape"}} =
+               GateDecision.from_map(%{"id" => "../escape", "version" => "1"})
+
+      assert {:error, {:missing_gate_version, nil}} =
+               GateDecision.from_map(%{"id" => "gate_001"})
+
+      assert {:error, {:unsupported_gate_version, "2"}} =
+               GateDecision.from_map(%{"id" => "gate_001", "version" => "2"})
+
+      assert {:error, {:invalid_gate_status, "done"}} =
+               GateDecision.from_map(%{"id" => "gate_001", "version" => "1", "status" => "done"})
+
+      assert {:error, {:invalid_gate_requester, :missing_type}} =
+               GateDecision.from_map(%{
+                 "id" => "gate_001",
+                 "version" => "1",
+                 "requested_by_id" => "executor"
+               })
+
+      assert {:error, {:invalid_gate_evidence_ref, "raw log"}} =
+               GateDecision.from_map(%{
+                 "id" => "gate_001",
+                 "version" => "1",
+                 "evidence_refs" => ["raw log"]
+               })
+    end
+  end
+end

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -113,6 +113,17 @@ No cache-prefixed `Sykli.Error` codes are emitted today. Cache failures currentl
 | `work_item_missing_title` | `sykli work create` was called without a title. | public-unstable | `core/lib/sykli/error.ex:602` |
 | `work_item_not_found` | A requested local work item does not exist. | public-unstable | `core/lib/sykli/error.ex:612` |
 
+### gates
+
+| Code | Description | Tier | Emitted from |
+|------|-------------|------|--------------|
+| `gate_decision_missing_reason` | `sykli gate approve` or `sykli gate reject` was called without a non-empty reason. | public-unstable | `core/lib/sykli/error.ex:719` |
+| `gate_not_found` | A requested local gate does not exist. | public-unstable | `core/lib/sykli/error.ex:678` |
+| `invalid_gate_decision` | A local gate command encountered structurally invalid gate data or arguments. | public-unstable | `core/lib/sykli/error.ex:729` |
+| `invalid_gate_id` | A local gate id failed validation, including path traversal attempts. | public-unstable | `core/lib/sykli/error.ex:688` |
+| `invalid_gate_transition` | A terminal or otherwise invalid gate status transition was rejected. | public-unstable | `core/lib/sykli/error.ex:709` |
+| `malformed_gate_json` | A persisted `.sykli/gates/<gate-id>.json` file is not valid JSON. | public-unstable | `core/lib/sykli/error.ex:698` |
+
 ### sdk
 
 | Code | Description | Tier | Emitted from |

--- a/docs/local-state-plane.md
+++ b/docs/local-state-plane.md
@@ -58,8 +58,7 @@ Documented in detail in `docs/false-protocol-schema.md`. Summary:
 - `.sykli/work/items/<id>.json` — local work item state.
 - Work/run links are stored on existing `.sykli/runs/*.json` manifests as
   `work_item_id` and `contract_hash`; work item files do not copy run logs.
-- (Phase 3 of the roadmap) `.sykli/gates/<gate-id>.json` — local gate
-  decision state.
+- `.sykli/gates/<gate-id>.json` — local gate decision state.
 
 The local store is self-contained. A daemon with no coordinator
 connection writes the same `.sykli/` it always did. The local-only mode
@@ -259,6 +258,10 @@ sykli work claim <work-id>
 sykli work note <work-id> "Found likely API breakage"
 sykli run <contract-or-dir> --work <work-id>
 sykli work runs <work-id>
+sykli gates list
+sykli gate show <gate-id>
+sykli gate approve <gate-id> --reason "Evidence reviewed"
+sykli gate reject <gate-id> --reason "Not safe"
 ```
 
 Each command supports `--json` and returns the shared CLI JSON envelope.
@@ -268,6 +271,39 @@ manifest records the work item id and a deterministic `sha256:` contract
 hash computed from canonicalized emitted contract JSON. Detailed evidence remains in
 the normal `.sykli/` run, occurrence, log, and attestation stores; work state
 only points at the run summary.
+
+Local gate decisions live at `.sykli/gates/<gate-id>.json`:
+
+```jsonc
+{
+  "id": "gate_001",
+  "version": "1",
+  "work_item_id": "work_001",
+  "run_id": "run_123",
+  "node_id": "approve-deploy",
+  "status": "waiting",
+  "reason": null,
+  "requested_by_type": "system",
+  "requested_by_id": "executor",
+  "decided_by": null,
+  "decided_at": null,
+  "created_at": "2026-05-09T10:00:00Z",
+  "updated_at": "2026-05-09T10:00:00Z",
+  "evidence_refs": [
+    {"type": "occurrence", "uri": "local://.sykli/occurrence.json"}
+  ]
+}
+```
+
+Allowed gate `status` values are `waiting`, `blocked`, `approved`, `rejected`,
+and `expired`. `waiting` and `blocked` may transition to `approved` or
+`rejected`; `approved`, `rejected`, and `expired` are terminal. Approvals and
+rejections require a reason.
+
+Gate `evidence_refs` are references only. They must not contain raw logs,
+source code, artifacts, environment dumps, secrets, or full stdout/stderr.
+Runtime gate request persistence is a follow-up hookup; this local store and
+CLI are the decision-state foundation.
 
 The roadmap adds local-only state for work items and gates **before**
 networking turns on. That is intentional: a user should be able to:

--- a/docs/local-state-plane.md
+++ b/docs/local-state-plane.md
@@ -300,6 +300,10 @@ and `expired`. `waiting` and `blocked` may transition to `approved` or
 `rejected`; `approved`, `rejected`, and `expired` are terminal. Approvals and
 rejections require a reason.
 
+When a decision is recorded, `decided_by` uses the same compact actor reference
+format accepted by the CLI, such as `member:yair`, `agent:claude`, or
+`daemon:worker-1`.
+
 Gate `evidence_refs` are references only. They must not contain raw logs,
 source code, artifacts, environment dumps, secrets, or full stdout/stderr.
 Runtime gate request persistence is a follow-up hookup; this local store and

--- a/docs/team-mode-roadmap.md
+++ b/docs/team-mode-roadmap.md
@@ -131,27 +131,33 @@ Exit criteria:
 Make approvals and rejections first-class locally. This is the dry run
 of the coordinator's gate flow, but entirely on one machine.
 
-Suggested CLI:
+Local CLI:
 
 ```bash
 sykli gates list
+sykli gate show <gate-id>
 sykli gate approve <gate-id> --reason "Looks safe"
 sykli gate reject <gate-id> --reason "API breakage not acceptable"
 ```
 
-Suggested local path:
+Local path:
 
 ```text
 .sykli/gates/<gate-id>.json
 ```
 
+Status values are `waiting`, `blocked`, `approved`, `rejected`, and `expired`.
+Only `waiting` and `blocked` gates may be approved or rejected. Terminal
+decisions are not silently overwritten.
+
 Exit criteria:
 
-- A blocked run with a gate persists the gate state to disk.
-- A subsequent `sykli gate approve` resumes the run on its next attempt.
-- `sykli explain` shows gate state in human and JSON output.
-- MCP tools `list_gates`, `approve_gate`, `reject_gate` exist
-  (local-only).
+- Local gate decisions persist under `.sykli/gates/<gate-id>.json`.
+- `sykli gates list`, `sykli gate show`, `sykli gate approve`, and
+  `sykli gate reject` support human and `--json` output.
+- Invalid transitions are rejected.
+- Runtime gate request persistence, run resumption, `sykli explain` gate
+  rendering, and MCP gate tools remain follow-up layers.
 
 ## Phase 4 — Coordinator skeleton
 

--- a/eval/oracle/run.sh
+++ b/eval/oracle/run.sh
@@ -1285,6 +1285,123 @@ if begin_case "062" "Work: run with missing work item returns JSON error"; then
   rm -rf "$dir"
 fi
 
+# --- case_063: gates list JSON returns local gate decisions ---
+if begin_case "063" "Gates: list JSON returns local gate decisions"; then
+  dir=$(tmp_workdir)
+  mkdir -p "$dir/.sykli/gates"
+  cat > "$dir/.sykli/gates/gate_001.json" <<'JSON'
+{"id":"gate_001","version":"1","work_item_id":"work_001","run_id":"run_001","node_id":"approve","status":"waiting","reason":null,"requested_by_type":"system","requested_by_id":"executor","decided_by":null,"decided_at":null,"created_at":"2026-05-09T10:00:00Z","updated_at":"2026-05-09T10:00:00Z","evidence_refs":[{"type":"occurrence","uri":"local://.sykli/occurrence.json"}]}
+JSON
+
+  LAST_OUTPUT=$(run_sykli "$dir" gates list --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 0 "$exit_code"; then
+    if assert_json_field "$LAST_OUTPUT" '.ok' "true"; then
+      if assert_json_field "$LAST_OUTPUT" '.data.gates[0].id' "gate_001"; then
+        pass 0
+      fi
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
+# --- case_064: gate show JSON returns one gate ---
+if begin_case "064" "Gates: show JSON returns one gate"; then
+  dir=$(tmp_workdir)
+  mkdir -p "$dir/.sykli/gates"
+  cat > "$dir/.sykli/gates/gate_001.json" <<'JSON'
+{"id":"gate_001","version":"1","work_item_id":"work_001","run_id":"run_001","node_id":"approve","status":"waiting","reason":null,"requested_by_type":"system","requested_by_id":"executor","decided_by":null,"decided_at":null,"created_at":"2026-05-09T10:00:00Z","updated_at":"2026-05-09T10:00:00Z","evidence_refs":[]}
+JSON
+
+  LAST_OUTPUT=$(run_sykli "$dir" gate show gate_001 --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 0 "$exit_code"; then
+    if assert_json_field "$LAST_OUTPUT" '.data.gate.id' "gate_001"; then
+      if assert_json_field "$LAST_OUTPUT" '.data.gate.status' "waiting"; then
+        pass 0
+      fi
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
+# --- case_065: gate approve JSON records decision ---
+if begin_case "065" "Gates: approve JSON records decision"; then
+  dir=$(tmp_workdir)
+  mkdir -p "$dir/.sykli/gates"
+  cat > "$dir/.sykli/gates/gate_001.json" <<'JSON'
+{"id":"gate_001","version":"1","work_item_id":null,"run_id":null,"node_id":"approve","status":"waiting","reason":null,"requested_by_type":null,"requested_by_id":null,"decided_by":null,"decided_at":null,"created_at":"2026-05-09T10:00:00Z","updated_at":"2026-05-09T10:00:00Z","evidence_refs":[]}
+JSON
+
+  LAST_OUTPUT=$(run_sykli "$dir" gate approve gate_001 --reason "Evidence reviewed" --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 0 "$exit_code"; then
+    if assert_json_field "$LAST_OUTPUT" '.data.gate.status' "approved"; then
+      if assert_json_field "$LAST_OUTPUT" '.data.gate.reason' "Evidence reviewed"; then
+        pass 0
+      fi
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
+# --- case_066: gate reject JSON records decision ---
+if begin_case "066" "Gates: reject JSON records decision"; then
+  dir=$(tmp_workdir)
+  mkdir -p "$dir/.sykli/gates"
+  cat > "$dir/.sykli/gates/gate_001.json" <<'JSON'
+{"id":"gate_001","version":"1","work_item_id":null,"run_id":null,"node_id":"approve","status":"waiting","reason":null,"requested_by_type":null,"requested_by_id":null,"decided_by":null,"decided_at":null,"created_at":"2026-05-09T10:00:00Z","updated_at":"2026-05-09T10:00:00Z","evidence_refs":[]}
+JSON
+
+  LAST_OUTPUT=$(run_sykli "$dir" gate reject gate_001 --reason "Not safe" --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 0 "$exit_code"; then
+    if assert_json_field "$LAST_OUTPUT" '.data.gate.status' "rejected"; then
+      if assert_json_field "$LAST_OUTPUT" '.data.gate.reason' "Not safe"; then
+        pass 0
+      fi
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
+# --- case_067: missing gate returns a stable JSON error ---
+if begin_case "067" "Gates: missing gate returns JSON error"; then
+  dir=$(tmp_workdir)
+  LAST_OUTPUT=$(run_sykli "$dir" gate show missing --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 1 "$exit_code"; then
+    if assert_json_field "$LAST_OUTPUT" '.error.code' "gate_not_found"; then
+      pass 0
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
+# --- case_068: invalid gate transition returns a stable JSON error ---
+if begin_case "068" "Gates: invalid transition returns JSON error"; then
+  dir=$(tmp_workdir)
+  mkdir -p "$dir/.sykli/gates"
+  cat > "$dir/.sykli/gates/gate_001.json" <<'JSON'
+{"id":"gate_001","version":"1","work_item_id":null,"run_id":null,"node_id":"approve","status":"approved","reason":"Reviewed","requested_by_type":null,"requested_by_id":null,"decided_by":"member:yair","decided_at":"2026-05-09T10:01:00Z","created_at":"2026-05-09T10:00:00Z","updated_at":"2026-05-09T10:01:00Z","evidence_refs":[]}
+JSON
+
+  LAST_OUTPUT=$(run_sykli "$dir" gate reject gate_001 --reason "No" --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 1 "$exit_code"; then
+    if assert_json_field "$LAST_OUTPUT" '.error.code' "invalid_gate_transition"; then
+      pass 0
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
+# --- case_069: invalid gate id returns a stable JSON error ---
+if begin_case "069" "Gates: invalid gate id returns JSON error"; then
+  dir=$(tmp_workdir)
+  LAST_OUTPUT=$(run_sykli "$dir" gate show "../escape" --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 1 "$exit_code"; then
+    if assert_json_field "$LAST_OUTPUT" '.error.code' "invalid_gate_id"; then
+      pass 0
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
 # ============================================================================
 # Summary
 # ============================================================================

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -16,7 +16,8 @@
     "SDK": "SDK - cross-language parity contract",
     "UI": "UI - visual reset contract",
     "GH": "GitHub - native receiver security contract",
-    "WORK": "Work items - local Team Mode workflow"
+    "WORK": "Work items - local Team Mode workflow",
+    "GATE": "Gates - local Team Mode decision workflow"
   },
   "cases": [
     {
@@ -1612,6 +1613,49 @@
       ],
       "source": "docs/local-state-plane.md; work ids must not escape local state paths",
       "validated_by": "Injected bug: pass --work id into local state path without validation."
+    },
+    {
+      "id": "GATE-001",
+      "name": "local gate decision CLI workflow persists state",
+      "fixture": "empty_dir",
+      "command": "mkdir -p .sykli/gates && printf '%s\\n' '{\"id\":\"gate_001\",\"version\":\"1\",\"work_item_id\":\"work_001\",\"run_id\":\"run_001\",\"node_id\":\"approve\",\"status\":\"waiting\",\"reason\":null,\"requested_by_type\":\"system\",\"requested_by_id\":\"executor\",\"decided_by\":null,\"decided_at\":null,\"created_at\":\"2026-05-09T10:00:00Z\",\"updated_at\":\"2026-05-09T10:00:00Z\",\"evidence_refs\":[{\"type\":\"occurrence\",\"uri\":\"local://.sykli/occurrence.json\"}]}' > .sykli/gates/gate_001.json && printf '%s\\n' '{\"id\":\"gate_002\",\"version\":\"1\",\"work_item_id\":\"work_001\",\"run_id\":\"run_001\",\"node_id\":\"reject\",\"status\":\"waiting\",\"reason\":null,\"requested_by_type\":\"system\",\"requested_by_id\":\"executor\",\"decided_by\":null,\"decided_at\":null,\"created_at\":\"2026-05-09T10:00:00Z\",\"updated_at\":\"2026-05-09T10:00:00Z\",\"evidence_refs\":[]}' > .sykli/gates/gate_002.json && sykli gates list --json | jq -e '(.data.gates | length) == 2 and .data.gates[0].id == \"gate_001\"' >/dev/null && sykli gate show gate_001 --json | jq -e '.data.gate.status == \"waiting\"' >/dev/null && sykli gate approve gate_001 --reason \"Evidence reviewed\" --json | jq -e '.data.gate.status == \"approved\" and .data.gate.reason == \"Evidence reviewed\"' >/dev/null && sykli gate reject gate_002 --reason \"Not safe\" --json | tee gate-reject.json >/dev/null && test -f .sykli/gates/gate_001.json && jq -e '.status == \"approved\" and .reason == \"Evidence reviewed\"' .sykli/gates/gate_001.json >/dev/null && ! grep -q \"secret\" .sykli/gates/gate_001.json && cat gate-reject.json",
+      "shell": true,
+      "expect_exit": 0,
+      "expect_json_jq": [
+        ".ok == true",
+        ".data.source == \"local\"",
+        ".data.gate.status == \"rejected\"",
+        ".data.gate.reason == \"Not safe\""
+      ],
+      "source": "docs/team-mode-roadmap.md Phase 3; docs/local-state-plane.md local gate decision state",
+      "validated_by": "Injected bug: gate CLI does not persist decisions or returns non-envelope JSON; workflow assertions fail."
+    },
+    {
+      "id": "GATE-002",
+      "name": "gate show rejects path traversal ids with JSON error",
+      "fixture": "empty_dir",
+      "command": "sykli gate show ../escape --json",
+      "expect_exit": 1,
+      "expect_json_jq": [
+        ".ok == false",
+        ".error.code == \"invalid_gate_id\""
+      ],
+      "source": "docs/local-state-plane.md; local gate ids must not escape .sykli/gates",
+      "validated_by": "Injected bug: pass raw gate ids into file path construction; traversal id is not rejected."
+    },
+    {
+      "id": "GATE-003",
+      "name": "terminal gate transition fails clearly",
+      "fixture": "empty_dir",
+      "command": "mkdir -p .sykli/gates && printf '%s\\n' '{\"id\":\"gate_001\",\"version\":\"1\",\"work_item_id\":null,\"run_id\":null,\"node_id\":\"approve\",\"status\":\"approved\",\"reason\":\"Reviewed\",\"requested_by_type\":null,\"requested_by_id\":null,\"decided_by\":\"member:yair\",\"decided_at\":\"2026-05-09T10:01:00Z\",\"created_at\":\"2026-05-09T10:00:00Z\",\"updated_at\":\"2026-05-09T10:01:00Z\",\"evidence_refs\":[]}' > .sykli/gates/gate_001.json && sykli gate reject gate_001 --reason \"No\" --json",
+      "shell": true,
+      "expect_exit": 1,
+      "expect_json_jq": [
+        ".ok == false",
+        ".error.code == \"invalid_gate_transition\""
+      ],
+      "source": "docs/team-mode-roadmap.md Phase 3; terminal gate decisions must not be silently overwritten",
+      "validated_by": "Injected bug: approve/reject overwrites terminal gate state; invalid transition assertion fails."
     },
     {
       "id": "GH-001",

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -1625,7 +1625,8 @@
         ".ok == true",
         ".data.source == \"local\"",
         ".data.gate.status == \"rejected\"",
-        ".data.gate.reason == \"Not safe\""
+        ".data.gate.reason == \"Not safe\"",
+        ".data.gate.decided_by | contains(\":\")"
       ],
       "source": "docs/team-mode-roadmap.md Phase 3; docs/local-state-plane.md local gate decision state",
       "validated_by": "Injected bug: gate CLI does not persist decisions or returns non-envelope JSON; workflow assertions fail."

--- a/test/blackbox/run.sh
+++ b/test/blackbox/run.sh
@@ -429,7 +429,7 @@ echo -e "${DIM}Dataset: $(jq '.cases | length' "$DATASET") test cases${RESET}"
 echo ""
 
 # Run categories in order
-for category in POS NEG SYS INT PERF LOAD ABN CACHE JSON DET SDK UI GH WORK; do
+for category in POS NEG SYS INT PERF LOAD ABN CACHE JSON DET SDK UI GH WORK GATE; do
   cases=$(jq -c ".cases[] | select(.id | startswith(\"$category\"))" "$DATASET")
   if [ -z "$cases" ]; then continue; fi
 


### PR DESCRIPTION
## Summary

This PR adds the local Team Mode gate decision layer. Gates now have a versioned local model, a file-backed `.sykli/gates/<gate-id>.json` store, and CLI commands for listing, showing, approving, and rejecting local gate decisions. This is local-only: no coordinator, network sync, daemon join, MCP, or remote execution behavior is introduced.

## Why

Gates are decision boundaries in execution contracts. Before Sykli can sync gate approvals through a team coordinator, it needs honest local decision state that can be persisted, inspected, and controlled. Manual gate decisions must not be silently overwritten or treated as successful without an explicit approval/rejection record.

## What changed

- Added `Sykli.GateDecision` for versioned local gate decision records.
- Added `Sykli.Gate.Store` backed by `.sykli/gates/<gate-id>.json`.
- Added strict gate status validation and transition rules:
  - `waiting` / `blocked` may transition to `approved` or `rejected`
  - `approved`, `rejected`, and `expired` are terminal
- Added `sykli gates list [--status STATUS]`.
- Added `sykli gate show <gate-id>`.
- Added `sykli gate approve <gate-id> --reason ...`.
- Added `sykli gate reject <gate-id> --reason ...`.
- Added `--json` support for every gate command.
- Added structured errors for missing gates, invalid IDs, malformed JSON, missing reasons, invalid decisions, and invalid transitions.
- Updated docs and README to document local gate state, commands, JSON shape, transition semantics, and public error codes.

## Runtime integration status

Runtime gate integration is deferred. This PR intentionally adds the local decision model/store/CLI only.

The existing executor gate path does not yet have a clean local state hook carrying the full run/work/gate lifecycle context needed to persist `.sykli/gates/<gate-id>.json` without broad executor changes. Existing runtime gates still do not silently pass; this PR does not weaken that behavior. The follow-up should thread gate request creation through execution once run/work context is available in the gate lifecycle.

## Validation

- [x] `python3 -m json.tool test/blackbox/dataset.json >/dev/null` passed
- [x] `mix format --check-formatted` passed
- [x] `git diff --check` passed
- [x] `mix test test/sykli/gate_decision_test.exs test/sykli/gate/store_test.exs test/sykli/cli/gate_test.exs test/sykli/cli_test.exs` passed: 56 tests, 0 failures
- [x] `mix escript.build` passed
- [x] `eval/oracle/run.sh --case 063` passed
- [x] `eval/oracle/run.sh --case 064` passed
- [x] `eval/oracle/run.sh --case 065` passed
- [x] `eval/oracle/run.sh --case 066` passed
- [x] `eval/oracle/run.sh --case 067` passed
- [x] `eval/oracle/run.sh --case 068` passed
- [x] `eval/oracle/run.sh --case 069` passed
- [x] `test/blackbox/run.sh --filter=GATE` passed: 3 passed, 0 failed, 155 skipped
- [x] `mix test` passed: 1 property, 1606 tests, 0 failures, 1 skipped, 13 excluded

Full conformance was not run because this PR does not change contract schemas, SDK output, or conformance fixtures.

## Oracle coverage

Added oracle cases:

- 063: gates list JSON returns local gate decisions
- 064: gate show JSON returns one gate
- 065: gate approve JSON records decision
- 066: gate reject JSON records decision
- 067: missing gate returns JSON error
- 068: invalid transition returns JSON error
- 069: invalid gate id returns JSON error

## Blackbox coverage

Added `GATE` blackbox category and scenarios:

- `GATE-001`: local gate decision CLI workflow persists state
- `GATE-002`: gate show rejects path traversal ids with JSON error
- `GATE-003`: terminal gate transition fails clearly

## Out of scope

- No coordinator
- No networking
- No daemon join
- No team sync
- No run summary sync to coordinator
- No gate approval sync through coordinator
- No MCP
- No Kubernetes deployment
- No remote execution
- No web UI
- No policy engine

## Next PR

Add self-hosted coordinator skeleton and store:

- `Sykli.Coordinator.Application`
- `Sykli.Coordinator.Router`
- `Sykli.Coordinator.Store`
- health endpoint
- org/team endpoints
- work item endpoints
- token auth
- coordinator API tests
- oracle JSON expectations
- blackbox service workflow if supported