### PR TITLE
Add daemon join and heartbeat sync

### DIFF
--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -2634,6 +2634,12 @@ defmodule Sykli.CLI do
     end
   end
 
+  defp handle_daemon(["join" | args]) do
+    ["join" | args]
+    |> Sykli.Daemon.Join.run()
+    |> halt()
+  end
+
   defp handle_daemon(["stop"]) do
     IO.puts("#{IO.ANSI.cyan()}Stopping SYKLI daemon...#{IO.ANSI.reset()}")
 
@@ -2654,6 +2660,16 @@ defmodule Sykli.CLI do
 
   defp handle_daemon(["status"]) do
     print_daemon_status()
+    halt(0)
+  end
+
+  defp handle_daemon(["status", "--json"]) do
+    print_daemon_status_json()
+    halt(0)
+  end
+
+  defp handle_daemon(["--json", "status"]) do
+    print_daemon_status_json()
     halt(0)
   end
 
@@ -2744,11 +2760,13 @@ defmodule Sykli.CLI do
       start --labels=<l>  Start with node labels
       stop               Stop the daemon
       status             Show daemon status
+      join               Join a self-hosted coordinator
 
     Examples:
       sykli daemon start                  Start full daemon (default)
       sykli daemon start --role worker    Start worker-only daemon
       sykli daemon start --labels=docker,gpu  Start with labels
+      sykli daemon join --coordinator https://sykli.internal --org false-systems --team platform
       sykli daemon start -f               Start in foreground
       sykli daemon status                 Check if daemon is running
       sykli daemon stop                   Stop the daemon
@@ -2803,6 +2821,37 @@ defmodule Sykli.CLI do
             IO.puts("  Run 'sykli daemon start' to start")
         end
     end
+  end
+
+  defp print_daemon_status_json do
+    daemon =
+      case Sykli.Daemon.status() do
+        {:running, info} ->
+          %{
+            status: "running",
+            pid: info.pid,
+            pid_file: info.pid_file,
+            node: if(info.node, do: Atom.to_string(info.node), else: nil),
+            role:
+              if(info.node, do: Sykli.Daemon.node_role(info.node) |> Atom.to_string(), else: nil)
+          }
+
+        {:stopped, info} ->
+          %{
+            status: "stopped",
+            reason: Atom.to_string(info.reason),
+            stale_pid: Map.get(info, :stale_pid),
+            pid_file: Map.get(info, :pid_file)
+          }
+      end
+
+    session =
+      case Sykli.Daemon.SessionStore.read() do
+        {:ok, data} -> Map.drop(data, ["token"])
+        {:error, _reason} -> nil
+      end
+
+    IO.puts(JsonResponse.ok(%{daemon: daemon, coordinator_session: session}))
   end
 
   defp format_role(:full), do: "full (execute + coordinate)"

--- a/core/lib/sykli/coordinator/client.ex
+++ b/core/lib/sykli/coordinator/client.ex
@@ -1,0 +1,61 @@
+defmodule Sykli.Coordinator.Client do
+  @moduledoc """
+  Small :httpc-backed client for the self-hosted Team Mode coordinator.
+  """
+
+  @timeout_ms 15_000
+
+  def post_json(base_url, path, token, body) do
+    request_json(:post, base_url, path, token, body)
+  end
+
+  def get_json(base_url, path, token) do
+    request_json(:get, base_url, path, token, nil)
+  end
+
+  def request_json(method, base_url, path, token, body) do
+    url = build_url(base_url, path)
+    headers = headers(token)
+    request = request_tuple(method, url, headers, body)
+    http_opts = [{:timeout, @timeout_ms}] ++ Sykli.HTTP.ssl_opts(url)
+
+    case :httpc.request(method, request, http_opts, []) do
+      {:ok, {{_version, status, _reason}, _headers, response_body}} ->
+        decode_response(status, response_body)
+
+      {:error, reason} ->
+        {:error, {:coordinator_unavailable, reason}}
+    end
+  end
+
+  defp request_tuple(:get, url, headers, nil), do: {String.to_charlist(url), headers}
+
+  defp request_tuple(:post, url, headers, body) do
+    {String.to_charlist(url), headers, ~c"application/json", Jason.encode!(body)}
+  end
+
+  defp headers(token) do
+    [
+      {~c"authorization", ~c"Bearer " ++ String.to_charlist(token)},
+      {~c"accept", ~c"application/json"}
+    ]
+  end
+
+  defp build_url(base_url, path) do
+    base = String.trim_trailing(base_url, "/")
+    path = "/" <> String.trim_leading(path, "/")
+    base <> path
+  end
+
+  defp decode_response(status, body) do
+    with {:ok, decoded} <- Jason.decode(to_string(body)) do
+      case decoded do
+        %{"ok" => true, "data" => data} when status in 200..299 -> {:ok, data}
+        %{"ok" => false, "error" => error} -> {:error, {:coordinator_error, status, error}}
+        _ -> {:error, {:invalid_coordinator_response, decoded}}
+      end
+    else
+      {:error, _reason} -> {:error, :invalid_coordinator_response}
+    end
+  end
+end

--- a/core/lib/sykli/daemon/join.ex
+++ b/core/lib/sykli/daemon/join.ex
@@ -43,12 +43,14 @@ defmodule Sykli.Daemon.Join do
   end
 
   def build_join_payload(opts, runtime_opts \\ []) do
-    with {:ok, _coordinator} <- required_opt(opts, :coordinator, :daemon_join_missing_coordinator),
+    with {:ok, _coordinator} <-
+           required_opt(opts, :coordinator, :daemon_join_missing_coordinator),
          {:ok, org} <- required_opt(opts, :org, :daemon_join_missing_org),
          {:ok, team} <- required_opt(opts, :team, :daemon_join_missing_team),
          {:ok, _token} <- required_opt(opts, :token, :daemon_join_missing_token),
          {:ok, labels} <- parse_list(Keyword.get(opts, :labels, ""), :labels),
-         {:ok, capabilities} <- parse_capabilities(Keyword.get(opts, :capabilities), runtime_opts),
+         {:ok, capabilities} <-
+           parse_capabilities(Keyword.get(opts, :capabilities), runtime_opts),
          {:ok, daemon_id} <- daemon_id(opts) do
       {:ok,
        %{

--- a/core/lib/sykli/daemon/join.ex
+++ b/core/lib/sykli/daemon/join.ex
@@ -1,0 +1,325 @@
+defmodule Sykli.Daemon.Join do
+  @moduledoc """
+  CLI/client flow for joining a self-hosted Team Mode coordinator.
+  """
+
+  alias Sykli.CLI.JsonResponse
+  alias Sykli.Coordinator.Client
+  alias Sykli.Daemon.SessionStore
+  alias Sykli.Error
+  alias Sykli.Error.Formatter
+
+  def run(args, runtime_opts \\ []) do
+    case parse(args) do
+      {:ok, :help, _opts} ->
+        print_help()
+        0
+
+      {:ok, opts} ->
+        join(opts, runtime_opts)
+
+      {:error, reason, opts} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  def join(opts, runtime_opts \\ []) do
+    json? = Keyword.get(opts, :json, false)
+
+    with {:ok, payload} <- build_join_payload(opts, runtime_opts),
+         {:ok, token} <- required_opt(opts, :token, :daemon_join_missing_token),
+         {:ok, data} <-
+           apply(client(runtime_opts), :post_json, [
+             Keyword.fetch!(opts, :coordinator),
+             "/v1/daemon-sessions",
+             token,
+             payload
+           ]),
+         {:ok, persisted} <- persist_session(opts, payload, data, runtime_opts) do
+      output_success(persisted, json?)
+    else
+      {:error, reason} -> output_error(reason, json?)
+    end
+  end
+
+  def build_join_payload(opts, runtime_opts \\ []) do
+    with {:ok, _coordinator} <- required_opt(opts, :coordinator, :daemon_join_missing_coordinator),
+         {:ok, org} <- required_opt(opts, :org, :daemon_join_missing_org),
+         {:ok, team} <- required_opt(opts, :team, :daemon_join_missing_team),
+         {:ok, _token} <- required_opt(opts, :token, :daemon_join_missing_token),
+         {:ok, labels} <- parse_list(Keyword.get(opts, :labels, ""), :labels),
+         {:ok, capabilities} <- parse_capabilities(Keyword.get(opts, :capabilities), runtime_opts),
+         {:ok, daemon_id} <- daemon_id(opts) do
+      {:ok,
+       %{
+         "daemon_id" => daemon_id,
+         "org" => org,
+         "team" => team,
+         "labels" => labels,
+         "capabilities" => capabilities,
+         "version" => version(runtime_opts),
+         "accepts_remote_work" => Keyword.get(opts, :accepts_remote_work, false)
+       }}
+    end
+  end
+
+  def heartbeat_payload(session, attrs \\ %{}) do
+    %{
+      "session_id" => session["session_id"],
+      "status" => Map.get(attrs, "status", "available"),
+      "current_work_item_id" => Map.get(attrs, "current_work_item_id"),
+      "labels" => Map.get(attrs, "labels", session["labels"] || []),
+      "capabilities" => Map.get(attrs, "capabilities", session["capabilities"] || []),
+      "last_run_id" => Map.get(attrs, "last_run_id")
+    }
+  end
+
+  defp persist_session(opts, payload, data, runtime_opts) do
+    session = %{
+      "coordinator" => Keyword.fetch!(opts, :coordinator),
+      "org" => payload["org"],
+      "team" => payload["team"],
+      "daemon_id" => payload["daemon_id"],
+      "session_id" => data["session_id"],
+      "team_id" => data["team_id"],
+      "heartbeat_interval_seconds" => data["heartbeat_interval_seconds"],
+      "policy" => data["policy"],
+      "labels" => payload["labels"],
+      "capabilities" => payload["capabilities"],
+      "accepts_remote_work" => payload["accepts_remote_work"],
+      "joined_at" => now(runtime_opts)
+    }
+
+    session_store(runtime_opts).write(session, path: Keyword.get(opts, :path))
+  end
+
+  defp output_success(session, true) do
+    IO.puts(JsonResponse.ok(%{session: public_session(session)}))
+    0
+  end
+
+  defp output_success(session, false) do
+    IO.puts("Joined coordinator #{session["coordinator"]}")
+    IO.puts("session_id: #{session["session_id"]}")
+    IO.puts("team_id: #{session["team_id"]}")
+    IO.puts("accepts_remote_work: #{session["accepts_remote_work"]}")
+    0
+  end
+
+  defp public_session(session), do: Map.drop(session, ["token"])
+
+  defp parse(args) do
+    {opts, positionals, error} = parse_flags(args, [], [])
+
+    cond do
+      error != nil -> {:error, error, opts}
+      positionals in [[], ["--help"], ["-h"]] -> {:ok, :help, opts}
+      positionals in [["join", "--help"], ["join", "-h"]] -> {:ok, :help, opts}
+      positionals == ["join"] -> {:ok, opts}
+      true -> {:error, {:invalid_daemon_join_command, Enum.join(positionals, " ")}, opts}
+    end
+  end
+
+  defp parse_flags([], opts, positionals),
+    do: {Enum.reverse(opts), Enum.reverse(positionals), nil}
+
+  defp parse_flags(["--json" | rest], opts, pos),
+    do: parse_flags(rest, [{:json, true} | opts], pos)
+
+  defp parse_flags(["--help" | rest], opts, pos), do: parse_flags(rest, opts, ["--help" | pos])
+  defp parse_flags(["-h" | rest], opts, pos), do: parse_flags(rest, opts, ["-h" | pos])
+
+  defp parse_flags(["--accept-remote-work" | rest], opts, pos),
+    do: parse_flags(rest, [{:accepts_remote_work, true} | opts], pos)
+
+  defp parse_flags(["--coordinator", value | rest], opts, pos),
+    do: parse_flags(rest, [{:coordinator, value} | opts], pos)
+
+  defp parse_flags([<<"--coordinator=", value::binary>> | rest], opts, pos),
+    do: parse_flags(rest, [{:coordinator, value} | opts], pos)
+
+  defp parse_flags(["--org", value | rest], opts, pos),
+    do: parse_flags(rest, [{:org, value} | opts], pos)
+
+  defp parse_flags([<<"--org=", value::binary>> | rest], opts, pos),
+    do: parse_flags(rest, [{:org, value} | opts], pos)
+
+  defp parse_flags(["--team", value | rest], opts, pos),
+    do: parse_flags(rest, [{:team, value} | opts], pos)
+
+  defp parse_flags([<<"--team=", value::binary>> | rest], opts, pos),
+    do: parse_flags(rest, [{:team, value} | opts], pos)
+
+  defp parse_flags(["--token", value | rest], opts, pos),
+    do: parse_flags(rest, [{:token, value} | opts], pos)
+
+  defp parse_flags([<<"--token=", value::binary>> | rest], opts, pos),
+    do: parse_flags(rest, [{:token, value} | opts], pos)
+
+  defp parse_flags(["--labels", value | rest], opts, pos),
+    do: parse_flags(rest, [{:labels, value} | opts], pos)
+
+  defp parse_flags([<<"--labels=", value::binary>> | rest], opts, pos),
+    do: parse_flags(rest, [{:labels, value} | opts], pos)
+
+  defp parse_flags(["--capabilities", value | rest], opts, pos),
+    do: parse_flags(rest, [{:capabilities, value} | opts], pos)
+
+  defp parse_flags([<<"--capabilities=", value::binary>> | rest], opts, pos),
+    do: parse_flags(rest, [{:capabilities, value} | opts], pos)
+
+  defp parse_flags(["--name", value | rest], opts, pos),
+    do: parse_flags(rest, [{:name, value} | opts], pos)
+
+  defp parse_flags([<<"--name=", value::binary>> | rest], opts, pos),
+    do: parse_flags(rest, [{:name, value} | opts], pos)
+
+  defp parse_flags([<<"--", _::binary>> = flag | _rest], opts, pos),
+    do: {Enum.reverse(opts), Enum.reverse(pos), {:unknown_daemon_join_flag, flag}}
+
+  defp parse_flags([arg | rest], opts, pos), do: parse_flags(rest, opts, [arg | pos])
+
+  defp required_opt(opts, key, reason) do
+    case Keyword.get(opts, key) || env_for(key) do
+      value when is_binary(value) ->
+        value = String.trim(value)
+        if value == "", do: {:error, reason}, else: {:ok, value}
+
+      _ ->
+        {:error, reason}
+    end
+  end
+
+  defp env_for(:token), do: System.get_env("SYKLI_TEAM_TOKEN")
+  defp env_for(_key), do: nil
+
+  defp parse_capabilities(nil, runtime_opts),
+    do: {:ok, Keyword.get(runtime_opts, :default_capabilities, ["local"])}
+
+  defp parse_capabilities(value, _runtime_opts), do: parse_list(value, :capabilities)
+
+  defp parse_list(value, field) when is_binary(value) do
+    values =
+      value
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+
+    if Enum.all?(values, &valid_list_value?/1),
+      do: {:ok, values},
+      else: {:error, {:invalid_daemon_list, field}}
+  end
+
+  defp valid_list_value?(value),
+    do: String.length(value) <= 128 and Regex.match?(~r/^[a-zA-Z0-9._-]+$/, value)
+
+  defp daemon_id(opts) do
+    value = Keyword.get(opts, :name) || Sykli.Daemon.get_hostname()
+    value = String.downcase(value)
+
+    if Regex.match?(~r/^[a-z0-9._-]{1,128}$/, value),
+      do: {:ok, value},
+      else: {:error, {:invalid_daemon_id, value}}
+  end
+
+  defp version(runtime_opts),
+    do: Keyword.get(runtime_opts, :version, Application.spec(:sykli, :vsn) |> to_string())
+
+  defp now(runtime_opts) do
+    case Keyword.get(runtime_opts, :now, DateTime.utc_now()) do
+      %DateTime{} = dt -> DateTime.to_iso8601(dt)
+      value when is_binary(value) -> value
+    end
+  end
+
+  defp client(runtime_opts), do: Keyword.get(runtime_opts, :client, Client)
+  defp session_store(runtime_opts), do: Keyword.get(runtime_opts, :session_store, SessionStore)
+
+  defp output_error(reason, json?) do
+    error = join_error(reason)
+
+    if json? do
+      IO.puts(JsonResponse.error(error))
+    else
+      IO.puts(:stderr, Formatter.format(error))
+    end
+
+    1
+  end
+
+  defp join_error(:daemon_join_missing_coordinator),
+    do: validation("daemon.join_missing_coordinator", "daemon join requires --coordinator")
+
+  defp join_error(:daemon_join_missing_org),
+    do: validation("daemon.join_missing_org", "daemon join requires --org")
+
+  defp join_error(:daemon_join_missing_team),
+    do: validation("daemon.join_missing_team", "daemon join requires --team")
+
+  defp join_error(:daemon_join_missing_token),
+    do:
+      validation("daemon.join_missing_token", "daemon join requires --token or SYKLI_TEAM_TOKEN")
+
+  defp join_error({:invalid_daemon_id, id}),
+    do: validation("daemon.invalid_id", "invalid daemon id: #{inspect(id)}")
+
+  defp join_error({:invalid_daemon_list, field}),
+    do: validation("daemon.invalid_join_payload", "invalid comma-separated #{field}")
+
+  defp join_error({:unknown_daemon_join_flag, flag}),
+    do: validation("daemon.invalid_join_command", "unknown daemon join flag: #{flag}")
+
+  defp join_error({:invalid_daemon_join_command, command}),
+    do: validation("daemon.invalid_join_command", "invalid daemon join command: #{command}")
+
+  defp join_error({:coordinator_unavailable, reason}),
+    do: runtime("daemon.coordinator_unavailable", "coordinator unavailable: #{inspect(reason)}")
+
+  defp join_error({:coordinator_error, 401, _error}),
+    do:
+      runtime("daemon.coordinator_unauthorized", "coordinator rejected daemon join authorization")
+
+  defp join_error({:coordinator_error, _status, %{"message" => message}}),
+    do: runtime("daemon.coordinator_error", "coordinator rejected daemon join: #{message}")
+
+  defp join_error(:invalid_coordinator_response),
+    do: runtime("daemon.invalid_coordinator_response", "coordinator returned invalid JSON")
+
+  defp join_error({:invalid_coordinator_response, _}),
+    do:
+      runtime(
+        "daemon.invalid_coordinator_response",
+        "coordinator returned an unexpected JSON shape"
+      )
+
+  defp join_error(reason),
+    do: runtime("daemon.join_failed", "daemon join failed: #{inspect(reason)}")
+
+  defp validation(code, message),
+    do: %Error{code: code, type: :validation, message: message, step: :validate, hints: []}
+
+  defp runtime(code, message),
+    do: %Error{code: code, type: :runtime, message: message, step: :setup, hints: []}
+
+  defp print_help do
+    IO.puts("""
+    Usage: sykli daemon join --coordinator URL --org ORG --team TEAM --token TOKEN [options]
+
+    Join a self-hosted Team Mode coordinator. This registers daemon presence
+    only; it does not enable remote execution.
+
+    Options:
+      --json                    Output JSON
+      --coordinator URL         Coordinator base URL
+      --org SLUG                Org slug
+      --team SLUG               Team slug
+      --token TOKEN             Team token; SYKLI_TEAM_TOKEN is also supported
+      --labels LIST             Comma-separated labels, e.g. macos,docker
+      --capabilities LIST       Comma-separated capabilities, default: local
+      --name NAME               Stable daemon id, default: hostname
+      --accept-remote-work      Explicitly advertise remote-work acceptance
+
+    Remote work is disabled by default.
+    """)
+  end
+end

--- a/core/lib/sykli/daemon/session_store.ex
+++ b/core/lib/sykli/daemon/session_store.ex
@@ -1,0 +1,54 @@
+defmodule Sykli.Daemon.SessionStore do
+  @moduledoc """
+  Local persistence for daemon coordinator session metadata.
+
+  The store intentionally does not persist the coordinator token. Tokens must
+  come from the environment, one-shot CLI flags, or a future secret store.
+  """
+
+  @session_version 1
+
+  def path(opts \\ []) do
+    base = Keyword.get(opts, :path) || Path.join([File.cwd!(), ".sykli"])
+    Path.join([base, "daemon", "session.json"])
+  end
+
+  def write(session, opts \\ []) when is_map(session) do
+    path = path(opts)
+    data = Map.put(session, "version", @session_version)
+
+    with :ok <- File.mkdir_p(Path.dirname(path)),
+         :ok <- File.write(path, Jason.encode!(data, pretty: true)),
+         :ok <- restrict_permissions(path) do
+      {:ok, data}
+    end
+  end
+
+  def read(opts \\ []) do
+    path = path(opts)
+
+    with {:ok, body} <- File.read(path),
+         {:ok, data} <- Jason.decode(body),
+         :ok <- validate(data) do
+      {:ok, data}
+    else
+      {:error, :enoent} -> {:error, :daemon_session_not_found}
+      {:error, %Jason.DecodeError{}} -> {:error, :daemon_session_malformed}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp validate(%{"version" => @session_version, "session_id" => id})
+       when is_binary(id) and id != "",
+       do: :ok
+
+  defp validate(_data), do: {:error, :daemon_session_invalid}
+
+  defp restrict_permissions(path) do
+    case :file.change_mode(String.to_charlist(path), 0o600) do
+      :ok -> :ok
+      {:error, :enoent} -> {:error, :enoent}
+      {:error, _reason} -> :ok
+    end
+  end
+end

--- a/core/lib/sykli/team_coordinator/router.ex
+++ b/core/lib/sykli/team_coordinator/router.ex
@@ -3,8 +3,8 @@ defmodule Sykli.TeamCoordinator.Router do
   Plug router for the self-hosted Team Mode coordinator skeleton.
 
   This HTTP surface coordinates org/team/work metadata only. It deliberately
-  exposes no execution, shell, log upload, artifact upload, daemon session, run,
-  gate, or evidence endpoints in this PR.
+  exposes no execution, shell, log upload, artifact upload, run, gate, or
+  evidence endpoints.
   """
 
   import Plug.Conn
@@ -118,6 +118,50 @@ defmodule Sykli.TeamCoordinator.Router do
     end
   end
 
+  defp route_v1(%Plug.Conn{method: "POST", path_info: ["v1", "daemon-sessions"]} = conn, opts) do
+    with {:ok, body, conn} <- read_json(conn),
+         {:ok, response, _session} <- Store.create_daemon_session(store(opts), body) do
+      send_json(conn, 201, response)
+    else
+      {:error, reason} -> send_error(conn, reason)
+    end
+  end
+
+  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "daemon-sessions"]} = conn, opts) do
+    conn = fetch_query_params(conn)
+
+    filters =
+      conn.query_params
+      |> Map.take(["org_id", "team_id"])
+      |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
+      |> Map.new()
+
+    with {:ok, sessions} <- Store.list_daemon_sessions(store(opts), filters) do
+      send_json(conn, 200, %{items: sessions})
+    end
+  end
+
+  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "daemon-sessions", id]} = conn, opts) do
+    with {:ok, session} <- Store.get_daemon_session(store(opts), id) do
+      send_json(conn, 200, %{daemon_session: session})
+    else
+      {:error, reason} -> send_error(conn, reason)
+    end
+  end
+
+  defp route_v1(
+         %Plug.Conn{method: "POST", path_info: ["v1", "daemon-sessions", id, "heartbeat"]} =
+           conn,
+         opts
+       ) do
+    with {:ok, body, conn} <- read_json(conn),
+         {:ok, heartbeat, _session} <- Store.heartbeat_daemon_session(store(opts), id, body) do
+      send_json(conn, 200, heartbeat)
+    else
+      {:error, reason} -> send_error(conn, reason)
+    end
+  end
+
   defp route_v1(conn, _opts), do: send_error(conn, :coordinator_route_not_found)
 
   defp read_json(conn) do
@@ -171,6 +215,11 @@ defmodule Sykli.TeamCoordinator.Router do
   defp status_for({:invalid_assignment_type, _type}), do: 400
   defp status_for({:invalid_work_item_id, _id}), do: 400
   defp status_for({:work_item_already_claimed, _id, _assignment}), do: 409
+  defp status_for({:invalid_daemon_id, _id}), do: 400
+  defp status_for({:invalid_daemon_list_field, _field}), do: 400
+  defp status_for({:invalid_daemon_status, _status}), do: 400
+  defp status_for({:invalid_daemon_session_id, _id}), do: 400
+  defp status_for({:daemon_session_not_found, _id}), do: 404
   defp status_for(_reason), do: 500
 
   defp coordinator_error(:coordinator_unauthorized),
@@ -223,6 +272,26 @@ defmodule Sykli.TeamCoordinator.Router do
 
   defp coordinator_error({:work_item_already_claimed, id, assignment}),
     do: Error.work_item_already_claimed(id, assignment)
+
+  defp coordinator_error({:invalid_daemon_id, id}),
+    do: error("coordinator.invalid_daemon_id", "invalid daemon id: #{inspect(id)}")
+
+  defp coordinator_error({:invalid_daemon_list_field, field}),
+    do:
+      error(
+        "coordinator.invalid_daemon_payload",
+        "daemon field must be a list of non-empty strings: #{field}"
+      )
+
+  defp coordinator_error({:invalid_daemon_status, status}),
+    do: error("coordinator.invalid_daemon_status", "invalid daemon status: #{inspect(status)}")
+
+  defp coordinator_error({:invalid_daemon_session_id, id}),
+    do:
+      error("coordinator.invalid_daemon_session_id", "invalid daemon session id: #{inspect(id)}")
+
+  defp coordinator_error({:daemon_session_not_found, id}),
+    do: error("coordinator.daemon_session_not_found", "daemon session was not found: #{id}")
 
   defp coordinator_error(reason),
     do: error("coordinator.internal_error", "coordinator failed: #{inspect(reason)}")

--- a/core/lib/sykli/team_coordinator/store.ex
+++ b/core/lib/sykli/team_coordinator/store.ex
@@ -12,6 +12,8 @@ defmodule Sykli.TeamCoordinator.Store do
   alias Sykli.WorkItem
 
   @assignment_types WorkItem.assignment_types()
+  @heartbeat_statuses ~w(available busy offline degraded draining)
+  @heartbeat_interval_seconds 15
 
   def start_link(opts \\ []) do
     {server_opts, init_opts} = Keyword.split(opts, [:name])
@@ -33,6 +35,18 @@ defmodule Sykli.TeamCoordinator.Store do
     do: GenServer.call(server, {:claim_work_item, id, attrs})
 
   def add_note(server, id, attrs), do: GenServer.call(server, {:add_note, id, attrs})
+
+  def create_daemon_session(server, attrs),
+    do: GenServer.call(server, {:create_daemon_session, attrs})
+
+  def list_daemon_sessions(server, filters \\ %{}),
+    do: GenServer.call(server, {:list_daemon_sessions, filters})
+
+  def get_daemon_session(server, id), do: GenServer.call(server, {:get_daemon_session, id})
+
+  def heartbeat_daemon_session(server, id, attrs),
+    do: GenServer.call(server, {:heartbeat_daemon_session, id, attrs})
+
   def audit_log(server), do: GenServer.call(server, :audit_log)
 
   @impl true
@@ -47,6 +61,8 @@ defmodule Sykli.TeamCoordinator.Store do
        teams_by_org_slug: %{},
        work_items: %{},
        notes_by_work_item: %{},
+       daemon_sessions: %{},
+       daemon_sessions_by_identity: %{},
        audit_log: []
      }}
   end
@@ -209,8 +225,113 @@ defmodule Sykli.TeamCoordinator.Store do
     end
   end
 
+  def handle_call({:create_daemon_session, attrs}, _from, state) do
+    with {:ok, org_id} <- org_id_from_join(state, attrs),
+         {:ok, team_id} <- team_id_from_join(state, attrs, org_id),
+         {:ok, daemon_id} <- required_daemon_id(attrs),
+         {:ok, labels} <- optional_string_list(attrs, "labels"),
+         {:ok, capabilities} <- optional_string_list(attrs, "capabilities"),
+         {:ok, version} <- required_string(attrs, "version"),
+         {:ok, accepts_remote_work} <- optional_boolean(attrs, "accepts_remote_work", false) do
+      now = now(state)
+      session_id = id(state)
+      identity = {org_id, team_id, daemon_id}
+
+      session = %{
+        "id" => session_id,
+        "session_id" => session_id,
+        "org_id" => org_id,
+        "team_id" => team_id,
+        "daemon_id" => daemon_id,
+        "display_name" => blank_to_nil(Map.get(attrs, "display_name")) || daemon_id,
+        "status" => "available",
+        "labels" => labels,
+        "capabilities" => capabilities,
+        "version" => version,
+        "accepts_remote_work" => accepts_remote_work,
+        "current_work_item_id" => nil,
+        "last_run_id" => nil,
+        "last_seen_at" => now,
+        "created_at" => now,
+        "updated_at" => now,
+        "superseded_by" => nil
+      }
+
+      state =
+        state
+        |> supersede_existing_daemon(identity, session_id, now)
+        |> put_in([:daemon_sessions, session_id], session)
+        |> put_in([:daemon_sessions_by_identity, identity], session_id)
+        |> audit("daemon.joined", "daemon_session", session_id, org_id, team_id)
+
+      {:reply, {:ok, session_response(session), session}, state}
+    else
+      {:error, reason} -> {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call({:list_daemon_sessions, filters}, _from, state) do
+    sessions =
+      state.daemon_sessions
+      |> sorted_values()
+      |> Enum.filter(fn session ->
+        filter_match?(session, "org_id", Map.get(filters, "org_id")) and
+          filter_match?(session, "team_id", Map.get(filters, "team_id"))
+      end)
+
+    {:reply, {:ok, sessions}, state}
+  end
+
+  def handle_call({:get_daemon_session, id}, _from, state) do
+    {:reply, fetch_daemon_session(state, id), state}
+  end
+
+  def handle_call({:heartbeat_daemon_session, id, attrs}, _from, state) do
+    with {:ok, session} <- fetch_daemon_session(state, id),
+         :ok <- validate_session_id_match(id, Map.get(attrs, "session_id")),
+         {:ok, status} <- required_heartbeat_status(attrs),
+         {:ok, labels} <- optional_string_list(attrs, "labels", session["labels"]),
+         {:ok, capabilities} <-
+           optional_string_list(attrs, "capabilities", session["capabilities"]) do
+      now = now(state)
+
+      updated =
+        session
+        |> Map.put("status", status)
+        |> Map.put("labels", labels)
+        |> Map.put("capabilities", capabilities)
+        |> Map.put("current_work_item_id", blank_to_nil(Map.get(attrs, "current_work_item_id")))
+        |> Map.put("last_run_id", blank_to_nil(Map.get(attrs, "last_run_id")))
+        |> Map.put("last_seen_at", now)
+        |> Map.put("updated_at", now)
+
+      state =
+        state
+        |> put_in([:daemon_sessions, id], updated)
+        |> audit("daemon.heartbeat", "daemon_session", id, session["org_id"], session["team_id"])
+
+      heartbeat = %{
+        "next_heartbeat_seconds" => @heartbeat_interval_seconds,
+        "decisions" => [],
+        "assignments" => []
+      }
+
+      {:reply, {:ok, heartbeat, updated}, state}
+    else
+      {:error, reason} -> {:reply, {:error, reason}, state}
+    end
+  end
+
   def handle_call(:audit_log, _from, state) do
     {:reply, {:ok, Enum.reverse(state.audit_log)}, state}
+  end
+
+  defp org_id_from_join(state, attrs) do
+    org_id(state, Map.put_new(attrs, "org_slug", Map.get(attrs, "org")))
+  end
+
+  defp team_id_from_join(state, attrs, org_id) do
+    team_id(state, Map.put_new(attrs, "team_slug", Map.get(attrs, "team")), org_id)
   end
 
   defp required_slug(attrs, field) do
@@ -231,6 +352,50 @@ defmodule Sykli.TeamCoordinator.Store do
 
       _ ->
         {:error, {:missing_field, field}}
+    end
+  end
+
+  defp required_daemon_id(attrs) do
+    with {:ok, daemon_id} <- required_string(attrs, "daemon_id") do
+      if Regex.match?(~r/^[a-z0-9._-]{1,128}$/, daemon_id) do
+        {:ok, daemon_id}
+      else
+        {:error, {:invalid_daemon_id, daemon_id}}
+      end
+    end
+  end
+
+  defp optional_string_list(attrs, field, default \\ []) do
+    case Map.get(attrs, field, default) do
+      values when is_list(values) ->
+        values
+        |> Enum.reduce_while({:ok, []}, fn
+          value, {:ok, acc} when is_binary(value) ->
+            value = String.trim(value)
+
+            cond do
+              value == "" -> {:halt, {:error, {:invalid_daemon_list_field, field}}}
+              String.length(value) > 128 -> {:halt, {:error, {:invalid_daemon_list_field, field}}}
+              true -> {:cont, {:ok, [value | acc]}}
+            end
+
+          _value, _acc ->
+            {:halt, {:error, {:invalid_daemon_list_field, field}}}
+        end)
+        |> case do
+          {:ok, values} -> {:ok, Enum.reverse(values)}
+          error -> error
+        end
+
+      _other ->
+        {:error, {:invalid_daemon_list_field, field}}
+    end
+  end
+
+  defp optional_boolean(attrs, field, default) do
+    case Map.get(attrs, field, default) do
+      value when is_boolean(value) -> {:ok, value}
+      _ -> {:error, {:invalid_field, field}}
     end
   end
 
@@ -274,6 +439,17 @@ defmodule Sykli.TeamCoordinator.Store do
     end
   end
 
+  defp required_heartbeat_status(attrs) do
+    case Map.get(attrs, "status") do
+      status when status in @heartbeat_statuses -> {:ok, status}
+      status -> {:error, {:invalid_daemon_status, status}}
+    end
+  end
+
+  defp validate_session_id_match(_id, nil), do: :ok
+  defp validate_session_id_match(id, id), do: :ok
+  defp validate_session_id_match(_id, value), do: {:error, {:invalid_daemon_session_id, value}}
+
   defp fetch_work_item(state, id) do
     with :ok <- WorkItem.validate_id(id) do
       case Map.fetch(state.work_items, id) do
@@ -281,6 +457,51 @@ defmodule Sykli.TeamCoordinator.Store do
         :error -> {:error, {:work_item_not_found, id}}
       end
     end
+  end
+
+  defp fetch_daemon_session(state, id) when is_binary(id) and id not in ["", ".", ".."] do
+    if String.contains?(id, ["/", "\\", <<0>>]) do
+      {:error, {:invalid_daemon_session_id, id}}
+    else
+      case Map.fetch(state.daemon_sessions, id) do
+        {:ok, session} -> {:ok, session}
+        :error -> {:error, {:daemon_session_not_found, id}}
+      end
+    end
+  end
+
+  defp fetch_daemon_session(_state, id), do: {:error, {:invalid_daemon_session_id, id}}
+
+  defp supersede_existing_daemon(state, identity, new_session_id, now) do
+    case Map.fetch(state.daemon_sessions_by_identity, identity) do
+      {:ok, old_session_id} ->
+        update_in(state, [:daemon_sessions, old_session_id], fn
+          nil ->
+            nil
+
+          session ->
+            session
+            |> Map.put("status", "offline")
+            |> Map.put("superseded_by", new_session_id)
+            |> Map.put("updated_at", now)
+        end)
+
+      :error ->
+        state
+    end
+  end
+
+  defp session_response(session) do
+    %{
+      "session_id" => session["session_id"],
+      "heartbeat_interval_seconds" => @heartbeat_interval_seconds,
+      "team_id" => session["team_id"],
+      "policy" => %{
+        "sync_run_summaries" => true,
+        "sync_evidence_refs" => true,
+        "upload_raw_logs_by_default" => false
+      }
+    }
   end
 
   defp ensure_claimable(%{"status" => "open"}), do: :ok

--- a/core/test/sykli/daemon/join_test.exs
+++ b/core/test/sykli/daemon/join_test.exs
@@ -1,0 +1,142 @@
+defmodule Sykli.Daemon.JoinTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias Sykli.Daemon.Join
+
+  @now "2026-05-09T10:00:00Z"
+
+  test "builds join payload with labels capabilities and remote work disabled by default" do
+    assert {:ok, payload} =
+             Join.build_join_payload(
+               [
+                 coordinator: "https://sykli.internal",
+                 org: "false-systems",
+                 team: "platform",
+                 token: "secret",
+                 labels: "macos,docker",
+                 name: "yair-mbp"
+               ],
+               version: "0.6.1"
+             )
+
+    assert payload["daemon_id"] == "yair-mbp"
+    assert payload["labels"] == ["macos", "docker"]
+    assert payload["capabilities"] == ["local"]
+    assert payload["version"] == "0.6.1"
+    assert payload["accepts_remote_work"] == false
+    refute Map.has_key?(payload, "token")
+  end
+
+  test "heartbeat payload is shaped for coordinator" do
+    session = %{"session_id" => "sess_001", "labels" => ["macos"], "capabilities" => ["local"]}
+
+    assert Join.heartbeat_payload(session, %{"last_run_id" => "run_001"}) == %{
+             "session_id" => "sess_001",
+             "status" => "available",
+             "current_work_item_id" => nil,
+             "labels" => ["macos"],
+             "capabilities" => ["local"],
+             "last_run_id" => "run_001"
+           }
+  end
+
+  test "successful join persists session and does not print token" do
+    tmp = Path.join(System.tmp_dir!(), "sykli-join-test-#{System.unique_integer([:positive])}")
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    output =
+      capture_io(fn ->
+        assert Join.join(
+                 [
+                   coordinator: "https://sykli.internal",
+                   org: "false-systems",
+                   team: "platform",
+                   token: "super-secret",
+                   labels: "macos,docker",
+                   name: "yair-mbp",
+                   json: true,
+                   path: tmp
+                 ],
+                 client: __MODULE__.FakeClient,
+                 now: @now,
+                 version: "0.6.1"
+               ) == 0
+      end)
+
+    decoded = Jason.decode!(output)
+    assert decoded["data"]["session"]["session_id"] == "sess_001"
+    refute output =~ "super-secret"
+
+    {:ok, file} = File.read(Sykli.Daemon.SessionStore.path(path: tmp))
+    refute file =~ "super-secret"
+  end
+
+  test "join accepts token from environment without persisting it" do
+    tmp =
+      Path.join(System.tmp_dir!(), "sykli-join-env-test-#{System.unique_integer([:positive])}")
+
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    System.put_env("SYKLI_TEAM_TOKEN", "super-secret")
+    on_exit(fn -> System.delete_env("SYKLI_TEAM_TOKEN") end)
+
+    capture_io(fn ->
+      assert Join.join(
+               [
+                 coordinator: "https://sykli.internal",
+                 org: "false-systems",
+                 team: "platform",
+                 name: "yair-mbp",
+                 json: true,
+                 path: tmp
+               ],
+               client: __MODULE__.FakeClient,
+               now: @now,
+               version: "0.6.1"
+             ) == 0
+    end)
+
+    {:ok, file} = File.read(Sykli.Daemon.SessionStore.path(path: tmp))
+    refute file =~ "super-secret"
+  end
+
+  test "join help works after subcommand name" do
+    output =
+      capture_io(fn ->
+        assert Join.run(["join", "--help"]) == 0
+      end)
+
+    assert output =~ "Usage: sykli daemon join"
+  end
+
+  test "missing required args return structured json error" do
+    output =
+      capture_io(fn ->
+        assert Join.run(["join", "--org", "false-systems", "--json"]) == 1
+      end)
+
+    assert Jason.decode!(output)["error"]["code"] == "daemon.join_missing_coordinator"
+  end
+
+  defmodule FakeClient do
+    def post_json(_url, "/v1/daemon-sessions", "super-secret", payload) do
+      if Map.has_key?(payload, "token") do
+        raise "join payload leaked token"
+      end
+
+      {:ok,
+       %{
+         "session_id" => "sess_001",
+         "heartbeat_interval_seconds" => 15,
+         "team_id" => "team_001",
+         "policy" => %{
+           "sync_run_summaries" => true,
+           "sync_evidence_refs" => true,
+           "upload_raw_logs_by_default" => false
+         }
+       }}
+    end
+  end
+end

--- a/core/test/sykli/daemon/session_store_test.exs
+++ b/core/test/sykli/daemon/session_store_test.exs
@@ -1,0 +1,42 @@
+defmodule Sykli.Daemon.SessionStoreTest do
+  use ExUnit.Case, async: true
+
+  import Bitwise
+
+  alias Sykli.Daemon.SessionStore
+
+  setup do
+    tmp =
+      Path.join(System.tmp_dir!(), "sykli-session-store-#{System.unique_integer([:positive])}")
+
+    on_exit(fn -> File.rm_rf(tmp) end)
+    {:ok, tmp: tmp}
+  end
+
+  test "writes and reloads session without token", %{tmp: tmp} do
+    session = %{
+      "coordinator" => "https://sykli.internal",
+      "session_id" => "sess_001",
+      "team_id" => "team_001",
+      "token" => "secret"
+    }
+
+    assert {:ok, written} = SessionStore.write(Map.delete(session, "token"), path: tmp)
+    assert written["version"] == 1
+
+    assert {:ok, reloaded} = SessionStore.read(path: tmp)
+    assert reloaded["session_id"] == "sess_001"
+    refute Map.has_key?(reloaded, "token")
+
+    {:ok, stat} = File.stat(SessionStore.path(path: tmp))
+    assert (stat.mode &&& 0o077) == 0
+  end
+
+  test "malformed session returns clear error", %{tmp: tmp} do
+    path = SessionStore.path(path: tmp)
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, "{bad")
+
+    assert {:error, :daemon_session_malformed} = SessionStore.read(path: tmp)
+  end
+end

--- a/core/test/sykli/team_coordinator/daemon_session_test.exs
+++ b/core/test/sykli/team_coordinator/daemon_session_test.exs
@@ -1,0 +1,162 @@
+defmodule Sykli.TeamCoordinator.DaemonSessionTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.TeamCoordinator.Store
+
+  @now "2026-05-09T10:00:00Z"
+  @later "2026-05-09T10:00:15Z"
+
+  setup do
+    {:ok, clock} = Agent.start_link(fn -> [@now, @later] end)
+
+    {:ok, store} =
+      Store.start_link(
+        now: fn ->
+          Agent.get_and_update(clock, fn
+            [value | rest] -> {value, rest}
+            [] -> {@later, []}
+          end)
+        end,
+        id:
+          id_sequence(
+            ~w(org_001 audit_001 team_001 audit_002 sess_001 audit_003 sess_002 audit_004 audit_005)
+          )
+      )
+
+    {:ok, org} = Store.create_org(store, %{"slug" => "false-systems", "name" => "False Systems"})
+
+    {:ok, team} =
+      Store.create_team(store, %{
+        "org_id" => org["id"],
+        "slug" => "platform",
+        "name" => "Platform"
+      })
+
+    {:ok, store: store, org: org, team: team}
+  end
+
+  test "creates daemon session with safe defaults", %{store: store, team: team} do
+    assert {:ok, response, session} =
+             Store.create_daemon_session(store, %{
+               "daemon_id" => "yair-mbp",
+               "org" => "false-systems",
+               "team" => "platform",
+               "labels" => ["macos", "docker"],
+               "capabilities" => ["local"],
+               "version" => "0.6.1"
+             })
+
+    assert response["session_id"] == "sess_001"
+    assert response["team_id"] == team["id"]
+    assert response["heartbeat_interval_seconds"] == 15
+    assert response["policy"]["upload_raw_logs_by_default"] == false
+    assert session["accepts_remote_work"] == false
+    assert session["status"] == "available"
+    assert session["labels"] == ["macos", "docker"]
+    refute Map.has_key?(session, "token")
+  end
+
+  test "rejoin supersedes prior session deterministically", %{store: store} do
+    attrs = %{
+      "daemon_id" => "worker-1",
+      "org" => "false-systems",
+      "team" => "platform",
+      "labels" => [],
+      "capabilities" => ["local"],
+      "version" => "0.6.1"
+    }
+
+    assert {:ok, _response, first} = Store.create_daemon_session(store, attrs)
+    assert {:ok, _response, second} = Store.create_daemon_session(store, attrs)
+
+    assert {:ok, old} = Store.get_daemon_session(store, first["id"])
+    assert old["status"] == "offline"
+    assert old["superseded_by"] == second["id"]
+  end
+
+  test "heartbeat updates status and liveness fields", %{store: store} do
+    {:ok, _response, session} =
+      Store.create_daemon_session(store, %{
+        "daemon_id" => "worker-1",
+        "org" => "false-systems",
+        "team" => "platform",
+        "labels" => ["macos"],
+        "capabilities" => ["local"],
+        "version" => "0.6.1"
+      })
+
+    assert {:ok, heartbeat, updated} =
+             Store.heartbeat_daemon_session(store, session["id"], %{
+               "session_id" => session["id"],
+               "status" => "busy",
+               "labels" => ["macos", "docker"],
+               "capabilities" => ["local", "shell"],
+               "current_work_item_id" => "work_001",
+               "last_run_id" => "run_001"
+             })
+
+    assert heartbeat == %{"next_heartbeat_seconds" => 15, "decisions" => [], "assignments" => []}
+    assert updated["status"] == "busy"
+    assert updated["labels"] == ["macos", "docker"]
+    assert updated["last_seen_at"] == @later
+    assert updated["current_work_item_id"] == "work_001"
+  end
+
+  test "validates daemon session inputs", %{store: store} do
+    assert {:error, {:org_not_found, "missing"}} =
+             Store.create_daemon_session(store, %{
+               "daemon_id" => "worker-1",
+               "org" => "missing",
+               "team" => "platform",
+               "version" => "0.6.1"
+             })
+
+    assert {:error, {:invalid_daemon_id, "../escape"}} =
+             Store.create_daemon_session(store, %{
+               "daemon_id" => "../escape",
+               "org" => "false-systems",
+               "team" => "platform",
+               "version" => "0.6.1"
+             })
+
+    {:ok, _response, session} =
+      Store.create_daemon_session(store, %{
+        "daemon_id" => "worker-1",
+        "org" => "false-systems",
+        "team" => "platform",
+        "version" => "0.6.1"
+      })
+
+    assert {:error, {:invalid_daemon_status, "wat"}} =
+             Store.heartbeat_daemon_session(store, session["id"], %{"status" => "wat"})
+
+    assert {:error, {:daemon_session_not_found, "missing"}} =
+             Store.get_daemon_session(store, "missing")
+  end
+
+  test "lists sessions deterministically", %{store: store} do
+    for daemon_id <- ["worker-b", "worker-a"] do
+      assert {:ok, _response, _session} =
+               Store.create_daemon_session(store, %{
+                 "daemon_id" => daemon_id,
+                 "org" => "false-systems",
+                 "team" => "platform",
+                 "version" => "0.6.1"
+               })
+    end
+
+    assert {:ok, sessions} = Store.list_daemon_sessions(store)
+    assert Enum.map(sessions, & &1["id"]) == ["sess_001", "sess_002"]
+  end
+
+  defp id_sequence(ids) do
+    {:ok, agent} = Agent.start_link(fn -> ids end)
+
+    fn ->
+      Agent.get_and_update(agent, fn
+        [id | rest] -> {id, rest}
+        [] -> flunk("id sequence exhausted")
+      end)
+    end
+  end
+end

--- a/core/test/sykli/team_coordinator/router_test.exs
+++ b/core/test/sykli/team_coordinator/router_test.exs
@@ -15,7 +15,7 @@ defmodule Sykli.TeamCoordinator.RouterTest do
         now: fn -> @now end,
         id:
           id_sequence(
-            ~w(org_001 audit_001 team_001 audit_002 work_001 audit_003 audit_004 note_001 audit_005)
+            ~w(org_001 audit_001 team_001 audit_002 work_001 audit_003 audit_004 note_001 audit_005 sess_001 audit_006 audit_007)
           )
       )
 
@@ -157,6 +157,85 @@ defmodule Sykli.TeamCoordinator.RouterTest do
 
     assert conn.status == 404
     assert json(conn)["error"]["code"] == "coordinator.not_found"
+  end
+
+  test "creates lists shows and heartbeats daemon sessions", %{opts: opts} do
+    assert 201 =
+             :post
+             |> authed_json_conn("/v1/orgs", %{
+               "slug" => "false-systems",
+               "name" => "False Systems"
+             })
+             |> call(opts)
+             |> Map.fetch!(:status)
+
+    assert 201 =
+             :post
+             |> authed_json_conn("/v1/teams", %{
+               "org_id" => "org_001",
+               "slug" => "platform",
+               "name" => "Platform"
+             })
+             |> call(opts)
+             |> Map.fetch!(:status)
+
+    join =
+      :post
+      |> authed_json_conn("/v1/daemon-sessions", %{
+        "daemon_id" => "yair-mbp",
+        "org" => "false-systems",
+        "team" => "platform",
+        "labels" => ["macos", "docker"],
+        "capabilities" => ["local", "shell"],
+        "version" => "0.6.1"
+      })
+      |> call(opts)
+
+    assert join.status == 201
+    session_id = json(join)["data"]["session_id"]
+    assert is_binary(session_id)
+    assert json(join)["data"]["team_id"] == "team_001"
+    assert json(join)["data"]["heartbeat_interval_seconds"] == 15
+    assert json(join)["data"]["policy"]["upload_raw_logs_by_default"] == false
+
+    list =
+      :get
+      |> authed_conn("/v1/daemon-sessions")
+      |> call(opts)
+
+    assert list.status == 200
+    assert [%{"id" => ^session_id, "accepts_remote_work" => false}] = json(list)["data"]["items"]
+
+    show =
+      :get
+      |> authed_conn("/v1/daemon-sessions/#{session_id}")
+      |> call(opts)
+
+    assert show.status == 200
+    assert json(show)["data"]["daemon_session"]["status"] == "available"
+
+    heartbeat =
+      :post
+      |> authed_json_conn("/v1/daemon-sessions/#{session_id}/heartbeat", %{
+        "session_id" => session_id,
+        "status" => "busy",
+        "labels" => ["macos"],
+        "capabilities" => ["local"],
+        "last_run_id" => "run_001"
+      })
+      |> call(opts)
+
+    assert heartbeat.status == 200
+    assert json(heartbeat)["data"]["next_heartbeat_seconds"] == 15
+    assert json(heartbeat)["data"]["assignments"] == []
+
+    invalid =
+      :post
+      |> authed_json_conn("/v1/daemon-sessions/#{session_id}/heartbeat", %{"status" => "wat"})
+      |> call(opts)
+
+    assert invalid.status == 400
+    assert json(invalid)["error"]["code"] == "coordinator.invalid_daemon_status"
   end
 
   defp call(conn, opts) do

--- a/docs/daemon-join-protocol.md
+++ b/docs/daemon-join-protocol.md
@@ -2,12 +2,15 @@
 
 ## Status
 
-Design document. Specifies how a Sykli daemon establishes and maintains
-a session with a self-hosted coordinator. Phase 0 of
-`docs/team-mode-roadmap.md`.
+Implemented incrementally. PR #192 adds the first daemon join and
+heartbeat slice: coordinator daemon-session endpoints, the
+`sykli daemon join` client command, local session persistence, and
+`sykli daemon status --json` session visibility.
 
-No implementation in this PR. Wire shapes below are normative;
-exact field types and error codes are firmed up by the implementing PR.
+Later phases still add work sync, run summary sync, gate decision sync,
+and event-stream delivery. Wire shapes below are the current contract for
+the implemented join/heartbeat slice unless a later section explicitly
+marks behavior as future work.
 
 ## Architecture sentence
 
@@ -37,20 +40,19 @@ The daemon must:
 - Verify the coordinator's TLS certificate against the system trust
   store, with the same hostname-checking rules as the rest of Sykli's
   HTTP layer (see `Sykli.HTTP.ssl_opts/1`).
-- Refuse to connect to plaintext HTTP except when `--insecure` is set
-  for local development. `--insecure` must log a clear warning per
-  connect.
+- Prefer HTTPS for non-local coordinator URLs. The current implementation
+  also supports plain HTTP for the local coordinator skeleton and tests;
+  production deployments should terminate TLS at an ingress or proxy.
 - Carry an `Authorization: Bearer <token>` header on every request that
   needs authentication.
 
 The coordinator must:
 
-- Reject any request without TLS unless explicitly configured for
-  development.
 - Reject any request whose token is missing, malformed, expired, revoked,
   or scoped to a different org/team.
-- Rate-limit join attempts per source IP and per token to resist token
-  exfiltration brute force.
+- Rate-limit join attempts per source IP and per token in the durable
+  production coordinator. The current in-memory skeleton does not include
+  rate limiting yet.
 
 ## Daemon identity
 
@@ -153,14 +155,14 @@ Field rules:
     default and only secure value for v0 is `false`.
 
 If the coordinator rejects the join, the response uses the standard error
-envelope with a code from `docs/error-codes.md` (with new
-coordinator-specific codes added in Phase 4). Examples:
+envelope with a code from `docs/error-codes.md`. Implemented examples
+include:
 
-- `team.token.invalid`
-- `team.token.expired`
-- `team.token.scope_mismatch`
-- `team.daemon.label_unknown`
-- `team.policy.refused_remote_work`
+- `coordinator.unauthorized`
+- `coordinator.org_not_found`
+- `coordinator.team_not_found`
+- `coordinator.invalid_daemon_id`
+- `coordinator.invalid_daemon_payload`
 
 ## Heartbeat
 
@@ -185,9 +187,10 @@ Content-Type: application/json
 
 Field rules:
 
-- `status` — one of `available`, `busy`, `draining`. `draining` means the
-  daemon is finishing in-flight work but will not accept new work; it is
-  the equivalent of the SIGTERM drain behavior in `Sykli.Application`.
+- `status` — one of `available`, `busy`, `offline`, `degraded`, or
+  `draining`. `draining` means the daemon is finishing in-flight work but
+  will not accept new work; it is the equivalent of the SIGTERM drain
+  behavior in `Sykli.Application`.
 - `current_work_item_id` — if the daemon is currently running a work item.
 - `labels` and `capabilities` — re-sent on every heartbeat. The
   coordinator treats the latest heartbeat as authoritative. A daemon may
@@ -195,7 +198,7 @@ Field rules:
 - `last_run_id` — the most recent run the daemon has reported. The
   coordinator uses this to detect dropped run summaries.
 
-The heartbeat response is the daemon's pickup channel for shared
+The heartbeat response is the daemon's future pickup channel for shared
 decisions:
 
 ```json
@@ -224,9 +227,11 @@ decisions:
 }
 ```
 
-The decisions and assignments arrays may be empty. The daemon must
-process every entry it receives idempotently; the coordinator may
-re-send a decision if the previous heartbeat's response was dropped.
+The current implementation returns empty `decisions` and `assignments`
+arrays because work sync and gate sync are later phases. Once those
+phases land, the daemon must process every entry it receives
+idempotently; the coordinator may re-send a decision if the previous
+heartbeat's response was dropped.
 
 If the coordinator returns 401/403, the daemon must stop sending and
 surface the failure to the operator. It must not retry blindly with

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -32,10 +32,15 @@ surface is still young. They are emitted in the JSON envelope returned by
 | `coordinator.body_read_failed` | Plug failed to read the coordinator request body. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:194` |
 | `coordinator.duplicate_org_slug` | An org create request used an org slug that already exists. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:206` |
 | `coordinator.duplicate_team_slug` | A team create request used a team slug that already exists in the org. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:209` |
+| `coordinator.daemon_session_not_found` | A daemon session lookup or heartbeat referenced a session that does not exist. | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
 | `coordinator.internal_error` | Fallback coordinator API error for an unexpected structured reason. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:227` |
 | `coordinator.invalid_assignment_type` | A work claim request used an unsupported assignment type. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:221` |
 | `coordinator.invalid_bind` | The coordinator CLI received an invalid `--bind` address. | public-unstable | `core/lib/sykli/cli/coordinator.ex:190` |
 | `coordinator.invalid_command` | The coordinator CLI received an unsupported command or flag. | public-unstable | `core/lib/sykli/cli/coordinator.ex:200`, `core/lib/sykli/cli/coordinator.ex:210` |
+| `coordinator.invalid_daemon_id` | A daemon join request used an invalid daemon id. | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
+| `coordinator.invalid_daemon_payload` | A daemon join or heartbeat request used malformed labels, capabilities, or list fields. | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
+| `coordinator.invalid_daemon_session_id` | A heartbeat or daemon-session lookup used an invalid session id. | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
+| `coordinator.invalid_daemon_status` | A heartbeat request used an unsupported daemon status. | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
 | `coordinator.invalid_json` | The coordinator request body was not valid JSON. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:185` |
 | `coordinator.invalid_payload` | The coordinator request body was not an object or missed required fields. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:188`, `core/lib/sykli/team_coordinator/router.ex:200`, `core/lib/sykli/team_coordinator/router.ex:203` |
 | `coordinator.invalid_port` | The coordinator CLI received an invalid `--port` value. | public-unstable | `core/lib/sykli/cli/coordinator.ex:180` |
@@ -46,6 +51,27 @@ surface is still young. They are emitted in the JSON envelope returned by
 | `coordinator.team_not_found` | A coordinator request referenced a team that does not exist. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:215` |
 | `coordinator.token_required` | `sykli coordinator start` was called without `--token` or `SYKLI_COORDINATOR_TOKEN`. | public-unstable | `core/lib/sykli/cli/coordinator.ex:170` |
 | `coordinator.unauthorized` | A protected coordinator endpoint was called without a valid bearer token. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:176`, `core/lib/sykli/team_coordinator/router.ex:179` |
+
+### daemon
+
+Daemon Team Mode codes are public-unstable while daemon join/session
+behavior is new. They are emitted by `sykli daemon join --json` and
+daemon status/session JSON surfaces.
+
+| Code | Description | Tier | Emitted from |
+|------|-------------|------|--------------|
+| `daemon.coordinator_error` | The coordinator rejected daemon join with a structured non-auth error. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.coordinator_unauthorized` | The coordinator rejected daemon join authorization. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.coordinator_unavailable` | The daemon join client could not reach the coordinator. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.invalid_coordinator_response` | The coordinator returned invalid JSON or an unexpected response shape. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.invalid_id` | `sykli daemon join` received or inferred an invalid daemon id. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.invalid_join_command` | `sykli daemon join` received an unsupported command form or flag. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.invalid_join_payload` | `sykli daemon join` received malformed label or capability arguments. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.join_failed` | Fallback daemon join failure for unexpected structured reasons. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.join_missing_coordinator` | `sykli daemon join` was called without `--coordinator`. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.join_missing_org` | `sykli daemon join` was called without `--org`. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.join_missing_team` | `sykli daemon join` was called without `--team`. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.join_missing_token` | `sykli daemon join` was called without `--token` or `SYKLI_TEAM_TOKEN`. | public-unstable | `core/lib/sykli/daemon/join.ex` |
 
 ### execution
 

--- a/docs/self-hosted-coordinator.md
+++ b/docs/self-hosted-coordinator.md
@@ -2,12 +2,11 @@
 
 ## Status
 
-Design document for the Sykli Coordinator service. Phase 0 of
-`docs/team-mode-roadmap.md`. No implementation in this PR.
-
-The schema, API, and deployment shape below are normative for future
-implementation PRs but illustrative in detail (table column names, exact
-HTTP paths, Helm value names) until the first slice lands.
+Design and implementation reference for the Sykli Coordinator service.
+The initial skeleton is implemented with an in-memory store,
+bearer-token auth, org/team/work item endpoints, and daemon
+join/heartbeat endpoints. Durable Postgres storage, run sync, gate sync,
+and deployment manifests remain future implementation slices.
 
 ## Product sentence
 
@@ -163,6 +162,8 @@ Current behavior:
   TLS at the ingress or proxy until in-process TLS is explicitly added.
 - State is lost when the coordinator process exits.
 - State-changing calls append in-memory audit events.
+- Daemon join and heartbeat sessions are stored in memory and are lost
+  when the coordinator exits.
 - Durable Postgres storage, migrations, and deployment assets remain
   follow-up work.
 

--- a/docs/team-mode-roadmap.md
+++ b/docs/team-mode-roadmap.md
@@ -208,6 +208,12 @@ Exit criteria:
 
 Daemons connect outbound and announce themselves.
 
+Status: PR #192 adds coordinator daemon-session endpoints, authenticated
+join/heartbeat handling, `sykli daemon join`, local coordinator session
+persistence without storing the token, and `sykli daemon status --json`
+session visibility. Work sync, run sync, gate sync, offline liveness
+expiry, and reconnect outbox behavior remain later slices.
+
 Suggested CLI:
 
 ```bash
@@ -233,9 +239,11 @@ Coordinator tracks:
 Exit criteria:
 
 - `daemon join` succeeds against the coordinator from Phase 4.
-- Heartbeats keep `daemon_sessions.status` in `online`.
+- Heartbeats keep `daemon_sessions.status` current with `available`,
+  `busy`, `offline`, `degraded`, or `draining`.
 - A killed daemon transitions to `offline` after the documented
-  liveness cutoff.
+  liveness cutoff. This expiry loop remains follow-up after the first
+  join/heartbeat slice.
 - `sykli daemon status` reflects coordinator-side state when joined,
   local-only state when not.
 - Black-box cases cover token rejection, TLS failure, and reconnect.

--- a/docs/team-mode-security.md
+++ b/docs/team-mode-security.md
@@ -86,9 +86,9 @@ The coordinator issues team-scoped tokens through `sykli team token create`.
 
 The coordinator skeleton bootstraps with a single bearer token supplied by
 `--token` or `SYKLI_COORDINATOR_TOKEN`. This is intentionally minimal and
-does not implement RBAC, OIDC, GitHub org mapping, or daemon join tokens
-yet. Every non-health `/v1/*` endpoint rejects missing or incorrect bearer
-tokens.
+does not implement RBAC, OIDC, or GitHub org mapping yet. Daemon join and
+heartbeat requests use the same bearer-token boundary. Every non-health
+`/v1/*` endpoint rejects missing or incorrect bearer tokens.
 
 The skeleton binds to `127.0.0.1` by default. Exposing it on `0.0.0.0` or
 another non-loopback address requires an explicit `--bind` value and should
@@ -101,9 +101,10 @@ Properties:
 - Carry no execution authority over individual daemons.
 - Revocable at any time. Revocation invalidates all sessions on the
   next heartbeat.
-- Stored on daemons in `SYKLI_TEAM_TOKEN` (env var) or a config file
-  with strict file permissions (`0600`). Never written to a CLI argument
-  in production.
+- Supplied to daemons via `SYKLI_TEAM_TOKEN` (env var) or a one-shot
+  `--token` flag. The current daemon session file stores coordinator
+  URL, org/team, `session_id`, policy, labels, and capabilities, but does
+  not persist the bearer token.
 
 Tokens are not user identities. They authenticate a daemon's right to
 participate in a team. Member identities (who claimed a work item, who

--- a/eval/oracle/run.sh
+++ b/eval/oracle/run.sh
@@ -1553,6 +1553,64 @@ if begin_case "073" "Coordinator: duplicate org slug JSON error"; then
   fi
 fi
 
+# --- case_074: daemon join and heartbeat JSON shapes ---
+if begin_case "074" "Coordinator: daemon join and heartbeat JSON"; then
+  if ! command -v curl &>/dev/null; then
+    skip "curl not available"
+  else
+    dir=$(tmp_workdir)
+    port=$((24000 + RANDOM % 10000))
+    (cd "$dir" && SYKLI_COORDINATOR_TOKEN=secret "$SYKLI_BIN" coordinator start --port "$port" >coordinator.log 2>&1) &
+    pid=$!
+
+    for _ in {1..80}; do
+      if curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 0.1
+    done
+
+    org_json=$(curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' \
+      -d '{"slug":"false-systems","name":"False Systems"}' \
+      "http://127.0.0.1:$port/v1/orgs")
+    org_id=$(echo "$org_json" | jq -r '.data.org.id')
+
+    curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' \
+      -d "{\"org_id\":\"$org_id\",\"slug\":\"platform\",\"name\":\"Platform\"}" \
+      "http://127.0.0.1:$port/v1/teams" >/dev/null
+
+    LAST_OUTPUT=$(cd "$dir" && "$SYKLI_BIN" daemon join \
+      --coordinator "http://127.0.0.1:$port" \
+      --org false-systems \
+      --team platform \
+      --token secret \
+      --labels macos,docker \
+      --name yair-mbp \
+      --json 2>&1) && exit_code=0 || exit_code=$?
+
+    session_id=$(echo "$LAST_OUTPUT" | jq -r '.data.session.session_id // empty')
+    heartbeat_json=$(curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' \
+      -d "{\"session_id\":\"$session_id\",\"status\":\"busy\",\"labels\":[\"macos\"],\"capabilities\":[\"local\"],\"last_run_id\":\"run_001\"}" \
+      "http://127.0.0.1:$port/v1/daemon-sessions/$session_id/heartbeat")
+    list_json=$(curl -fsS -H 'Authorization: Bearer secret' "http://127.0.0.1:$port/v1/daemon-sessions")
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+
+    if assert_exit 0 "$exit_code"; then
+      if assert_json_field "$LAST_OUTPUT" '.data.session.accepts_remote_work' "false"; then
+        if assert_json_field "$LAST_OUTPUT" '.data.session.policy.upload_raw_logs_by_default' "false"; then
+          if assert_json_field "$heartbeat_json" '.data.next_heartbeat_seconds' "15"; then
+            if assert_json_field "$list_json" '.data.items[0].status' "busy"; then
+              pass 0
+            fi
+          fi
+        fi
+      fi
+    fi
+    rm -rf "$dir"
+  fi
+fi
+
 # ============================================================================
 # Summary
 # ============================================================================

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -1681,6 +1681,27 @@
       "validated_by": "Injected bug: coordinator write endpoints are unauthenticated or work API does not persist shared state."
     },
     {
+      "id": "COORD-002",
+      "name": "daemon joins coordinator and heartbeats",
+      "fixture": "empty_dir",
+      "command": "port=$((24000 + RANDOM % 10000)); SYKLI_COORDINATOR_TOKEN=secret sykli coordinator start --port \"$port\" >coord.log 2>&1 & pid=$!; trap 'kill $pid 2>/dev/null || true' EXIT; for i in {1..80}; do curl -fsS \"http://127.0.0.1:$port/health\" >/dev/null 2>&1 && break; sleep 0.1; done; curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' -d '{\"slug\":\"false-systems\",\"name\":\"False Systems\"}' \"http://127.0.0.1:$port/v1/orgs\" >org.json; org=$(jq -r '.data.org.id' org.json); curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' -d \"{\\\"org_id\\\":\\\"$org\\\",\\\"slug\\\":\\\"platform\\\",\\\"name\\\":\\\"Platform\\\"}\" \"http://127.0.0.1:$port/v1/teams\" >team.json; sykli daemon join --coordinator \"http://127.0.0.1:$port\" --org false-systems --team platform --token secret --labels macos,docker --name yair-mbp --json >join.json; session=$(jq -r '.data.session.session_id' join.json); ! grep -q secret join.json; curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' -d \"{\\\"session_id\\\":\\\"$session\\\",\\\"status\\\":\\\"busy\\\",\\\"labels\\\":[\\\"macos\\\"],\\\"capabilities\\\":[\\\"local\\\"],\\\"last_run_id\\\":\\\"run_001\\\"}\" \"http://127.0.0.1:$port/v1/daemon-sessions/$session/heartbeat\" >heartbeat.json; curl -fsS -H 'Authorization: Bearer secret' \"http://127.0.0.1:$port/v1/daemon-sessions\" >sessions.json; cat sessions.json",
+      "shell": true,
+      "requires": "curl",
+      "expect_exit": 0,
+      "expect_json_jq": [
+        ".ok == true",
+        ".data.items | length == 1",
+        ".data.items[0].daemon_id == \"yair-mbp\"",
+        ".data.items[0].status == \"busy\"",
+        ".data.items[0].accepts_remote_work == false",
+        ".data.items[0] | has(\"token\") | not",
+        ".data.items[0] | has(\"logs\") | not",
+        ".data.items[0] | has(\"artifacts\") | not"
+      ],
+      "source": "docs/daemon-join-protocol.md Phase 5; daemon join/heartbeat must be authenticated and presence-only",
+      "validated_by": "Injected bug: daemon join leaks token, defaults accepts_remote_work true, or heartbeat does not update coordinator state."
+    },
+    {
       "id": "GH-001",
       "name": "Receiver refuses to start without webhook role",
       "fixture": "single_task",


### PR DESCRIPTION
## Summary

Adds daemon presence for self-hosted Team Mode. Daemons can now join a coordinator, persist local session metadata, and send authenticated heartbeats without enabling remote execution.

## Why

The coordinator skeleton exists, but remote teams need daemon presence without assuming BEAM mesh/LAN connectivity. This slice keeps the relationship outbound and authenticated: the daemon registers itself with labels, capabilities, version, status, and an `accepts_remote_work` flag that defaults to `false`.

This is the foundation for later team work sync. It is not execution authorization.

## What changed

- Added coordinator daemon-session store support and endpoints:
  - `POST /v1/daemon-sessions`
  - `GET /v1/daemon-sessions`
  - `GET /v1/daemon-sessions/:id`
  - `POST /v1/daemon-sessions/:id/heartbeat`
- Added deterministic duplicate daemon behavior: rejoin creates a new session and marks the prior session offline/superseded.
- Added `Sykli.Coordinator.Client` for JSON/bearer-token coordinator calls.
- Added `Sykli.Daemon.Join` for `sykli daemon join`.
- Added `.sykli/daemon/session.json` persistence via `Sykli.Daemon.SessionStore`.
- Extended `sykli daemon status --json` to include coordinator session metadata when joined.
- Added oracle and blackbox daemon join/heartbeat coverage.
- Updated docs and public error-code catalog.

## Security behavior

- Join requires bearer-token auth.
- Heartbeat requires bearer-token auth.
- `accepts_remote_work` defaults to `false`.
- Token is not printed in human or JSON output.
- Token is not persisted in `.sykli/daemon/session.json`.
- No remote execution endpoint was added.
- No remote shell endpoint was added.
- No log, artifact, source, or raw-output upload endpoint was added.

## JSON shapes

Join response data includes:

```json
{
  "session_id": "...",
  "heartbeat_interval_seconds": 15,
  "team_id": "...",
  "policy": {
    "sync_run_summaries": true,
    "sync_evidence_refs": true,
    "upload_raw_logs_by_default": false
  }
}
```

Daemon join CLI `--json` returns the persisted public session object under `data.session`; token fields are dropped.

Heartbeat response data includes:

```json
{
  "next_heartbeat_seconds": 15,
  "decisions": [],
  "assignments": []
}
```

The arrays are intentionally empty in this PR because work sync and gate sync are later layers.

## Validation

Ran locally:

- `mix format lib/sykli/cli.ex lib/sykli/team_coordinator/router.ex lib/sykli/team_coordinator/store.ex lib/sykli/coordinator/client.ex lib/sykli/daemon/join.ex lib/sykli/daemon/session_store.ex test/sykli/team_coordinator/router_test.exs test/sykli/team_coordinator/daemon_session_test.exs test/sykli/daemon/join_test.exs test/sykli/daemon/session_store_test.exs` ✅
- `mix test test/sykli/team_coordinator/daemon_session_test.exs test/sykli/team_coordinator/router_test.exs test/sykli/daemon/session_store_test.exs test/sykli/daemon/join_test.exs test/sykli/cli_test.exs test/sykli/team_coordinator` ✅ (`54 tests, 0 failures`)
- `mix escript.build` ✅
- `test/blackbox/run.sh --filter=COORD-002` ✅
- `eval/oracle/run.sh --case 074` ✅
- `mix test` ✅ (`1 property, 1639 tests, 0 failures, 1 skipped`)
- `mix credo --strict` ✅ (`found no issues`; existing module-redefinition warning only)
- `git diff --check` ✅

Full conformance was not run because this PR does not change contract schemas, SDK emitters, or conformance fixtures.

## Oracle coverage

Added oracle case:

- `074` — coordinator daemon join and heartbeat JSON shape, including `accepts_remote_work: false`, policy `upload_raw_logs_by_default: false`, heartbeat response, and session status update.

## Blackbox coverage

Added blackbox case:

- `COORD-002` — starts coordinator, creates org/team, runs `sykli daemon join`, asserts token is not printed, sends heartbeat, lists daemon sessions, and verifies presence-only session data.

## Out of scope

- No team work sync.
- No run sync.
- No gate sync.
- No remote execution.
- No remote shell.
- No MCP.
- No Kubernetes deployment.
- No web UI.
- No complex RBAC/OIDC/GitHub org mapping.

## Next PR

Sync work items through coordinator:

- coordinator work client
- local vs team mode selection
- `sykli work create/list/show/claim/note --team`
- not-joined/coordinator-unavailable errors
- team work CLI tests
- oracle JSON expectations
- blackbox team work workflow
