### PR TITLE
Sync work items through coordinator

### DIFF
--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -165,7 +165,7 @@ defmodule Sykli.CLI do
       sykli history    List recent runs
       sykli daemon     Manage daemon (see: sykli daemon --help)
       sykli coordinator Start the self-hosted Team Mode coordinator
-      sykli work       Manage local work items (see: sykli work --help)
+      sykli work       Manage local or coordinator work items (see: sykli work --help)
       sykli gates      List local gate decisions
       sykli gate       Manage local gate decisions (see: sykli gate --help)
       sykli cache      Manage cache (see: sykli cache --help)

--- a/core/lib/sykli/cli/work.ex
+++ b/core/lib/sykli/cli/work.ex
@@ -1,14 +1,16 @@
 defmodule Sykli.CLI.Work do
   @moduledoc """
-  Local work item CLI commands.
+  Work item CLI commands.
 
-  This module is intentionally local-only. Team/coordinator routing is added in
-  later Team Mode phases.
+  Commands are local by default. Passing `--team TEAM` routes supported work
+  operations through the joined self-hosted Team Mode coordinator.
   """
 
   alias Sykli.CLI.JsonResponse
+  alias Sykli.Daemon.SessionStore
   alias Sykli.Error
   alias Sykli.Error.Formatter
+  alias Sykli.TeamCoordinator.WorkClient
   alias Sykli.Work.Store
   alias Sykli.WorkItem
 
@@ -31,6 +33,59 @@ defmodule Sykli.CLI.Work do
   end
 
   defp execute({:create, title}, opts, runtime_opts) do
+    if team_mode?(opts) do
+      execute_team_create(title, opts, runtime_opts)
+    else
+      execute_local_create(title, opts, runtime_opts)
+    end
+  end
+
+  defp execute(:list, opts, runtime_opts) do
+    if team_mode?(opts) do
+      execute_team_list(opts, runtime_opts)
+    else
+      execute_local_list(opts, runtime_opts)
+    end
+  end
+
+  defp execute({:show, id}, opts, runtime_opts) do
+    if team_mode?(opts) do
+      execute_team_show(id, opts, runtime_opts)
+    else
+      execute_local_show(id, opts, runtime_opts)
+    end
+  end
+
+  defp execute({:claim, id}, opts, runtime_opts) do
+    if team_mode?(opts) do
+      execute_team_claim(id, opts, runtime_opts)
+    else
+      execute_local_claim(id, opts, runtime_opts)
+    end
+  end
+
+  defp execute({:note, id, body}, opts, runtime_opts) do
+    if team_mode?(opts) do
+      execute_team_note(id, body, opts, runtime_opts)
+    else
+      execute_local_note(id, body, opts, runtime_opts)
+    end
+  end
+
+  defp execute({:runs, id}, opts, runtime_opts) do
+    if team_mode?(opts) do
+      output_error(:team_work_runs_not_supported, Keyword.get(opts, :json, false))
+    else
+      execute_local_runs(id, opts, runtime_opts)
+    end
+  end
+
+  defp execute(:help, _opts, _runtime_opts) do
+    print_help()
+    0
+  end
+
+  defp execute_local_create(title, opts, runtime_opts) do
     {actor_type, actor_id} = actor(opts, runtime_opts)
 
     create_opts =
@@ -52,7 +107,7 @@ defmodule Sykli.CLI.Work do
     end
   end
 
-  defp execute(:list, opts, runtime_opts) do
+  defp execute_local_list(opts, runtime_opts) do
     case Store.list(store_opts(runtime_opts)) do
       {:ok, items} ->
         output_success(%{source: "local", items: Enum.map(items, &item_map/1)}, opts, fn ->
@@ -72,7 +127,7 @@ defmodule Sykli.CLI.Work do
     end
   end
 
-  defp execute({:show, id}, opts, runtime_opts) do
+  defp execute_local_show(id, opts, runtime_opts) do
     case Store.get(id, store_opts(runtime_opts)) do
       {:ok, item} ->
         output_success(%{source: "local", item: item_map(item)}, opts, fn ->
@@ -84,7 +139,7 @@ defmodule Sykli.CLI.Work do
     end
   end
 
-  defp execute({:claim, id}, opts, runtime_opts) do
+  defp execute_local_claim(id, opts, runtime_opts) do
     {actor_type, actor_id} = actor(opts, runtime_opts)
 
     claim_opts =
@@ -103,7 +158,7 @@ defmodule Sykli.CLI.Work do
     end
   end
 
-  defp execute({:note, id, body}, opts, runtime_opts) do
+  defp execute_local_note(id, body, opts, runtime_opts) do
     {actor_type, actor_id} = actor(opts, runtime_opts)
 
     note_opts =
@@ -123,7 +178,7 @@ defmodule Sykli.CLI.Work do
     end
   end
 
-  defp execute({:runs, id}, opts, runtime_opts) do
+  defp execute_local_runs(id, opts, runtime_opts) do
     store_opts = store_opts(runtime_opts)
     history_opts = Keyword.merge(store_opts, Keyword.take(runtime_opts, [:limit]))
 
@@ -150,9 +205,94 @@ defmodule Sykli.CLI.Work do
     end
   end
 
-  defp execute(:help, _opts, _runtime_opts) do
-    print_help()
-    0
+  defp execute_team_create(title, opts, runtime_opts) do
+    {actor_type, actor_id} = actor(opts, runtime_opts)
+
+    attrs =
+      %{"title" => title, "created_by" => "#{actor_type}:#{actor_id}"}
+      |> maybe_put("intent", Keyword.get(opts, :intent))
+
+    with {:ok, session, token} <- team_session(opts, runtime_opts),
+         {:ok, item} <-
+           work_client(runtime_opts).create(session, token, attrs, client_opts(runtime_opts)) do
+      output_success(%{source: "team", team: session["team"], item: item}, opts, fn ->
+        IO.puts("Created team work item #{item["id"]}")
+        IO.puts(item["title"])
+      end)
+    else
+      {:error, reason} -> output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute_team_list(opts, runtime_opts) do
+    with {:ok, session, token} <- team_session(opts, runtime_opts),
+         {:ok, items} <- work_client(runtime_opts).list(session, token, client_opts(runtime_opts)) do
+      output_success(%{source: "team", team: session["team"], items: items}, opts, fn ->
+        if items == [] do
+          IO.puts("No team work items")
+        else
+          IO.puts("Team work items:")
+
+          Enum.each(items, fn item ->
+            IO.puts("  #{item["id"]}  #{item["status"]}  #{item["title"]}")
+          end)
+        end
+      end)
+    else
+      {:error, reason} -> output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute_team_show(id, opts, runtime_opts) do
+    with {:ok, session, token} <- team_session(opts, runtime_opts),
+         {:ok, item} <-
+           work_client(runtime_opts).show(session, token, id, client_opts(runtime_opts)) do
+      output_success(%{source: "team", team: session["team"], item: item}, opts, fn ->
+        print_remote_item(item)
+      end)
+    else
+      {:error, reason} -> output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute_team_claim(id, opts, runtime_opts) do
+    {actor_type, actor_id} = actor(opts, runtime_opts)
+
+    attrs = %{
+      "assigned_to_type" => actor_type,
+      "assigned_to_id" => actor_id
+    }
+
+    with {:ok, session, token} <- team_session(opts, runtime_opts),
+         {:ok, item} <-
+           work_client(runtime_opts).claim(session, token, id, attrs, client_opts(runtime_opts)) do
+      output_success(%{source: "team", team: session["team"], item: item}, opts, fn ->
+        IO.puts("Claimed team work item #{item["id"]}")
+        IO.puts("#{item["assigned_to_type"]}:#{item["assigned_to_id"]}")
+      end)
+    else
+      {:error, reason} -> output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  defp execute_team_note(id, body, opts, runtime_opts) do
+    {actor_type, actor_id} = actor(opts, runtime_opts)
+
+    attrs = %{
+      "body" => body,
+      "author_type" => actor_type,
+      "author_id" => actor_id
+    }
+
+    with {:ok, session, token} <- team_session(opts, runtime_opts),
+         {:ok, note} <-
+           work_client(runtime_opts).note(session, token, id, attrs, client_opts(runtime_opts)) do
+      output_success(%{source: "team", team: session["team"], note: note}, opts, fn ->
+        IO.puts("Added note #{note["id"]} to team work item #{id}")
+      end)
+    else
+      {:error, reason} -> output_error(reason, Keyword.get(opts, :json, false))
+    end
   end
 
   defp parse(args) do
@@ -238,6 +378,14 @@ defmodule Sykli.CLI.Work do
 
   defp parse_flags([<<"--intent=", value::binary>> | rest], opts, positionals) do
     parse_flags(rest, [{:intent, value} | opts], positionals)
+  end
+
+  defp parse_flags(["--team", value | rest], opts, positionals) do
+    parse_flags(rest, [{:team, value} | opts], positionals)
+  end
+
+  defp parse_flags([<<"--team=", value::binary>> | rest], opts, positionals) do
+    parse_flags(rest, [{:team, value} | opts], positionals)
   end
 
   defp parse_flags(["--actor", value | rest], opts, positionals) do
@@ -330,6 +478,42 @@ defmodule Sykli.CLI.Work do
 
   defp store_opts(runtime_opts), do: Keyword.take(runtime_opts, [:path])
 
+  defp team_mode?(opts), do: Keyword.has_key?(opts, :team)
+
+  defp team_session(opts, runtime_opts) do
+    requested_team = Keyword.get(opts, :team)
+
+    with {:ok, session} <-
+           session_store(runtime_opts).read(path: Keyword.get(runtime_opts, :path)),
+         :ok <- validate_requested_team(session, requested_team),
+         {:ok, token} <- team_token(runtime_opts) do
+      {:ok, session, token}
+    end
+  end
+
+  defp validate_requested_team(_session, team) when team in [nil, ""],
+    do: {:error, :team_work_team_required}
+
+  defp validate_requested_team(%{"team" => team}, team), do: :ok
+
+  defp validate_requested_team(%{"team" => joined_team}, requested_team),
+    do: {:error, {:team_work_team_mismatch, requested_team, joined_team}}
+
+  defp team_token(runtime_opts) do
+    case Keyword.get(runtime_opts, :team_token) || System.get_env("SYKLI_TEAM_TOKEN") do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, :team_work_missing_token}
+    end
+  end
+
+  defp session_store(runtime_opts), do: Keyword.get(runtime_opts, :session_store, SessionStore)
+  defp work_client(runtime_opts), do: Keyword.get(runtime_opts, :work_client, WorkClient)
+  defp client_opts(runtime_opts), do: Keyword.take(runtime_opts, [:client])
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, ""), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
   defp output_success(data, opts, human_fun) do
     if Keyword.get(opts, :json, false) do
       IO.puts(JsonResponse.ok(data))
@@ -341,7 +525,7 @@ defmodule Sykli.CLI.Work do
   end
 
   defp output_error(reason, json_output) do
-    error = Error.wrap(reason)
+    error = work_error(reason)
 
     if json_output do
       IO.puts(JsonResponse.error(error))
@@ -350,6 +534,88 @@ defmodule Sykli.CLI.Work do
     end
 
     1
+  end
+
+  defp work_error(:daemon_session_not_found),
+    do: team_error("work.team_not_joined", "team work requires `sykli daemon join` first")
+
+  defp work_error(:daemon_session_malformed),
+    do: team_error("work.team_session_invalid", "local daemon coordinator session is malformed")
+
+  defp work_error(:daemon_session_invalid),
+    do: team_error("work.team_session_invalid", "local daemon coordinator session is invalid")
+
+  defp work_error(:team_work_missing_token),
+    do: team_error("work.team_missing_token", "team work requires SYKLI_TEAM_TOKEN")
+
+  defp work_error(:team_work_team_required),
+    do: team_error("work.team_required", "team mode requires --team <team>")
+
+  defp work_error({:team_work_team_mismatch, requested, joined}),
+    do:
+      team_error(
+        "work.team_mismatch",
+        "requested team #{inspect(requested)} does not match joined team #{inspect(joined)}"
+      )
+
+  defp work_error(:team_work_runs_not_supported),
+    do:
+      team_error(
+        "work.team_runs_not_supported",
+        "`sykli work runs --team` is not available until run summary sync"
+      )
+
+  defp work_error(:team_unauthorized),
+    do:
+      team_error(
+        "work.team_unauthorized",
+        "coordinator rejected team work authorization"
+      )
+
+  defp work_error({:team_coordinator_unavailable, reason}),
+    do:
+      team_error(
+        "work.team_coordinator_unavailable",
+        "coordinator unavailable: #{inspect(reason)}"
+      )
+
+  defp work_error(:team_invalid_coordinator_response),
+    do: team_error("work.team_invalid_coordinator_response", "coordinator returned invalid JSON")
+
+  defp work_error({:team_invalid_coordinator_response, _data}),
+    do:
+      team_error(
+        "work.team_invalid_coordinator_response",
+        "coordinator returned an unexpected JSON shape"
+      )
+
+  defp work_error({:team_coordinator_error, %{"code" => code, "message" => message} = error}) do
+    %Error{
+      code: code,
+      type: :runtime,
+      message: message,
+      step: :setup,
+      hints: Map.get(error, "hints", [])
+    }
+  end
+
+  defp work_error({:team_coordinator_error, error}),
+    do:
+      team_error(
+        "work.team_coordinator_error",
+        "coordinator rejected team work request: #{inspect(error)}"
+      )
+
+  defp work_error(reason), do: Error.wrap(reason)
+
+  defp team_error(code, message) do
+    %Error{
+      code: code,
+      type: :runtime,
+      message: message,
+      step: :setup,
+      hints: []
+    }
   end
 
   defp item_map(%WorkItem{} = item), do: WorkItem.to_map(item)
@@ -370,24 +636,38 @@ defmodule Sykli.CLI.Work do
     end
   end
 
+  defp print_remote_item(item) do
+    IO.puts("#{item["id"]}  #{item["status"]}  #{item["title"]}")
+
+    if item["intent"] do
+      IO.puts("intent: #{item["intent"]}")
+    end
+
+    if item["assigned_to_type"] && item["assigned_to_id"] do
+      IO.puts("assigned: #{item["assigned_to_type"]}:#{item["assigned_to_id"]}")
+    end
+  end
+
   defp print_help do
     IO.puts("""
     Usage: sykli work <command>
 
-    Local work item commands.
+    Local work item commands by default. Add `--team TEAM` to use a joined
+    self-hosted coordinator for shared team work items.
 
     Unquoted title/body words are joined with spaces. Unknown flags are rejected.
 
     Commands:
-      sykli work create "Title" [--intent TEXT] [--actor TYPE:ID]
-      sykli work list
-      sykli work show <work-id>
-      sykli work claim <work-id> [--actor TYPE:ID]
-      sykli work note <work-id> "Body" [--actor TYPE:ID]
+      sykli work create "Title" [--intent TEXT] [--actor TYPE:ID] [--team TEAM]
+      sykli work list [--team TEAM]
+      sykli work show <work-id> [--team TEAM]
+      sykli work claim <work-id> [--actor TYPE:ID] [--team TEAM]
+      sykli work note <work-id> "Body" [--actor TYPE:ID] [--team TEAM]
       sykli work runs <work-id>
 
     Options:
       --json          Output as JSON
+      --team TEAM     Use the joined coordinator team instead of local .sykli state
       --intent TEXT   Set work item intent when creating
       --actor TYPE:ID Set actor identity, e.g. member:yair, agent:claude, daemon:worker-1
     """)

--- a/core/lib/sykli/team_coordinator/work_client.ex
+++ b/core/lib/sykli/team_coordinator/work_client.ex
@@ -1,0 +1,92 @@
+defmodule Sykli.TeamCoordinator.WorkClient do
+  @moduledoc """
+  Client helpers for Team Mode work-item operations.
+
+  This module is intentionally a thin adapter over the coordinator HTTP API.
+  It does not cache team work locally and it does not execute or assign work.
+  """
+
+  alias Sykli.Coordinator.Client
+  alias Sykli.WorkItem
+
+  def create(session, token, attrs, opts \\ []) do
+    body =
+      attrs
+      |> Map.take(["title", "intent", "created_by"])
+      |> Map.put("org_slug", session["org"])
+      |> Map.put("team_slug", session["team"])
+
+    session
+    |> post_json("/v1/work-items", token, body, opts)
+    |> unwrap("work_item")
+  end
+
+  def list(session, token, opts \\ []) do
+    session
+    |> get_json(work_items_path(session), token, opts)
+    |> unwrap("items")
+  end
+
+  def show(session, token, id, opts \\ []) do
+    with :ok <- WorkItem.validate_id(id) do
+      session
+      |> get_json("/v1/work-items/#{id}", token, opts)
+      |> unwrap("work_item")
+    end
+  end
+
+  def claim(session, token, id, attrs, opts \\ []) do
+    with :ok <- WorkItem.validate_id(id) do
+      session
+      |> post_json("/v1/work-items/#{id}/claim", token, attrs, opts)
+      |> unwrap("work_item")
+    end
+  end
+
+  def note(session, token, id, attrs, opts \\ []) do
+    with :ok <- WorkItem.validate_id(id) do
+      session
+      |> post_json("/v1/work-items/#{id}/notes", token, attrs, opts)
+      |> unwrap("note")
+    end
+  end
+
+  defp work_items_path(%{"team_id" => team_id}) when is_binary(team_id) and team_id != "" do
+    "/v1/work-items?" <> URI.encode_query(%{"team_id" => team_id})
+  end
+
+  defp work_items_path(_session), do: "/v1/work-items"
+
+  defp get_json(session, path, token, opts) do
+    client(opts).get_json(session["coordinator"], path, token)
+  end
+
+  defp post_json(session, path, token, body, opts) do
+    client(opts).post_json(session["coordinator"], path, token, body)
+  end
+
+  defp unwrap({:ok, data}, key) do
+    case Map.fetch(data, key) do
+      {:ok, value} -> {:ok, value}
+      :error -> {:error, {:team_invalid_coordinator_response, data}}
+    end
+  end
+
+  defp unwrap({:error, {:coordinator_error, 401, _error}}, _key), do: {:error, :team_unauthorized}
+
+  defp unwrap({:error, {:coordinator_error, _status, error}}, _key),
+    do: {:error, {:team_coordinator_error, error}}
+
+  defp unwrap({:error, {:coordinator_unavailable, reason}}, _key),
+    do: {:error, {:team_coordinator_unavailable, reason}}
+
+  defp unwrap({:error, :invalid_coordinator_response}, _key),
+    do: {:error, :team_invalid_coordinator_response}
+
+  defp unwrap({:error, {:invalid_coordinator_response, data}}, _key),
+    do: {:error, {:team_invalid_coordinator_response, data}}
+
+  defp unwrap({:error, reason}, _key), do: {:error, reason}
+
+  defp client(opts), do: Keyword.get(opts, :client, Client)
+end

--- a/core/test/sykli/cli/work_test.exs
+++ b/core/test/sykli/cli/work_test.exs
@@ -4,6 +4,7 @@ defmodule Sykli.CLI.WorkTest do
   import ExUnit.CaptureIO
 
   alias Sykli.CLI.Work
+  alias Sykli.Daemon.SessionStore
   alias Sykli.RunHistory
 
   @moduletag :tmp_dir
@@ -162,6 +163,141 @@ defmodule Sykli.CLI.WorkTest do
     end
   end
 
+  describe "team work commands" do
+    setup %{tmp_dir: tmp_dir} do
+      write_session(tmp_dir)
+      :ok
+    end
+
+    test "create --team routes to coordinator and does not create local item", %{tmp_dir: tmp_dir} do
+      result =
+        run_json(["create", "Investigate deploy", "--team", "platform", "--json"],
+          path: tmp_dir,
+          work_client: __MODULE__.FakeTeamClient,
+          team_token: "secret",
+          now: @now
+        )
+
+      assert result["data"]["source"] == "team"
+      assert result["data"]["team"] == "platform"
+      assert result["data"]["item"]["id"] == "work_team_001"
+      refute File.exists?(Path.join([tmp_dir, ".sykli", "work", "items", "work_team_001.json"]))
+
+      assert_received {:create_team_work, "secret",
+                       %{"title" => "Investigate deploy", "created_by" => "member:test-user"}}
+    end
+
+    test "list show claim and note --team return team JSON", %{tmp_dir: tmp_dir} do
+      assert run_json(["list", "--team", "platform", "--json"],
+               path: tmp_dir,
+               work_client: __MODULE__.FakeTeamClient,
+               team_token: "secret"
+             )["data"]["items"] == [%{"id" => "work_team_001", "status" => "open"}]
+
+      assert run_json(["show", "work_team_001", "--team", "platform", "--json"],
+               path: tmp_dir,
+               work_client: __MODULE__.FakeTeamClient,
+               team_token: "secret"
+             )["data"]["item"]["id"] == "work_team_001"
+
+      claim =
+        run_json(["claim", "work_team_001", "--team", "platform", "--json"],
+          path: tmp_dir,
+          work_client: __MODULE__.FakeTeamClient,
+          team_token: "secret"
+        )
+
+      assert claim["data"]["item"]["status"] == "claimed"
+      assert claim["data"]["item"]["assigned_to_id"] == "test-user"
+
+      note =
+        run_json(["note", "work_team_001", "Found issue", "--team", "platform", "--json"],
+          path: tmp_dir,
+          work_client: __MODULE__.FakeTeamClient,
+          team_token: "secret"
+        )
+
+      assert note["data"]["note"]["body"] == "Found issue"
+      assert note["data"]["source"] == "team"
+    end
+
+    test "team mode without joined session fails and does not fall back locally", %{
+      tmp_dir: tmp_dir
+    } do
+      File.rm!(SessionStore.path(path: tmp_dir))
+
+      result =
+        run_json(["create", "Investigate deploy", "--team", "platform", "--json"],
+          path: tmp_dir,
+          work_client: __MODULE__.FakeTeamClient,
+          team_token: "secret",
+          expect: 1
+        )
+
+      assert result["error"]["code"] == "work.team_not_joined"
+      assert {:ok, []} = Sykli.Work.Store.list(path: tmp_dir)
+    end
+
+    test "team mismatch and missing token fail clearly", %{tmp_dir: tmp_dir} do
+      mismatch =
+        run_json(["list", "--team", "other", "--json"],
+          path: tmp_dir,
+          work_client: __MODULE__.FakeTeamClient,
+          team_token: "secret",
+          expect: 1
+        )
+
+      assert mismatch["error"]["code"] == "work.team_mismatch"
+
+      missing_token =
+        run_json(["list", "--team", "platform", "--json"],
+          path: tmp_dir,
+          work_client: __MODULE__.FakeTeamClient,
+          expect: 1
+        )
+
+      assert missing_token["error"]["code"] == "work.team_missing_token"
+    end
+
+    test "coordinator unavailable and unauthorized are structured without token leakage", %{
+      tmp_dir: tmp_dir
+    } do
+      unavailable =
+        run_json(["list", "--team", "platform", "--json"],
+          path: tmp_dir,
+          work_client: __MODULE__.UnavailableTeamClient,
+          team_token: "super-secret",
+          expect: 1
+        )
+
+      assert unavailable["error"]["code"] == "work.team_coordinator_unavailable"
+      refute Jason.encode!(unavailable) =~ "super-secret"
+
+      unauthorized =
+        run_json(["list", "--team", "platform", "--json"],
+          path: tmp_dir,
+          work_client: __MODULE__.UnauthorizedTeamClient,
+          team_token: "super-secret",
+          expect: 1
+        )
+
+      assert unauthorized["error"]["code"] == "work.team_unauthorized"
+      refute Jason.encode!(unauthorized) =~ "super-secret"
+    end
+
+    test "team runs command is explicitly unsupported before run sync", %{tmp_dir: tmp_dir} do
+      result =
+        run_json(["runs", "work_team_001", "--team", "platform", "--json"],
+          path: tmp_dir,
+          work_client: __MODULE__.FakeTeamClient,
+          team_token: "secret",
+          expect: 1
+        )
+
+      assert result["error"]["code"] == "work.team_runs_not_supported"
+    end
+  end
+
   describe "errors" do
     test "create without title returns structured JSON error", %{tmp_dir: tmp_dir} do
       result = run_json(["create", "--json"], path: tmp_dir, expect: 1)
@@ -266,5 +402,71 @@ defmodule Sykli.CLI.WorkTest do
     }
 
     :ok = RunHistory.save(run, path: tmp_dir)
+  end
+
+  defp write_session(tmp_dir) do
+    {:ok, _session} =
+      SessionStore.write(
+        %{
+          "coordinator" => "https://sykli.internal",
+          "org" => "false-systems",
+          "team" => "platform",
+          "daemon_id" => "test-daemon",
+          "session_id" => "sess_001",
+          "team_id" => "team_001",
+          "heartbeat_interval_seconds" => 15,
+          "policy" => %{"upload_raw_logs_by_default" => false},
+          "labels" => [],
+          "capabilities" => ["local"],
+          "accepts_remote_work" => false,
+          "joined_at" => @now
+        },
+        path: tmp_dir
+      )
+  end
+
+  defmodule FakeTeamClient do
+    def create(session, token, attrs, _opts) do
+      send(self(), {:create_team_work, token, attrs})
+
+      {:ok,
+       %{
+         "id" => "work_team_001",
+         "team_id" => session["team_id"],
+         "title" => attrs["title"],
+         "status" => "open"
+       }}
+    end
+
+    def list(_session, _token, _opts) do
+      {:ok, [%{"id" => "work_team_001", "status" => "open"}]}
+    end
+
+    def show(_session, _token, "work_team_001", _opts) do
+      {:ok, %{"id" => "work_team_001", "status" => "open", "title" => "Investigate deploy"}}
+    end
+
+    def claim(_session, _token, "work_team_001", attrs, _opts) do
+      {:ok,
+       %{
+         "id" => "work_team_001",
+         "status" => "claimed",
+         "assigned_to_type" => attrs["assigned_to_type"],
+         "assigned_to_id" => attrs["assigned_to_id"]
+       }}
+    end
+
+    def note(_session, _token, "work_team_001", attrs, _opts) do
+      {:ok, %{"id" => "note_001", "work_item_id" => "work_team_001", "body" => attrs["body"]}}
+    end
+  end
+
+  defmodule UnavailableTeamClient do
+    def list(_session, _token, _opts),
+      do: {:error, {:team_coordinator_unavailable, :econnrefused}}
+  end
+
+  defmodule UnauthorizedTeamClient do
+    def list(_session, _token, _opts), do: {:error, :team_unauthorized}
   end
 end

--- a/core/test/sykli/team_coordinator/work_client_test.exs
+++ b/core/test/sykli/team_coordinator/work_client_test.exs
@@ -1,0 +1,121 @@
+defmodule Sykli.TeamCoordinator.WorkClientTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.TeamCoordinator.WorkClient
+
+  @session %{
+    "coordinator" => "https://sykli.internal",
+    "org" => "false-systems",
+    "team" => "platform",
+    "team_id" => "team_001"
+  }
+
+  test "create work sends authenticated coordinator request" do
+    assert {:ok, %{"id" => "work_001"}} =
+             WorkClient.create(
+               @session,
+               "secret",
+               %{"title" => "Investigate deploy", "created_by" => "member:yair"},
+               client: __MODULE__.FakeClient
+             )
+
+    assert_received {:post, "https://sykli.internal", "/v1/work-items", "secret",
+                     %{
+                       "org_slug" => "false-systems",
+                       "team_slug" => "platform",
+                       "title" => "Investigate deploy",
+                       "created_by" => "member:yair"
+                     }}
+  end
+
+  test "list show claim and note use authenticated team endpoints" do
+    assert {:ok, [%{"id" => "work_001"}]} =
+             WorkClient.list(@session, "secret", client: __MODULE__.FakeClient)
+
+    assert {:ok, %{"id" => "work_001"}} =
+             WorkClient.show(@session, "secret", "work_001", client: __MODULE__.FakeClient)
+
+    assert {:ok, %{"status" => "claimed"}} =
+             WorkClient.claim(
+               @session,
+               "secret",
+               "work_001",
+               %{"assigned_to_type" => "member", "assigned_to_id" => "yair"},
+               client: __MODULE__.FakeClient
+             )
+
+    assert {:ok, %{"body" => "Found issue"}} =
+             WorkClient.note(
+               @session,
+               "secret",
+               "work_001",
+               %{"body" => "Found issue"},
+               client: __MODULE__.FakeClient
+             )
+
+    assert_received {:get, _, "/v1/work-items?team_id=team_001", "secret"}
+    assert_received {:get, _, "/v1/work-items/work_001", "secret"}
+    assert_received {:post, _, "/v1/work-items/work_001/claim", "secret", _}
+    assert_received {:post, _, "/v1/work-items/work_001/notes", "secret", _}
+  end
+
+  test "rejects invalid ids before building path" do
+    assert {:error, {:invalid_work_item_id, "../escape"}} =
+             WorkClient.show(@session, "secret", "../escape", client: __MODULE__.FakeClient)
+
+    refute_received {:get, _, _, _}
+  end
+
+  test "maps coordinator transport and response errors" do
+    assert {:error, :team_unauthorized} =
+             WorkClient.list(@session, "secret", client: __MODULE__.UnauthorizedClient)
+
+    assert {:error, {:team_coordinator_error, %{"code" => "work_item_not_found"}}} =
+             WorkClient.show(@session, "secret", "missing", client: __MODULE__.NotFoundClient)
+
+    assert {:error, :team_invalid_coordinator_response} =
+             WorkClient.list(@session, "secret", client: __MODULE__.InvalidJsonClient)
+
+    assert {:error, {:team_coordinator_unavailable, :econnrefused}} =
+             WorkClient.list(@session, "secret", client: __MODULE__.UnavailableClient)
+  end
+
+  defmodule FakeClient do
+    def post_json(base, path, token, body) do
+      send(self(), {:post, base, path, token, body})
+
+      case path do
+        "/v1/work-items" -> {:ok, %{"work_item" => %{"id" => "work_001"}}}
+        "/v1/work-items/work_001/claim" -> {:ok, %{"work_item" => %{"status" => "claimed"}}}
+        "/v1/work-items/work_001/notes" -> {:ok, %{"note" => %{"body" => body["body"]}}}
+      end
+    end
+
+    def get_json(base, path, token) do
+      send(self(), {:get, base, path, token})
+
+      case path do
+        "/v1/work-items?team_id=team_001" -> {:ok, %{"items" => [%{"id" => "work_001"}]}}
+        "/v1/work-items/work_001" -> {:ok, %{"work_item" => %{"id" => "work_001"}}}
+      end
+    end
+  end
+
+  defmodule UnauthorizedClient do
+    def get_json(_base, _path, _token),
+      do: {:error, {:coordinator_error, 401, %{"code" => "coordinator.unauthorized"}}}
+  end
+
+  defmodule NotFoundClient do
+    def get_json(_base, _path, _token),
+      do: {:error, {:coordinator_error, 404, %{"code" => "work_item_not_found"}}}
+  end
+
+  defmodule InvalidJsonClient do
+    def get_json(_base, _path, _token), do: {:error, :invalid_coordinator_response}
+  end
+
+  defmodule UnavailableClient do
+    def get_json(_base, _path, _token), do: {:error, {:coordinator_unavailable, :econnrefused}}
+  end
+end

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -162,6 +162,16 @@ daemon status/session JSON surfaces.
 | `invalid_work_item` | A local work item command encountered structurally invalid work item data or arguments. | public-unstable | `core/lib/sykli/error.ex:654` |
 | `invalid_work_item_id` | A local work item id failed validation, including path traversal attempts. | public-unstable | `core/lib/sykli/error.ex:622` |
 | `malformed_work_item_json` | A persisted `.sykli/work/items/<id>.json` file is not valid JSON. | public-unstable | `core/lib/sykli/error.ex:643` |
+| `work.team_coordinator_error` | The coordinator rejected a team work command with a structured non-auth error. | public-unstable | `core/lib/sykli/cli/work.ex` |
+| `work.team_coordinator_unavailable` | A team work command could not reach the joined coordinator. | public-unstable | `core/lib/sykli/cli/work.ex` |
+| `work.team_invalid_coordinator_response` | The coordinator returned invalid JSON or an unexpected response shape for a team work command. | public-unstable | `core/lib/sykli/cli/work.ex` |
+| `work.team_mismatch` | A team work command requested a team other than the joined coordinator team. | public-unstable | `core/lib/sykli/cli/work.ex` |
+| `work.team_missing_token` | A team work command was run without `SYKLI_TEAM_TOKEN`. | public-unstable | `core/lib/sykli/cli/work.ex` |
+| `work.team_not_joined` | A team work command was run before `sykli daemon join` created a local coordinator session. | public-unstable | `core/lib/sykli/cli/work.ex` |
+| `work.team_required` | Team mode was selected without a team name. | public-unstable | `core/lib/sykli/cli/work.ex` |
+| `work.team_runs_not_supported` | `sykli work runs --team` was requested before run summary sync exists. | public-unstable | `core/lib/sykli/cli/work.ex` |
+| `work.team_session_invalid` | The local daemon coordinator session file is malformed or invalid. | public-unstable | `core/lib/sykli/cli/work.ex` |
+| `work.team_unauthorized` | The coordinator rejected authorization for a team work command. | public-unstable | `core/lib/sykli/cli/work.ex` |
 | `work_item_already_claimed` | A local work item claim was rejected because the item is no longer open. | public-unstable | `core/lib/sykli/error.ex:632` |
 | `work_item_missing_title` | `sykli work create` was called without a title. | public-unstable | `core/lib/sykli/error.ex:602` |
 | `work_item_not_found` | A requested local work item does not exist. | public-unstable | `core/lib/sykli/error.ex:612` |

--- a/docs/local-state-plane.md
+++ b/docs/local-state-plane.md
@@ -203,8 +203,8 @@ agent surface. With the coordinator, the same command may touch:
 
 - The local plane (`.sykli/`) — for `sykli explain`, `sykli fix`, MCP
   tools, full evidence.
-- The coordinator — for `sykli work list --team`, `sykli gate approve`,
-  team-wide queries.
+- The coordinator — for `sykli work list --team platform` and later
+  team-wide run/gate queries.
 
 A command that operates on both must be explicit about which it is
 reading. The CLI surface in `docs/team-mode-roadmap.md` uses `--team` (or
@@ -214,7 +214,7 @@ operation, exactly as today.
 
 This rule must hold for `--json` output as well: the envelope's `data`
 payload must carry a clear marker for which plane the answer came from
-(e.g. `"source": "local"` vs `"source": "coordinator"`).
+(e.g. `"source": "local"` vs `"source": "team"`).
 
 ## What the local plane gains in Phase 1+
 
@@ -263,6 +263,22 @@ sykli gate show <gate-id>
 sykli gate approve <gate-id> --reason "Evidence reviewed"
 sykli gate reject <gate-id> --reason "Not safe"
 ```
+
+Team work items are exposed through the same work commands with an
+explicit coordinator team:
+
+```bash
+sykli work create "Review PR #176" --team platform
+sykli work list --team platform
+sykli work show <work-id> --team platform
+sykli work claim <work-id> --team platform
+sykli work note <work-id> "Found likely API breakage" --team platform
+```
+
+These commands use the daemon session at `.sykli/daemon/session.json`
+and `SYKLI_TEAM_TOKEN`. They do not store remote work items in the local
+work-item store, and they do not sync runs, gates, logs, artifacts,
+source code, secrets, environment dumps, or full stdout/stderr.
 
 Each command supports `--json` and returns the shared CLI JSON envelope.
 

--- a/docs/self-hosted-coordinator.md
+++ b/docs/self-hosted-coordinator.md
@@ -164,6 +164,13 @@ Current behavior:
 - State-changing calls append in-memory audit events.
 - Daemon join and heartbeat sessions are stored in memory and are lost
   when the coordinator exits.
+- `sykli work create/list/show/claim/note --team <team>` can operate
+  against the coordinator after `sykli daemon join` writes a local
+  session file.
+- Team work commands require `SYKLI_TEAM_TOKEN`; the daemon session file
+  stores coordinator metadata but not the bearer token.
+- Team work commands fail rather than falling back to local `.sykli/`
+  state when the coordinator is unavailable or authorization fails.
 - Durable Postgres storage, migrations, and deployment assets remain
   follow-up work.
 

--- a/docs/team-mode-roadmap.md
+++ b/docs/team-mode-roadmap.md
@@ -250,29 +250,43 @@ Exit criteria:
 
 ## Phase 6 — Work sync
 
-The local work store gains a `--team` mode.
+The local work CLI gains a `--team <team>` mode.
 
-Suggested CLI:
+Implemented in PR #193:
 
 ```bash
-sykli work create --team "Investigate failing checkout deploy"
-sykli work list --team
-sykli work claim <work-id> --team
-sykli work assign <work-id> --to agent:claude --team
-sykli work note <work-id> --team "Investigated, see local evidence"
+sykli work create "Investigate failing checkout deploy" --team platform
+sykli work list --team platform
+sykli work show <work-id> --team platform
+sykli work claim <work-id> --team platform
+sykli work note <work-id> "Investigated, see local evidence" --team platform
 ```
 
 Without `--team`, every command is local exactly as in Phase 1. With
-`--team`, operations write to (or read from) the coordinator and the
-audit log records each one.
+`--team <team>`, operations read from or write to the coordinator using
+the daemon session created by `sykli daemon join`. Team mode requires
+`SYKLI_TEAM_TOKEN` because the session file intentionally does not store
+the bearer token.
+
+If team mode cannot reach or authenticate to the coordinator, the command
+fails. It does not silently fall back to local `.sykli/` state.
+
+Still out of scope:
+
+- `sykli work assign`
+- `sykli work runs --team`
+- local caching of coordinator work items
+- run summary sync
+- gate approval sync
 
 Exit criteria:
 
-- `sykli work list --team` returns the coordinator's view, paginated.
+- `sykli work list --team platform` returns the coordinator's view for
+  the joined team.
 - `sykli work claim <id> --team` is atomic at the coordinator: only one
   successful claim per work item.
-- `--json` envelope distinguishes `"source": "coordinator"` from
-  `"source": "local"`.
+- `--json` envelope distinguishes `"source": "team"` from `"source":
+  "local"`.
 
 ## Phase 7 — Run summary sync
 
@@ -442,11 +456,16 @@ Work:
 
 ```bash
 sykli work create "Investigate failing checkout deploy"
+sykli work create "Investigate failing checkout deploy" --team platform
 sykli work list
+sykli work list --team platform
 sykli work show <work-id>
+sykli work show <work-id> --team platform
 sykli work claim <work-id>
+sykli work claim <work-id> --team platform
 sykli work assign <work-id> --to agent:claude
 sykli work note <work-id> "Found likely API breakage"
+sykli work note <work-id> "Found likely API breakage" --team platform
 ```
 
 Run:
@@ -485,7 +504,7 @@ Concrete scenario the design optimizes for, achievable after Phases 6–8:
 
    ```bash
    sykli work list --team platform
-   sykli work claim <work-id>
+   sykli work claim <work-id> --team platform
    ```
 
 3. Dima's daemon runs a Sykli contract:

--- a/docs/team-mode-security.md
+++ b/docs/team-mode-security.md
@@ -105,11 +105,20 @@ Properties:
   `--token` flag. The current daemon session file stores coordinator
   URL, org/team, `session_id`, policy, labels, and capabilities, but does
   not persist the bearer token.
+- Reused by team work CLI calls through `SYKLI_TEAM_TOKEN` after
+  `sykli daemon join`. The token is not printed in normal or JSON
+  command output.
 
 Tokens are not user identities. They authenticate a daemon's right to
 participate in a team. Member identities (who claimed a work item, who
 approved a gate) are separately recorded based on the originating CLI
 or MCP call.
+
+Team work commands are explicit. Local work commands remain the default,
+and `sykli work ... --team <team>` fails rather than falling back to
+local state when no coordinator session exists, the requested team does
+not match the joined session, the token is missing, or authorization
+fails.
 
 ### Future — OIDC and GitHub org mapping
 

--- a/eval/oracle/run.sh
+++ b/eval/oracle/run.sh
@@ -1611,6 +1611,126 @@ if begin_case "074" "Coordinator: daemon join and heartbeat JSON"; then
   fi
 fi
 
+# --- case_075: team work CLI syncs through coordinator ---
+if begin_case "075" "Team Work: coordinator work CLI JSON"; then
+  if ! command -v curl &>/dev/null; then
+    skip "curl not available"
+  else
+    dir=$(tmp_workdir)
+    port=$((24000 + RANDOM % 10000))
+    (cd "$dir" && SYKLI_COORDINATOR_TOKEN=secret "$SYKLI_BIN" coordinator start --port "$port" >coordinator.log 2>&1) &
+    pid=$!
+
+    for _ in {1..80}; do
+      if curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 0.1
+    done
+
+    org_json=$(curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' \
+      -d '{"slug":"false-systems","name":"False Systems"}' \
+      "http://127.0.0.1:$port/v1/orgs")
+    org_id=$(echo "$org_json" | jq -r '.data.org.id')
+
+    curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' \
+      -d "{\"org_id\":\"$org_id\",\"slug\":\"platform\",\"name\":\"Platform\"}" \
+      "http://127.0.0.1:$port/v1/teams" >/dev/null
+
+    (cd "$dir" && "$SYKLI_BIN" daemon join \
+      --coordinator "http://127.0.0.1:$port" \
+      --org false-systems \
+      --team platform \
+      --token secret \
+      --name oracle-daemon \
+      --json >/dev/null)
+
+    create_json=$(cd "$dir" && SYKLI_TEAM_TOKEN=secret "$SYKLI_BIN" work create "Team work item" --team platform --json)
+    work_id=$(echo "$create_json" | jq -r '.data.item.id')
+    list_json=$(cd "$dir" && SYKLI_TEAM_TOKEN=secret "$SYKLI_BIN" work list --team platform --json)
+    show_json=$(cd "$dir" && SYKLI_TEAM_TOKEN=secret "$SYKLI_BIN" work show "$work_id" --team platform --json)
+    claim_json=$(cd "$dir" && SYKLI_TEAM_TOKEN=secret "$SYKLI_BIN" work claim "$work_id" --team platform --json)
+    LAST_OUTPUT=$(cd "$dir" && SYKLI_TEAM_TOKEN=secret "$SYKLI_BIN" work note "$work_id" "Found issue" --team platform --json 2>&1) && exit_code=0 || exit_code=$?
+
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+
+    if assert_exit 0 "$exit_code"; then
+      if assert_json_field "$create_json" '.data.source' "team"; then
+        if assert_json_field "$list_json" '.data.items[0].title' "Team work item"; then
+          if assert_json_field "$show_json" '.data.item.id' "$work_id"; then
+            if assert_json_field "$claim_json" '.data.item.status' "claimed"; then
+              if assert_json_field "$LAST_OUTPUT" '.data.note.body' "Found issue"; then
+                pass 0
+              fi
+            fi
+          fi
+        fi
+      fi
+    fi
+    rm -rf "$dir"
+  fi
+fi
+
+# --- case_076: team work without joined session returns JSON error ---
+if begin_case "076" "Team Work: not joined JSON error"; then
+  dir=$(tmp_workdir)
+  LAST_OUTPUT=$(cd "$dir" && SYKLI_TEAM_TOKEN=secret "$SYKLI_BIN" work list --team platform --json 2>&1) && exit_code=0 || exit_code=$?
+  if assert_exit 1 "$exit_code"; then
+    if assert_json_field "$LAST_OUTPUT" '.error.code' "work.team_not_joined"; then
+      pass 0
+    fi
+  fi
+  rm -rf "$dir"
+fi
+
+# --- case_077: team work unauthorized returns JSON error ---
+if begin_case "077" "Team Work: unauthorized JSON error"; then
+  if ! command -v curl &>/dev/null; then
+    skip "curl not available"
+  else
+    dir=$(tmp_workdir)
+    port=$((24000 + RANDOM % 10000))
+    (cd "$dir" && SYKLI_COORDINATOR_TOKEN=secret "$SYKLI_BIN" coordinator start --port "$port" >coordinator.log 2>&1) &
+    pid=$!
+
+    for _ in {1..80}; do
+      if curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 0.1
+    done
+
+    org_json=$(curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' \
+      -d '{"slug":"false-systems","name":"False Systems"}' \
+      "http://127.0.0.1:$port/v1/orgs")
+    org_id=$(echo "$org_json" | jq -r '.data.org.id')
+
+    curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' \
+      -d "{\"org_id\":\"$org_id\",\"slug\":\"platform\",\"name\":\"Platform\"}" \
+      "http://127.0.0.1:$port/v1/teams" >/dev/null
+
+    (cd "$dir" && "$SYKLI_BIN" daemon join \
+      --coordinator "http://127.0.0.1:$port" \
+      --org false-systems \
+      --team platform \
+      --token secret \
+      --name oracle-daemon \
+      --json >/dev/null)
+
+    LAST_OUTPUT=$(cd "$dir" && SYKLI_TEAM_TOKEN=wrong "$SYKLI_BIN" work list --team platform --json 2>&1) && exit_code=0 || exit_code=$?
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+
+    if assert_exit 1 "$exit_code"; then
+      if assert_json_field "$LAST_OUTPUT" '.error.code' "work.team_unauthorized"; then
+        pass 0
+      fi
+    fi
+    rm -rf "$dir"
+  fi
+fi
+
 # ============================================================================
 # Summary
 # ============================================================================

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -1702,6 +1702,40 @@
       "validated_by": "Injected bug: daemon join leaks token, defaults accepts_remote_work true, or heartbeat does not update coordinator state."
     },
     {
+      "id": "COORD-003",
+      "name": "team work CLI syncs through coordinator",
+      "fixture": "empty_dir",
+      "command": "port=$((24000 + RANDOM % 10000)); SYKLI_COORDINATOR_TOKEN=secret sykli coordinator start --port \"$port\" >coord.log 2>&1 & pid=$!; trap 'kill $pid 2>/dev/null || true' EXIT; for i in {1..80}; do curl -fsS \"http://127.0.0.1:$port/health\" >/dev/null 2>&1 && break; sleep 0.1; done; curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' -d '{\"slug\":\"false-systems\",\"name\":\"False Systems\"}' \"http://127.0.0.1:$port/v1/orgs\" >org.json; org=$(jq -r '.data.org.id' org.json); curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' -d \"{\\\"org_id\\\":\\\"$org\\\",\\\"slug\\\":\\\"platform\\\",\\\"name\\\":\\\"Platform\\\"}\" \"http://127.0.0.1:$port/v1/teams\" >team.json; sykli daemon join --coordinator \"http://127.0.0.1:$port\" --org false-systems --team platform --token secret --name team-work-daemon --json >/dev/null; work=$(SYKLI_TEAM_TOKEN=secret sykli work create \"Team work item\" --team platform --json | jq -r '.data.item.id'); SYKLI_TEAM_TOKEN=secret sykli work list --team platform --json | jq -e --arg work \"$work\" '.data.source == \"team\" and .data.items[0].id == $work' >/dev/null; SYKLI_TEAM_TOKEN=secret sykli work show \"$work\" --team platform --json | jq -e --arg work \"$work\" '.data.item.id == $work' >/dev/null; SYKLI_TEAM_TOKEN=secret sykli work claim \"$work\" --team platform --json | jq -e '.data.item.status == \"claimed\" and .data.item.assigned_to_type == \"member\"' >/dev/null; SYKLI_TEAM_TOKEN=secret sykli work note \"$work\" \"Found likely API breakage\" --team platform --json >note.json; test ! -f \".sykli/work/items/$work.json\"; local=$(sykli work create \"Local still default\" --json | jq -r '.data.item.id'); test -f \".sykli/work/items/$local.json\"; cat note.json",
+      "shell": true,
+      "requires": "curl",
+      "expect_exit": 0,
+      "expect_json_jq": [
+        ".ok == true",
+        ".data.source == \"team\"",
+        ".data.team == \"platform\"",
+        ".data.note.body == \"Found likely API breakage\"",
+        ".data.note | has(\"logs\") | not",
+        ".data.note | has(\"artifacts\") | not",
+        ".data.note | has(\"secrets\") | not"
+      ],
+      "source": "docs/team-mode-roadmap.md Phase 6; team work commands use coordinator only when --team is explicit",
+      "validated_by": "Injected bug: team work commands fall back to local, omit auth/session, or leak raw logs/artifacts/secrets."
+    },
+    {
+      "id": "COORD-004",
+      "name": "team work without join fails without local fallback",
+      "fixture": "empty_dir",
+      "command": "SYKLI_TEAM_TOKEN=secret sykli work create \"Should not be local\" --team platform --json >out.json; code=$?; test \"$code\" = 1; test ! -d .sykli/work/items; cat out.json",
+      "shell": true,
+      "expect_exit": 0,
+      "expect_json_jq": [
+        ".ok == false",
+        ".error.code == \"work.team_not_joined\""
+      ],
+      "source": "docs/team-mode-security.md; team mode must not silently fall back to local mode",
+      "validated_by": "Injected bug: missing coordinator session still creates a local .sykli work item."
+    },
+    {
       "id": "GH-001",
       "name": "Receiver refuses to start without webhook role",
       "fixture": "single_task",


### PR DESCRIPTION
## Summary

This PR lets `sykli work ... --team <team>` operate against the self-hosted Team Mode coordinator while keeping local work commands as the default.

## Why

Local work items, the coordinator skeleton, and daemon join/heartbeat now exist. Teams need the first shared workflow: creating, listing, showing, claiming, and annotating work items through the coordinator. This is still coordination only: no run sync, no gate sync, and no remote execution.

## What changed

- Added `Sykli.TeamCoordinator.WorkClient` for coordinator work-item API calls.
- Routed `sykli work create/list/show/claim/note --team <team>` through the coordinator.
- Kept local work commands as the default when `--team` is omitted.
- Resolved team mode from the local daemon session created by `sykli daemon join`.
- Required `SYKLI_TEAM_TOKEN` for team work calls because the session file does not persist bearer tokens.
- Added structured team-mode errors for not-joined, missing token, team mismatch, coordinator unavailable, unauthorized, invalid response, and unsupported `work runs --team`.
- Updated docs and public-unstable error-code catalog.

## Security behavior

- Local mode remains default.
- Team mode requires an existing coordinator session and bearer token.
- Failed team mode does not silently fall back to local state.
- Tokens are not printed in normal or JSON output.
- No remote execution, remote shell, run sync, gate sync, artifact upload, log upload, source upload, or secret sync was added.

## Validation

- `git diff --check` - passed.
- `cd core && mix format lib/sykli/cli.ex lib/sykli/cli/work.ex lib/sykli/team_coordinator/work_client.ex test/sykli/cli/work_test.exs test/sykli/team_coordinator/work_client_test.exs` - passed.
- `cd core && mix test test/sykli/team_coordinator/work_client_test.exs test/sykli/cli/work_test.exs` - passed, 30 tests.
- `cd core && mix test` - passed, 1649 tests, 1 skipped, 13 excluded.
- `cd core && mix credo --strict` - passed, no issues.
- `cd core && mix escript.build` - passed.
- `eval/oracle/run.sh --case 075` - passed.
- `eval/oracle/run.sh --case 076` - passed.
- `eval/oracle/run.sh --case 077` - passed.
- `test/blackbox/run.sh --filter=COORD-003` - passed.
- `test/blackbox/run.sh --filter=COORD-004` - passed.

Note: I initially invoked blackbox with the wrong filter form (`--filter COORD-003` / `--filter COORD-004`), which ran the full dataset twice. The new `COORD-003` and `COORD-004` cases passed in those runs, but the full dataset still reported pre-existing unrelated failures for `POS-006` version text and stale SDK expected-red markers.

## Oracle coverage

- `075` - team work create/list/show/claim/note through coordinator JSON.
- `076` - `--team` without joined session returns `work.team_not_joined`.
- `077` - unauthorized team work returns `work.team_unauthorized`.

## Blackbox coverage

- `COORD-003` - full team work CLI workflow through coordinator, plus local commands still create local `.sykli/` state when `--team` is omitted.
- `COORD-004` - team work without join fails and does not create a local fallback item.

## Out of scope

- No run sync.
- No gate sync.
- No remote execution.
- No MCP.
- No Kubernetes deployment.
- No web UI.

## Next PR

Sync run summaries to coordinator:

- safe run summary projection
- `POST/PATCH /v1/runs`
- node summary sync
- evidence refs
- no raw logs/secrets/artifacts by default
- oracle and blackbox coverage
