### PR TITLE
Typed failure semantics V1

### DIFF
--- a/core/lib/sykli.ex
+++ b/core/lib/sykli.ex
@@ -276,7 +276,8 @@ defmodule Sykli do
             status: t.status,
             duration_ms: t.duration_ms,
             cached: t.cached,
-            error: t.error
+            error: t.error,
+            failure_semantics: t.failure_semantics
           }
         end)
     }
@@ -449,6 +450,9 @@ defmodule Sykli do
         duration_ms: result.duration_ms,
         cached: result.status == :cached,
         error: format_error_for_history(result.error),
+        failure_semantics:
+          result.failure_semantics ||
+            Sykli.FailureSemantics.for_result(result.status, result.error),
         inputs: inputs,
         streak: streak
       }

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -412,6 +412,7 @@ defmodule Sykli.CLI do
       }
       |> maybe_add_success_criteria_results(r.success_criteria_results)
       |> maybe_add_review_result(r.review_result)
+      |> maybe_add_failure_semantics(r.failure_semantics)
 
     case r.error do
       %Sykli.Error{} = err ->
@@ -435,6 +436,12 @@ defmodule Sykli.CLI do
 
   defp maybe_add_review_result(base, result) do
     Map.put(base, :review_result, review_result_to_map(result))
+  end
+
+  defp maybe_add_failure_semantics(base, nil), do: base
+
+  defp maybe_add_failure_semantics(base, semantics) do
+    Map.put(base, :failure_semantics, Sykli.FailureSemantics.to_map(semantics))
   end
 
   defp review_result_to_map(result) do
@@ -2113,7 +2120,8 @@ defmodule Sykli.CLI do
                     status: t.status,
                     duration_ms: t.duration_ms,
                     cached: t.cached,
-                    error: t.error
+                    error: t.error,
+                    failure_semantics: t.failure_semantics
                   }
                 end)
             }
@@ -2415,12 +2423,20 @@ defmodule Sykli.CLI do
             streak: t.streak
           }
           |> maybe_put(:error, t.error)
+          |> maybe_put(:failure_semantics, history_failure_semantics(t.failure_semantics))
           |> maybe_put(:likely_cause, t.likely_cause)
         end)
     }
 
     IO.puts(JsonResponse.ok(output))
   end
+
+  defp history_failure_semantics(nil), do: nil
+
+  defp history_failure_semantics(%Sykli.FailureSemantics{} = semantics),
+    do: Sykli.FailureSemantics.to_map(semantics)
+
+  defp history_failure_semantics(map) when is_map(map), do: map
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -2423,20 +2423,13 @@ defmodule Sykli.CLI do
             streak: t.streak
           }
           |> maybe_put(:error, t.error)
-          |> maybe_put(:failure_semantics, history_failure_semantics(t.failure_semantics))
+          |> maybe_put(:failure_semantics, Sykli.FailureSemantics.to_map(t.failure_semantics))
           |> maybe_put(:likely_cause, t.likely_cause)
         end)
     }
 
     IO.puts(JsonResponse.ok(output))
   end
-
-  defp history_failure_semantics(nil), do: nil
-
-  defp history_failure_semantics(%Sykli.FailureSemantics{} = semantics),
-    do: Sykli.FailureSemantics.to_map(semantics)
-
-  defp history_failure_semantics(map) when is_map(map), do: map
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/core/lib/sykli/context.ex
+++ b/core/lib/sykli/context.ex
@@ -234,18 +234,11 @@ defmodule Sykli.Context do
       "duration_ms" => result[:duration_ms],
       "cached" => result[:cached] == true,
       "error" => result[:error],
-      "failure_semantics" => failure_semantics_to_map(result[:failure_semantics])
+      "failure_semantics" => Sykli.FailureSemantics.to_map(result[:failure_semantics])
     }
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
     |> Map.new()
   end
-
-  defp failure_semantics_to_map(nil), do: nil
-
-  defp failure_semantics_to_map(%Sykli.FailureSemantics{} = semantics),
-    do: Sykli.FailureSemantics.to_map(semantics)
-
-  defp failure_semantics_to_map(map) when is_map(map), do: map
 
   defp maybe_add_semantic(map, task) do
     if Task.has_semantic?(task) do

--- a/core/lib/sykli/context.ex
+++ b/core/lib/sykli/context.ex
@@ -233,11 +233,19 @@ defmodule Sykli.Context do
       "status" => to_string(result[:status] || :unknown),
       "duration_ms" => result[:duration_ms],
       "cached" => result[:cached] == true,
-      "error" => result[:error]
+      "error" => result[:error],
+      "failure_semantics" => failure_semantics_to_map(result[:failure_semantics])
     }
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
     |> Map.new()
   end
+
+  defp failure_semantics_to_map(nil), do: nil
+
+  defp failure_semantics_to_map(%Sykli.FailureSemantics{} = semantics),
+    do: Sykli.FailureSemantics.to_map(semantics)
+
+  defp failure_semantics_to_map(map) when is_map(map), do: map
 
   defp maybe_add_semantic(map, task) do
     if Task.has_semantic?(task) do

--- a/core/lib/sykli/executor.ex
+++ b/core/lib/sykli/executor.ex
@@ -424,16 +424,14 @@ defmodule Sykli.Executor do
             {{task_ref, {:exit, reason}}, original} ->
               Task.shutdown(task_ref, :brutal_kill)
 
+              error = Error.internal("task process crashed: #{inspect(reason)}")
+
               %TaskResult{
                 name: original.name,
                 status: :errored,
                 duration_ms: 0,
-                error: Error.internal("task process crashed: #{inspect(reason)}"),
-                failure_semantics:
-                  Sykli.FailureSemantics.internal_error(
-                    "task_process_crashed",
-                    "task process crashed"
-                  ),
+                error: error,
+                failure_semantics: Sykli.FailureSemantics.for_error(error),
                 command: original.command
               }
 
@@ -576,11 +574,17 @@ defmodule Sykli.Executor do
          ai_hooks: %{on_fail: :skip}
        })
        when status in [:failed, :errored] do
+    original_semantics = Sykli.FailureSemantics.to_map(result.failure_semantics)
+
     %TaskResult{
       result
       | status: :skipped,
         failure_semantics:
-          Sykli.FailureSemantics.skipped("ai_hook_skip", "task skipped by ai_hooks.on_fail")
+          Sykli.FailureSemantics.skipped(
+            "ai_hook_skip",
+            "task skipped by ai_hooks.on_fail",
+            %{original_failure_semantics: original_semantics}
+          )
     }
   end
 
@@ -658,17 +662,14 @@ defmodule Sykli.Executor do
                 Output.oidc_failed(task.name, reason)
 
                 duration = System.monotonic_time(:millisecond) - start_time
+                error = Error.internal("OIDC credential exchange failed: #{reason}")
 
                 %TaskResult{
                   name: task.name,
                   status: :errored,
                   duration_ms: duration,
-                  error: Error.internal("OIDC credential exchange failed: #{reason}"),
-                  failure_semantics:
-                    Sykli.FailureSemantics.internal_error(
-                      "oidc_exchange_failed",
-                      "OIDC credential exchange failed"
-                    ),
+                  error: error,
+                  failure_semantics: Sykli.FailureSemantics.for_error(error),
                   command: task.command
                 }
             end

--- a/core/lib/sykli/executor.ex
+++ b/core/lib/sykli/executor.ex
@@ -55,6 +55,7 @@ defmodule Sykli.Executor do
       :error,
       :output,
       :command,
+      :failure_semantics,
       :review_result,
       success_criteria_results: []
     ]
@@ -67,6 +68,7 @@ defmodule Sykli.Executor do
             error: term() | nil,
             output: String.t() | nil,
             command: String.t() | nil,
+            failure_semantics: Sykli.FailureSemantics.t() | nil,
             review_result: Sykli.ReviewPrimitive.Result.t() | nil,
             success_criteria_results: [Sykli.SuccessCriteria.Result.t()]
           }
@@ -399,6 +401,12 @@ defmodule Sykli.Executor do
                     status: :errored,
                     duration_ms: duration,
                     error: reason,
+                    failure_semantics:
+                      Sykli.FailureSemantics.dependency_failure(
+                        "task_input_resolution_failed",
+                        "task input resolution failed",
+                        %{reason: inspect(reason)}
+                      ),
                     command: task.command
                   }
               end
@@ -421,6 +429,11 @@ defmodule Sykli.Executor do
                 status: :errored,
                 duration_ms: 0,
                 error: Error.internal("task process crashed: #{inspect(reason)}"),
+                failure_semantics:
+                  Sykli.FailureSemantics.internal_error(
+                    "task_process_crashed",
+                    "task process crashed"
+                  ),
                 command: original.command
               }
 
@@ -432,6 +445,11 @@ defmodule Sykli.Executor do
                 status: :errored,
                 duration_ms: 0,
                 error: Error.internal("task process timed out"),
+                failure_semantics:
+                  Sykli.FailureSemantics.timeout(
+                    "task_process_timeout",
+                    "task process timed out"
+                  ),
                 command: original.command
               }
           end)
@@ -503,6 +521,11 @@ defmodule Sykli.Executor do
         status: :blocked,
         duration_ms: 0,
         error: :dependency_failed,
+        failure_semantics:
+          Sykli.FailureSemantics.dependency_failure(
+            "dependency_failed",
+            "blocked by failed dependency"
+          ),
         command: task.command
       }
     end)
@@ -553,7 +576,12 @@ defmodule Sykli.Executor do
          ai_hooks: %{on_fail: :skip}
        })
        when status in [:failed, :errored] do
-    %TaskResult{result | status: :skipped}
+    %TaskResult{
+      result
+      | status: :skipped,
+        failure_semantics:
+          Sykli.FailureSemantics.skipped("ai_hook_skip", "task skipped by ai_hooks.on_fail")
+    }
   end
 
   defp apply_on_fail_hook(result, _task), do: result
@@ -614,11 +642,14 @@ defmodule Sykli.Executor do
 
                     duration = System.monotonic_time(:millisecond) - start_time
 
+                    error = Error.missing_secrets(task.name, missing)
+
                     %TaskResult{
                       name: task.name,
                       status: :errored,
                       duration_ms: duration,
-                      error: Error.missing_secrets(task.name, missing),
+                      error: error,
+                      failure_semantics: Sykli.FailureSemantics.for_error(error),
                       command: task.command
                     }
                 end
@@ -633,6 +664,11 @@ defmodule Sykli.Executor do
                   status: :errored,
                   duration_ms: duration,
                   error: Error.internal("OIDC credential exchange failed: #{reason}"),
+                  failure_semantics:
+                    Sykli.FailureSemantics.internal_error(
+                      "oidc_exchange_failed",
+                      "OIDC credential exchange failed"
+                    ),
                   command: task.command
                 }
             end
@@ -650,6 +686,11 @@ defmodule Sykli.Executor do
             status: :skipped,
             duration_ms: duration,
             error: nil,
+            failure_semantics:
+              Sykli.FailureSemantics.skipped(
+                "condition_not_met",
+                "task skipped because condition was not met"
+              ),
             command: task.command
           }
         end
@@ -677,6 +718,7 @@ defmodule Sykli.Executor do
       status: status,
       duration_ms: System.monotonic_time(:millisecond) - start_time,
       error: error,
+      failure_semantics: if(error, do: Sykli.FailureSemantics.for_error(error)),
       command: nil,
       review_result: review_result
     }
@@ -719,6 +761,11 @@ defmodule Sykli.Executor do
           status: :failed,
           duration_ms: duration,
           error: Error.internal("gate '#{task.name}' denied: #{reason}"),
+          failure_semantics:
+            Sykli.FailureSemantics.policy_block(
+              "gate_denied",
+              "gate '#{task.name}' denied: #{reason}"
+            ),
           command: task.command
         }
 
@@ -732,6 +779,11 @@ defmodule Sykli.Executor do
           status: :failed,
           duration_ms: duration,
           error: Error.internal("gate '#{task.name}' timed out after #{gate.timeout}s"),
+          failure_semantics:
+            Sykli.FailureSemantics.timeout(
+              "gate_timeout",
+              "gate '#{task.name}' timed out after #{gate.timeout}s"
+            ),
           command: task.command
         }
     end
@@ -907,6 +959,7 @@ defmodule Sykli.Executor do
           error: run_result.error,
           output: run_result.output,
           command: task.command,
+          failure_semantics: Sykli.FailureSemantics.for_result(:failed, run_result.error),
           success_criteria_results: run_result.success_criteria_results
         }
 
@@ -920,6 +973,7 @@ defmodule Sykli.Executor do
           error: run_result.error,
           output: run_result.output,
           command: task.command,
+          failure_semantics: Sykli.FailureSemantics.for_result(:errored, run_result.error),
           success_criteria_results: run_result.success_criteria_results
         }
     end

--- a/core/lib/sykli/failure_semantics.ex
+++ b/core/lib/sykli/failure_semantics.ex
@@ -1,0 +1,277 @@
+defmodule Sykli.FailureSemantics do
+  @moduledoc """
+  Normalized task result/failure classification.
+
+  This is intentionally independent from the pipeline contract schema. It is
+  produced by the executor and persisted in history/occurrences so agents can
+  distinguish runtime failures, contract failures, unsupported targets, policy
+  blocks, and skipped work without reverse-engineering error strings.
+  """
+
+  @classes ~w(
+    runtime_failure
+    contract_failure
+    criteria_failure
+    unsupported_target
+    timeout
+    dependency_failure
+    policy_block
+    skipped
+    internal_error
+    unknown
+    missing_evidence
+    agent_variance_failure
+  )a
+
+  @sources ~w(executor target criteria gate dependency system unknown)a
+
+  @enforce_keys [:class, :retryable, :source, :reason, :message]
+  defstruct [:class, :retryable, :source, :reason, :message, details: %{}]
+
+  @type failure_class ::
+          :runtime_failure
+          | :contract_failure
+          | :criteria_failure
+          | :unsupported_target
+          | :timeout
+          | :dependency_failure
+          | :policy_block
+          | :skipped
+          | :internal_error
+          | :unknown
+          | :missing_evidence
+          | :agent_variance_failure
+
+  @type source :: :executor | :target | :criteria | :gate | :dependency | :system | :unknown
+
+  @type t :: %__MODULE__{
+          class: failure_class(),
+          retryable: boolean(),
+          source: source(),
+          reason: String.t(),
+          message: String.t(),
+          details: map()
+        }
+
+  def runtime_failure(reason, message, details \\ %{}) do
+    new(:runtime_failure, false, :target, reason, message, details)
+  end
+
+  def criteria_failure(reason, message, details \\ %{}) do
+    new(:criteria_failure, false, :criteria, reason, message, details)
+  end
+
+  def contract_failure(reason, message, details \\ %{}) do
+    new(:contract_failure, false, :executor, reason, message, details)
+  end
+
+  def unsupported_target(reason, message, details \\ %{}) do
+    new(:unsupported_target, false, :target, reason, message, details)
+  end
+
+  def timeout(reason, message, details \\ %{}) do
+    new(:timeout, true, :target, reason, message, details)
+  end
+
+  def dependency_failure(reason, message, details \\ %{}) do
+    new(:dependency_failure, false, :dependency, reason, message, details)
+  end
+
+  def policy_block(reason, message, details \\ %{}) do
+    new(:policy_block, false, :gate, reason, message, details)
+  end
+
+  def skipped(reason, message, details \\ %{}) do
+    new(:skipped, false, :executor, reason, message, details)
+  end
+
+  def internal_error(reason, message, details \\ %{}) do
+    new(:internal_error, false, :system, reason, message, details)
+  end
+
+  def unknown(reason, message, details \\ %{}) do
+    new(:unknown, false, :unknown, reason, message, details)
+  end
+
+  def missing_evidence(reason, message, details \\ %{}) do
+    new(:missing_evidence, false, :criteria, reason, message, details)
+  end
+
+  def agent_variance_failure(reason, message, details \\ %{}) do
+    new(:agent_variance_failure, false, :executor, reason, message, details)
+  end
+
+  @doc "Returns nil for successful/cached task results; otherwise classifies the result."
+  def for_result(:passed, _error), do: nil
+  def for_result(:cached, _error), do: nil
+  def for_result(:skipped, nil), do: skipped("condition_not_met", "task skipped")
+
+  def for_result(:skipped, reason),
+    do: skipped(to_reason(reason), message(reason, "task skipped"))
+
+  def for_result(:blocked, :dependency_failed),
+    do: dependency_failure("dependency_failed", "blocked by failed dependency")
+
+  def for_result(:blocked, reason),
+    do: dependency_failure(to_reason(reason), message(reason, "task blocked by dependency"))
+
+  def for_result(_status, %Sykli.Error{} = error), do: for_error(error)
+
+  def for_result(:errored, reason),
+    do: internal_error(to_reason(reason), message(reason, "task errored"))
+
+  def for_result(:failed, reason), do: unknown(to_reason(reason), message(reason, "task failed"))
+
+  def for_result(_status, reason),
+    do: unknown(to_reason(reason), message(reason, "task did not complete successfully"))
+
+  def for_error(%Sykli.Error{code: "task_failed"} = error) do
+    runtime_failure(
+      "command_failed",
+      error.message || "task command failed",
+      error_details(error)
+    )
+  end
+
+  def for_error(%Sykli.Error{code: "success_criteria_failed"} = error) do
+    criteria_failure(
+      "success_criteria_failed",
+      error.message || "success criteria failed",
+      error_details(error)
+    )
+  end
+
+  def for_error(%Sykli.Error{code: "unsupported_success_criteria_for_target"} = error) do
+    unsupported_target(
+      "unsupported_success_criteria",
+      error.message || "target cannot evaluate success criteria",
+      error_details(error)
+    )
+  end
+
+  def for_error(%Sykli.Error{code: "task_timeout"} = error) do
+    timeout("task_timeout", error.message || "task timed out", error_details(error))
+  end
+
+  def for_error(%Sykli.Error{code: "review_primitive_failed"} = error) do
+    contract_failure(
+      "review_primitive_failed",
+      error.message || "review primitive failed",
+      error_details(error)
+    )
+  end
+
+  def for_error(%Sykli.Error{code: "missing_secrets"} = error) do
+    dependency_failure(
+      "missing_secrets",
+      error.message || "required secrets were missing",
+      error_details(error)
+    )
+  end
+
+  def for_error(%Sykli.Error{type: :internal} = error) do
+    internal_error(
+      error.code || "internal_error",
+      error.message || "internal error",
+      error_details(error)
+    )
+  end
+
+  def for_error(%Sykli.Error{} = error) do
+    unknown(
+      error.code || "unknown",
+      error.message || "unclassified task failure",
+      error_details(error)
+    )
+  end
+
+  def to_map(nil), do: nil
+
+  def to_map(%__MODULE__{} = semantics) do
+    %{
+      "class" => Atom.to_string(semantics.class),
+      "retryable" => semantics.retryable,
+      "source" => Atom.to_string(semantics.source),
+      "reason" => semantics.reason,
+      "message" => semantics.message
+    }
+    |> maybe_put("details", non_empty_map(semantics.details))
+  end
+
+  def from_map(nil), do: nil
+
+  def from_map(map) when is_map(map) do
+    class = parse_atom(map["class"], @classes, :unknown)
+    source = parse_atom(map["source"], @sources, :unknown)
+
+    %__MODULE__{
+      class: class,
+      retryable: map["retryable"] == true,
+      source: source,
+      reason: string_or_default(map["reason"], "unknown"),
+      message: string_or_default(map["message"], "unclassified task result"),
+      details: map["details"] || %{}
+    }
+  end
+
+  defp new(class, retryable, source, reason, message, details) do
+    %__MODULE__{
+      class: class,
+      retryable: retryable,
+      source: source,
+      reason: to_reason(reason),
+      message: message,
+      details: stringify_keys(details || %{})
+    }
+  end
+
+  defp error_details(%Sykli.Error{} = error) do
+    %{}
+    |> maybe_put("code", error.code)
+    |> maybe_put("task", error.task)
+    |> maybe_put("step", atom_to_string(error.step))
+    |> maybe_put("exit_code", error.exit_code)
+    |> maybe_put("duration_ms", error.duration_ms)
+  end
+
+  defp to_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp to_reason(reason) when is_binary(reason), do: reason
+  defp to_reason(reason), do: inspect(reason)
+
+  defp message(%Sykli.Error{message: message}, _default) when is_binary(message), do: message
+  defp message(reason, default) when reason in [nil, ""], do: default
+  defp message(reason, _default) when is_binary(reason), do: reason
+  defp message(reason, _default), do: inspect(reason)
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, value) when value == %{}, do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp non_empty_map(map) when map == %{}, do: nil
+  defp non_empty_map(map), do: map
+
+  defp atom_to_string(nil), do: nil
+  defp atom_to_string(atom), do: Atom.to_string(atom)
+
+  defp parse_atom(value, allowed, default) when is_binary(value) do
+    atom = String.to_existing_atom(value)
+    if atom in allowed, do: atom, else: default
+  rescue
+    ArgumentError -> default
+  end
+
+  defp parse_atom(_value, _allowed, default), do: default
+
+  defp string_or_default(value, _default) when is_binary(value), do: value
+  defp string_or_default(_value, default), do: default
+
+  defp stringify_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), stringify_keys(value)}
+      {key, value} -> {key, stringify_keys(value)}
+    end)
+  end
+
+  defp stringify_keys(list) when is_list(list), do: Enum.map(list, &stringify_keys/1)
+  defp stringify_keys(value), do: value
+end

--- a/core/lib/sykli/failure_semantics.ex
+++ b/core/lib/sykli/failure_semantics.ex
@@ -8,6 +8,9 @@ defmodule Sykli.FailureSemantics do
   blocks, and skipped work without reverse-engineering error strings.
   """
 
+  # Keep @classes and the failure_class typespec in lockstep. `from_map/1`
+  # filters parsed atoms against this list, so a class missing here degrades to
+  # :unknown even if the type mentions it.
   @classes ~w(
     runtime_failure
     contract_failure
@@ -97,6 +100,8 @@ defmodule Sykli.FailureSemantics do
     new(:missing_evidence, false, :criteria, reason, message, details)
   end
 
+  # Reserved for the agent-variance contract work. V1 can deserialize it from
+  # future/local records, but no executor path emits it yet.
   def agent_variance_failure(reason, message, details \\ %{}) do
     new(:agent_variance_failure, false, :executor, reason, message, details)
   end
@@ -115,6 +120,8 @@ defmodule Sykli.FailureSemantics do
   def for_result(:blocked, reason),
     do: dependency_failure(to_reason(reason), message(reason, "task blocked by dependency"))
 
+  # Error structs carry the most precise code/type/step data; classify them via
+  # for_error/1 before any generic status fallback.
   def for_result(_status, %Sykli.Error{} = error), do: for_error(error)
 
   def for_result(:errored, reason),

--- a/core/lib/sykli/failure_semantics.ex
+++ b/core/lib/sykli/failure_semantics.ex
@@ -185,6 +185,14 @@ defmodule Sykli.FailureSemantics do
     )
   end
 
+  @doc """
+  Serializes failure semantics to a string-keyed map suitable for JSON output.
+
+  Accepts `nil` (passthrough), a `%FailureSemantics{}` struct (canonical
+  serialization), or an already-serialized map (passthrough — useful when a
+  value has been round-tripped through `from_map/1` and back, or when a caller
+  is unsure of the input shape).
+  """
   def to_map(nil), do: nil
 
   def to_map(%__MODULE__{} = semantics) do
@@ -197,6 +205,8 @@ defmodule Sykli.FailureSemantics do
     }
     |> maybe_put("details", non_empty_map(semantics.details))
   end
+
+  def to_map(map) when is_map(map), do: map
 
   def from_map(nil), do: nil
 

--- a/core/lib/sykli/mcp/tools.ex
+++ b/core/lib/sykli/mcp/tools.ex
@@ -201,7 +201,8 @@ defmodule Sykli.MCP.Tools do
                  cached: r.cached
                }
 
-               if r.error, do: Map.put(base, :error, r.error), else: base
+               base = if r.error, do: Map.put(base, :error, r.error), else: base
+               maybe_put_failure_semantics(base, r.failure_semantics)
              end)
          }}
 
@@ -420,7 +421,8 @@ defmodule Sykli.MCP.Tools do
              tasks:
                Enum.map(results, fn r ->
                  base = %{name: r.name, status: to_string(r.status), duration_ms: r.duration_ms}
-                 if r.error, do: Map.put(base, :error, inspect(r.error)), else: base
+                 base = if r.error, do: Map.put(base, :error, inspect(r.error)), else: base
+                 maybe_put_failure_semantics(base, r.failure_semantics)
                end)
            }}
 
@@ -475,6 +477,12 @@ defmodule Sykli.MCP.Tools do
       end
 
     opts
+  end
+
+  defp maybe_put_failure_semantics(map, nil), do: map
+
+  defp maybe_put_failure_semantics(map, semantics) do
+    Map.put(map, :failure_semantics, Sykli.FailureSemantics.to_map(semantics))
   end
 
   defp safe_store_call(fun) do

--- a/core/lib/sykli/occurrence/enrichment.ex
+++ b/core/lib/sykli/occurrence/enrichment.ex
@@ -350,6 +350,9 @@ defmodule Sykli.Occurrence.Enrichment do
 
         step =
           case r.error do
+            nil ->
+              step
+
             %Sykli.Error{} = err ->
               Map.put(step, "error", %{
                 "code" => err.code,
@@ -364,8 +367,12 @@ defmodule Sykli.Occurrence.Enrichment do
                 "failure_semantics" => failure_semantics_map(r)
               })
 
-            _ ->
-              step
+            other ->
+              Map.put(step, "error", %{
+                "code" => "unknown",
+                "what_failed" => "task #{r.name} failed: #{inspect(other)}",
+                "failure_semantics" => failure_semantics_map(r)
+              })
           end
 
         # Remove nil description

--- a/core/lib/sykli/occurrence/enrichment.ex
+++ b/core/lib/sykli/occurrence/enrichment.ex
@@ -353,13 +353,15 @@ defmodule Sykli.Occurrence.Enrichment do
             %Sykli.Error{} = err ->
               Map.put(step, "error", %{
                 "code" => err.code,
-                "what_failed" => err.message || "task #{r.name} failed"
+                "what_failed" => err.message || "task #{r.name} failed",
+                "failure_semantics" => failure_semantics_map(r)
               })
 
             :dependency_failed ->
               Map.put(step, "error", %{
                 "code" => "dependency_failed",
-                "what_failed" => "blocked by failed dependency"
+                "what_failed" => "blocked by failed dependency",
+                "failure_semantics" => failure_semantics_map(r)
               })
 
             _ ->
@@ -521,6 +523,7 @@ defmodule Sykli.Occurrence.Enrichment do
       task_map
       |> maybe_add("log", task_log_path(result, run_id))
       |> maybe_add("error", error_detail_map(result.error))
+      |> maybe_add("failure_semantics", failure_semantics_map(result))
       |> maybe_add("covers", non_empty(get_semantic_covers(task)))
       |> maybe_add("inputs", non_empty(get_field(task, :inputs)))
       |> maybe_add("depends_on", non_empty(get_field(task, :depends_on)))
@@ -571,6 +574,14 @@ defmodule Sykli.Occurrence.Enrichment do
 
   def error_detail_map(other) do
     %{"message" => inspect(other)}
+  end
+
+  defp failure_semantics_map(%TaskResult{} = result) do
+    semantics =
+      result.failure_semantics ||
+        Sykli.FailureSemantics.for_result(result.status, result.error)
+
+    Sykli.FailureSemantics.to_map(semantics)
   end
 
   # ─────────────────────────────────────────────────────────────────────────────

--- a/core/lib/sykli/query/history.ex
+++ b/core/lib/sykli/query/history.ex
@@ -61,6 +61,7 @@ defmodule Sykli.Query.History do
              task: task_name,
              status: :failed,
              error: task.error,
+             failure_semantics: failure_semantics_to_map(task.failure_semantics),
              duration_ms: task.duration_ms,
              run_id: run.id,
              timestamp: DateTime.to_iso8601(run.timestamp),
@@ -92,6 +93,13 @@ defmodule Sykli.Query.History do
       DateTime.to_date(run.timestamp) == today
     end)
   end
+
+  defp failure_semantics_to_map(nil), do: nil
+
+  defp failure_semantics_to_map(%Sykli.FailureSemantics{} = semantics),
+    do: Sykli.FailureSemantics.to_map(semantics)
+
+  defp failure_semantics_to_map(map) when is_map(map), do: map
 
   defp metadata(query) do
     %{query: query, timestamp: DateTime.utc_now() |> DateTime.to_iso8601()}

--- a/core/lib/sykli/query/history.ex
+++ b/core/lib/sykli/query/history.ex
@@ -61,7 +61,7 @@ defmodule Sykli.Query.History do
              task: task_name,
              status: :failed,
              error: task.error,
-             failure_semantics: failure_semantics_to_map(task.failure_semantics),
+             failure_semantics: Sykli.FailureSemantics.to_map(task.failure_semantics),
              duration_ms: task.duration_ms,
              run_id: run.id,
              timestamp: DateTime.to_iso8601(run.timestamp),
@@ -93,13 +93,6 @@ defmodule Sykli.Query.History do
       DateTime.to_date(run.timestamp) == today
     end)
   end
-
-  defp failure_semantics_to_map(nil), do: nil
-
-  defp failure_semantics_to_map(%Sykli.FailureSemantics{} = semantics),
-    do: Sykli.FailureSemantics.to_map(semantics)
-
-  defp failure_semantics_to_map(map) when is_map(map), do: map
 
   defp metadata(query) do
     %{query: query, timestamp: DateTime.utc_now() |> DateTime.to_iso8601()}

--- a/core/lib/sykli/query/runs.ex
+++ b/core/lib/sykli/query/runs.ex
@@ -80,19 +80,12 @@ defmodule Sykli.Query.Runs do
               duration_ms: t.duration_ms,
               cached: t.cached == true
             }
-            |> maybe_put(:failure_semantics, failure_semantics_to_map(t.failure_semantics))
+            |> maybe_put(:failure_semantics, Sykli.FailureSemantics.to_map(t.failure_semantics))
 
           maybe_put(result, :error, t.error)
         end)
     }
   end
-
-  defp failure_semantics_to_map(nil), do: nil
-
-  defp failure_semantics_to_map(%Sykli.FailureSemantics{} = semantics),
-    do: Sykli.FailureSemantics.to_map(semantics)
-
-  defp failure_semantics_to_map(map) when is_map(map), do: map
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/core/lib/sykli/query/runs.ex
+++ b/core/lib/sykli/query/runs.ex
@@ -73,17 +73,29 @@ defmodule Sykli.Query.Runs do
       overall: run.overall,
       tasks:
         Enum.map(run.tasks, fn t ->
-          result = %{
-            name: t.name,
-            status: t.status,
-            duration_ms: t.duration_ms,
-            cached: t.cached == true
-          }
+          result =
+            %{
+              name: t.name,
+              status: t.status,
+              duration_ms: t.duration_ms,
+              cached: t.cached == true
+            }
+            |> maybe_put(:failure_semantics, failure_semantics_to_map(t.failure_semantics))
 
-          if t.error, do: Map.put(result, :error, t.error), else: result
+          maybe_put(result, :error, t.error)
         end)
     }
   end
+
+  defp failure_semantics_to_map(nil), do: nil
+
+  defp failure_semantics_to_map(%Sykli.FailureSemantics{} = semantics),
+    do: Sykli.FailureSemantics.to_map(semantics)
+
+  defp failure_semantics_to_map(map) when is_map(map), do: map
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp serialize_run_summary(run) do
     %{

--- a/core/lib/sykli/run_history.ex
+++ b/core/lib/sykli/run_history.ex
@@ -27,6 +27,7 @@ defmodule Sykli.RunHistory do
       :status,
       :duration_ms,
       :error,
+      :failure_semantics,
       :inputs,
       :likely_cause,
       :verified_on,
@@ -40,6 +41,7 @@ defmodule Sykli.RunHistory do
             duration_ms: non_neg_integer(),
             cached: boolean(),
             error: String.t() | nil,
+            failure_semantics: map() | nil,
             inputs: [String.t()] | nil,
             likely_cause: [String.t()] | nil,
             verified_on: String.t() | nil,
@@ -310,6 +312,7 @@ defmodule Sykli.RunHistory do
       streak: tr.streak
     }
     |> maybe_add(:error, tr.error)
+    |> maybe_add(:failure_semantics, failure_semantics_to_map(tr.failure_semantics))
     |> maybe_add(:inputs, tr.inputs)
     |> maybe_add(:likely_cause, tr.likely_cause)
     |> maybe_add(:verified_on, tr.verified_on)
@@ -344,11 +347,19 @@ defmodule Sykli.RunHistory do
       cached: data["cached"] || false,
       streak: data["streak"] || 0,
       error: data["error"],
+      failure_semantics: Sykli.FailureSemantics.from_map(data["failure_semantics"]),
       inputs: data["inputs"],
       likely_cause: data["likely_cause"],
       verified_on: data["verified_on"]
     }
   end
+
+  defp failure_semantics_to_map(nil), do: nil
+
+  defp failure_semantics_to_map(%Sykli.FailureSemantics{} = semantics),
+    do: Sykli.FailureSemantics.to_map(semantics)
+
+  defp failure_semantics_to_map(map) when is_map(map), do: map
 
   defp parse_timestamp(str) do
     case DateTime.from_iso8601(str) do

--- a/core/lib/sykli/run_history.ex
+++ b/core/lib/sykli/run_history.ex
@@ -41,7 +41,7 @@ defmodule Sykli.RunHistory do
             duration_ms: non_neg_integer(),
             cached: boolean(),
             error: String.t() | nil,
-            failure_semantics: map() | nil,
+            failure_semantics: Sykli.FailureSemantics.t() | nil,
             inputs: [String.t()] | nil,
             likely_cause: [String.t()] | nil,
             verified_on: String.t() | nil,

--- a/core/lib/sykli/run_history.ex
+++ b/core/lib/sykli/run_history.ex
@@ -312,7 +312,7 @@ defmodule Sykli.RunHistory do
       streak: tr.streak
     }
     |> maybe_add(:error, tr.error)
-    |> maybe_add(:failure_semantics, failure_semantics_to_map(tr.failure_semantics))
+    |> maybe_add(:failure_semantics, Sykli.FailureSemantics.to_map(tr.failure_semantics))
     |> maybe_add(:inputs, tr.inputs)
     |> maybe_add(:likely_cause, tr.likely_cause)
     |> maybe_add(:verified_on, tr.verified_on)
@@ -353,13 +353,6 @@ defmodule Sykli.RunHistory do
       verified_on: data["verified_on"]
     }
   end
-
-  defp failure_semantics_to_map(nil), do: nil
-
-  defp failure_semantics_to_map(%Sykli.FailureSemantics{} = semantics),
-    do: Sykli.FailureSemantics.to_map(semantics)
-
-  defp failure_semantics_to_map(map) when is_map(map), do: map
 
   defp parse_timestamp(str) do
     case DateTime.from_iso8601(str) do

--- a/core/test/sykli/executor/failure_semantics_test.exs
+++ b/core/test/sykli/executor/failure_semantics_test.exs
@@ -1,0 +1,119 @@
+defmodule Sykli.Executor.FailureSemanticsTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.Error
+  alias Sykli.Executor
+  alias Sykli.Executor.TaskResult
+  alias Sykli.Graph.Task
+  alias Sykli.Target.Local
+
+  defmodule TimeoutTarget do
+    @behaviour Sykli.Target.Behaviour
+
+    @impl true
+    def name, do: "timeout-target"
+
+    @impl true
+    def available?, do: {:ok, %{}}
+
+    @impl true
+    def setup(opts), do: {:ok, %{workdir: Keyword.get(opts, :workdir, ".")}}
+
+    @impl true
+    def teardown(_state), do: :ok
+
+    @impl true
+    def run_task(task, _state, _opts),
+      do: {:error, Error.task_timeout(task.name, task.command, 1)}
+
+    @impl true
+    def resolve_secret(_name, _state), do: {:error, :not_found}
+
+    @impl true
+    def create_volume(_name, _opts, _state), do: {:ok, %{id: "v", host_path: nil, reference: "v"}}
+
+    @impl true
+    def artifact_path(_task, _artifact, _workdir, _state), do: "/tmp/missing"
+
+    @impl true
+    def copy_artifact(_src, _dest, _workdir, _state), do: :ok
+
+    @impl true
+    def start_services(_name, _services, _state), do: {:ok, nil}
+
+    @impl true
+    def stop_services(_info, _state), do: :ok
+  end
+
+  setup do
+    workdir =
+      Path.join(
+        System.tmp_dir!(),
+        "sykli-failure-semantics-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(workdir)
+    on_exit(fn -> File.rm_rf!(workdir) end)
+
+    {:ok, workdir: workdir}
+  end
+
+  test "timeout is classified distinctly from runtime failure", %{workdir: workdir} do
+    task = task("slow", command: "sleep 10")
+
+    assert {:error, [%TaskResult{status: :failed, failure_semantics: semantics}]} =
+             Executor.run([task], graph([task]), target: TimeoutTarget, workdir: workdir)
+
+    assert semantics.class == :timeout
+    assert semantics.retryable == true
+    assert semantics.source == :target
+  end
+
+  test "condition skip is classified as skipped and not as failure", %{workdir: workdir} do
+    task =
+      task("conditional", command: "echo no", condition: "branch == 'definitely-not-current'")
+
+    assert {:ok, [%TaskResult{status: :skipped, failure_semantics: semantics}]} =
+             Executor.run([task], graph([task]), target: Local, workdir: workdir)
+
+    assert semantics.class == :skipped
+    assert semantics.reason == "condition_not_met"
+  end
+
+  test "dependency blocked task is classified as dependency failure", %{workdir: workdir} do
+    build = task("build", command: "exit 2")
+    deploy = task("deploy", command: "echo deploy", depends_on: ["build"])
+
+    assert {:error, results} =
+             Executor.run([build, deploy], graph([build, deploy]),
+               target: Local,
+               workdir: workdir
+             )
+
+    assert %TaskResult{status: :blocked, failure_semantics: semantics} =
+             Enum.find(results, &(&1.name == "deploy"))
+
+    assert semantics.class == :dependency_failure
+    assert semantics.reason == "dependency_failed"
+  end
+
+  defp task(name, attrs) do
+    struct(
+      Task,
+      Keyword.merge(
+        [
+          name: name,
+          kind: :task,
+          command: "echo ok",
+          depends_on: [],
+          inputs: [],
+          outputs: %{},
+          success_criteria: []
+        ],
+        attrs
+      )
+    )
+  end
+
+  defp graph(tasks), do: Map.new(tasks, &{&1.name, &1})
+end

--- a/core/test/sykli/executor/failure_semantics_test.exs
+++ b/core/test/sykli/executor/failure_semantics_test.exs
@@ -4,6 +4,7 @@ defmodule Sykli.Executor.FailureSemanticsTest do
   alias Sykli.Error
   alias Sykli.Executor
   alias Sykli.Executor.TaskResult
+  alias Sykli.Graph.Task.AiHooks
   alias Sykli.Graph.Task
   alias Sykli.Target.Local
 
@@ -95,6 +96,22 @@ defmodule Sykli.Executor.FailureSemanticsTest do
 
     assert semantics.class == :dependency_failure
     assert semantics.reason == "dependency_failed"
+  end
+
+  test "on_fail skip preserves original failure semantics in details", %{workdir: workdir} do
+    task =
+      task("optional-failure",
+        command: "exit 3",
+        ai_hooks: %AiHooks{on_fail: :skip}
+      )
+
+    assert {:ok, [%TaskResult{status: :skipped, failure_semantics: semantics}]} =
+             Executor.run([task], graph([task]), target: Local, workdir: workdir)
+
+    assert semantics.class == :skipped
+    assert semantics.reason == "ai_hook_skip"
+    assert semantics.details["original_failure_semantics"]["class"] == "runtime_failure"
+    assert semantics.details["original_failure_semantics"]["reason"] == "command_failed"
   end
 
   defp task(name, attrs) do

--- a/core/test/sykli/executor/policy_and_review_failure_semantics_test.exs
+++ b/core/test/sykli/executor/policy_and_review_failure_semantics_test.exs
@@ -1,0 +1,119 @@
+defmodule Sykli.Executor.PolicyAndReviewFailureSemanticsTest do
+  @moduledoc """
+  Covers two executor classification paths not exercised by
+  Sykli.Executor.FailureSemanticsTest: gate denial -> policy_block and
+  review primitive failure -> contract_failure.
+
+  Both touch global state (System.put_env for gates, Application.put_env
+  for review runners) and therefore run with `async: false`.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Sykli.Executor
+  alias Sykli.Executor.TaskResult
+  alias Sykli.FailureSemantics
+  alias Sykli.Graph.{Review, Task}
+  alias Sykli.Graph.Task.Gate
+  alias Sykli.ReviewPrimitive.Result
+  alias Sykli.Target.Local
+
+  defmodule FailingApiBreakageRunner do
+    def evaluate(_task, _state, _opts) do
+      {:error,
+       %Result{
+         review_type: "api_breakage",
+         status: :failed,
+         severity: "breaking",
+         message: "public API breakage detected",
+         tool: "fixture",
+         findings: [%{"symbol" => "Client.connect", "change" => "removed"}],
+         evidence: %{}
+       }}
+    end
+  end
+
+  setup do
+    original_runner = Application.get_env(:sykli, :api_breakage_review_runner)
+    original_gate = System.get_env("SYKLI_TEST_FAILSEM_GATE")
+
+    on_exit(fn ->
+      if original_runner do
+        Application.put_env(:sykli, :api_breakage_review_runner, original_runner)
+      else
+        Application.delete_env(:sykli, :api_breakage_review_runner)
+      end
+
+      case original_gate do
+        nil -> System.delete_env("SYKLI_TEST_FAILSEM_GATE")
+        value -> System.put_env("SYKLI_TEST_FAILSEM_GATE", value)
+      end
+    end)
+
+    :ok
+  end
+
+  test "gate denial classifies the task as policy_block (source: gate)" do
+    System.put_env("SYKLI_TEST_FAILSEM_GATE", "denied")
+
+    task = %Task{
+      name: "approve-deploy",
+      kind: :task,
+      command: nil,
+      depends_on: [],
+      inputs: [],
+      outputs: %{},
+      success_criteria: [],
+      gate: %Gate{strategy: :env, env_var: "SYKLI_TEST_FAILSEM_GATE", timeout: 5}
+    }
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                failure_semantics: %FailureSemantics{
+                  class: :policy_block,
+                  source: :gate,
+                  retryable: false,
+                  reason: "gate_denied"
+                }
+              }
+            ]} = Executor.run([task], graph([task]), target: Local)
+  end
+
+  test "review primitive failure classifies the task as contract_failure (source: executor)" do
+    Application.put_env(:sykli, :api_breakage_review_runner, FailingApiBreakageRunner)
+
+    task = %Task{
+      name: "review-api",
+      kind: :review,
+      command: nil,
+      depends_on: [],
+      inputs: [],
+      outputs: %{},
+      services: [],
+      task_inputs: [],
+      review: %Review{
+        primitive: "api_breakage",
+        agent: "local",
+        context: ["lib/**/*.ex"],
+        deterministic: true
+      }
+    }
+
+    assert {:error,
+            [
+              %TaskResult{
+                status: :failed,
+                failure_semantics: %FailureSemantics{
+                  class: :contract_failure,
+                  source: :executor,
+                  retryable: false,
+                  reason: "review_primitive_failed"
+                }
+              }
+            ]} = Executor.run([task], graph([task]), target: Local)
+  end
+
+  defp graph(tasks), do: Map.new(tasks, &{&1.name, &1})
+end

--- a/core/test/sykli/executor/success_criteria_enforcement_test.exs
+++ b/core/test/sykli/executor/success_criteria_enforcement_test.exs
@@ -84,6 +84,11 @@ defmodule Sykli.Executor.SuccessCriteriaEnforcementTest do
               %TaskResult{
                 status: :failed,
                 error: %Error{code: "success_criteria_failed"},
+                failure_semantics: %Sykli.FailureSemantics{
+                  class: :criteria_failure,
+                  source: :criteria,
+                  retryable: false
+                },
                 success_criteria_results: [%Result{type: "file_exists", status: :failed}]
               }
             ]} = Executor.run([task], graph(task), target: Local, workdir: workdir)
@@ -166,6 +171,7 @@ defmodule Sykli.Executor.SuccessCriteriaEnforcementTest do
               %TaskResult{
                 status: :failed,
                 error: %Error{code: "success_criteria_failed"},
+                failure_semantics: %Sykli.FailureSemantics{class: :criteria_failure},
                 success_criteria_results: [%Result{type: "exit_code", status: :failed}]
               }
             ]} = Executor.run([task], graph(task), target: Local, workdir: workdir)
@@ -185,6 +191,10 @@ defmodule Sykli.Executor.SuccessCriteriaEnforcementTest do
               %TaskResult{
                 status: :failed,
                 error: %Error{code: "task_failed", exit_code: 7},
+                failure_semantics: %Sykli.FailureSemantics{
+                  class: :runtime_failure,
+                  source: :target
+                },
                 success_criteria_results: []
               }
             ]} = Executor.run([task], graph(task), target: Local, workdir: workdir)
@@ -202,6 +212,10 @@ defmodule Sykli.Executor.SuccessCriteriaEnforcementTest do
               %TaskResult{
                 status: :failed,
                 error: %Error{code: "unsupported_success_criteria_for_target"},
+                failure_semantics: %Sykli.FailureSemantics{
+                  class: :unsupported_target,
+                  reason: "unsupported_success_criteria"
+                },
                 success_criteria_results: [
                   %Result{type: "file_exists", status: :unsupported, target: "unsupported"}
                 ]

--- a/core/test/sykli/failure_semantics_test.exs
+++ b/core/test/sykli/failure_semantics_test.exs
@@ -34,6 +34,44 @@ defmodule Sykli.FailureSemanticsTest do
              FailureSemantics.for_result(:blocked, :dependency_failed)
   end
 
+  describe "for_result/2 dispatch covers status branches" do
+    test "success-like statuses have no failure semantics" do
+      assert FailureSemantics.for_result(:passed, nil) == nil
+      assert FailureSemantics.for_result(:cached, nil) == nil
+    end
+
+    test "skipped statuses remain skipped" do
+      assert %FailureSemantics{class: :skipped, reason: "condition_not_met"} =
+               FailureSemantics.for_result(:skipped, nil)
+
+      assert %FailureSemantics{class: :skipped, reason: "manual_skip"} =
+               FailureSemantics.for_result(:skipped, :manual_skip)
+    end
+
+    test "blocked statuses remain dependency failures" do
+      assert %FailureSemantics{class: :dependency_failure, reason: "dependency_failed"} =
+               FailureSemantics.for_result(:blocked, :dependency_failed)
+
+      assert %FailureSemantics{class: :dependency_failure, reason: "missing_artifact"} =
+               FailureSemantics.for_result(:blocked, :missing_artifact)
+    end
+
+    test "Sykli.Error values are classified by error code before status fallback" do
+      error = Error.task_timeout("slow", "sleep 10", 1_000)
+
+      assert %FailureSemantics{class: :timeout, reason: "task_timeout"} =
+               FailureSemantics.for_result(:errored, error)
+    end
+
+    test "non-error errored and failed values stay calibrated" do
+      assert %FailureSemantics{class: :internal_error, reason: "process_exit"} =
+               FailureSemantics.for_result(:errored, :process_exit)
+
+      assert %FailureSemantics{class: :unknown, reason: "raw_failure"} =
+               FailureSemantics.for_result(:failed, :raw_failure)
+    end
+  end
+
   test "serializes to stable string-keyed map" do
     semantics = FailureSemantics.timeout("task_timeout", "task timed out", %{duration_ms: 1000})
 

--- a/core/test/sykli/failure_semantics_test.exs
+++ b/core/test/sykli/failure_semantics_test.exs
@@ -1,0 +1,49 @@
+defmodule Sykli.FailureSemanticsTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.Error
+  alias Sykli.FailureSemantics
+
+  test "classifies command failure separately from criteria failure" do
+    command = Error.task_failed("test", "exit 1", 1, "")
+    criteria = Error.success_criteria_failed("test", [])
+
+    assert %FailureSemantics{class: :runtime_failure, source: :target, retryable: false} =
+             FailureSemantics.for_error(command)
+
+    assert %FailureSemantics{class: :criteria_failure, source: :criteria, retryable: false} =
+             FailureSemantics.for_error(criteria)
+  end
+
+  test "classifies unsupported criteria and timeouts distinctly" do
+    unsupported = Error.unsupported_success_criteria_for_target("test", "k8s", [])
+    timeout = Error.task_timeout("test", "sleep 10", 1_000)
+
+    assert %FailureSemantics{class: :unsupported_target, reason: "unsupported_success_criteria"} =
+             FailureSemantics.for_error(unsupported)
+
+    assert %FailureSemantics{class: :timeout, reason: "task_timeout", retryable: true} =
+             FailureSemantics.for_error(timeout)
+  end
+
+  test "classifies skipped and dependency-blocked results" do
+    assert %FailureSemantics{class: :skipped, reason: "condition_not_met"} =
+             FailureSemantics.for_result(:skipped, nil)
+
+    assert %FailureSemantics{class: :dependency_failure, source: :dependency} =
+             FailureSemantics.for_result(:blocked, :dependency_failed)
+  end
+
+  test "serializes to stable string-keyed map" do
+    semantics = FailureSemantics.timeout("task_timeout", "task timed out", %{duration_ms: 1000})
+
+    assert FailureSemantics.to_map(semantics) == %{
+             "class" => "timeout",
+             "retryable" => true,
+             "source" => "target",
+             "reason" => "task_timeout",
+             "message" => "task timed out",
+             "details" => %{"duration_ms" => 1000}
+           }
+  end
+end

--- a/core/test/sykli/failure_semantics_test.exs
+++ b/core/test/sykli/failure_semantics_test.exs
@@ -46,4 +46,133 @@ defmodule Sykli.FailureSemanticsTest do
              "details" => %{"duration_ms" => 1000}
            }
   end
+
+  test "to_map/1 passes through an already-serialized string-keyed map" do
+    already_serialized = %{
+      "class" => "criteria_failure",
+      "retryable" => false,
+      "source" => "criteria",
+      "reason" => "success_criteria_failed",
+      "message" => "criteria failed"
+    }
+
+    assert FailureSemantics.to_map(already_serialized) == already_serialized
+  end
+
+  describe "for_error/1 dispatch covers every named error code" do
+    # If any Sykli.Error.* factory renames its code, the corresponding test
+    # here fails — preventing a silent fall-through to the :unknown bucket.
+    test "task_failed -> runtime_failure" do
+      assert %FailureSemantics{class: :runtime_failure} =
+               FailureSemantics.for_error(Error.task_failed("t", "exit 1", 1, ""))
+    end
+
+    test "success_criteria_failed -> criteria_failure" do
+      assert %FailureSemantics{class: :criteria_failure} =
+               FailureSemantics.for_error(Error.success_criteria_failed("t", []))
+    end
+
+    test "unsupported_success_criteria_for_target -> unsupported_target" do
+      assert %FailureSemantics{class: :unsupported_target} =
+               FailureSemantics.for_error(
+                 Error.unsupported_success_criteria_for_target("t", "k8s", [])
+               )
+    end
+
+    test "task_timeout -> timeout (retryable)" do
+      assert %FailureSemantics{class: :timeout, retryable: true} =
+               FailureSemantics.for_error(Error.task_timeout("t", "sleep 10", 1000))
+    end
+
+    test "review_primitive_failed -> contract_failure" do
+      review_result = %{status: :failed, review_type: "api_breakage", message: "broke"}
+
+      assert %FailureSemantics{class: :contract_failure, source: :executor} =
+               FailureSemantics.for_error(Error.review_primitive_failed("review", review_result))
+    end
+
+    test "missing_secrets -> dependency_failure" do
+      assert %FailureSemantics{class: :dependency_failure, source: :dependency} =
+               FailureSemantics.for_error(Error.missing_secrets("t", ["TOKEN"]))
+    end
+
+    test "Error{type: :internal} -> internal_error" do
+      assert %FailureSemantics{class: :internal_error} =
+               FailureSemantics.for_error(Error.internal("BEAM lost its mind"))
+    end
+
+    test "Error with unrecognized code -> unknown (calibrated, not guessed)" do
+      surprise = %Error{code: "novel_future_code", type: :execution, message: "weird"}
+
+      assert %FailureSemantics{class: :unknown, source: :unknown} =
+               FailureSemantics.for_error(surprise)
+    end
+  end
+
+  describe "reserved future classes load safely" do
+    # missing_evidence and agent_variance_failure are declared but not yet
+    # produced by any code path. The deserializer uses String.to_existing_atom,
+    # so the atoms must be loaded at compile time. This test fails immediately
+    # if a future refactor drops them from @classes.
+    test "missing_evidence round-trips through from_map" do
+      input = %{
+        "class" => "missing_evidence",
+        "source" => "criteria",
+        "reason" => "r",
+        "message" => "m"
+      }
+
+      assert %FailureSemantics{class: :missing_evidence, source: :criteria} =
+               FailureSemantics.from_map(input)
+    end
+
+    test "agent_variance_failure round-trips through from_map" do
+      input = %{
+        "class" => "agent_variance_failure",
+        "source" => "executor",
+        "reason" => "r",
+        "message" => "m"
+      }
+
+      assert %FailureSemantics{class: :agent_variance_failure, source: :executor} =
+               FailureSemantics.from_map(input)
+    end
+
+    test "from_map falls back to :unknown for a class string not in @classes" do
+      input = %{
+        "class" => "made_up_class",
+        "source" => "executor",
+        "reason" => "r",
+        "message" => "m"
+      }
+
+      assert %FailureSemantics{class: :unknown} = FailureSemantics.from_map(input)
+    end
+  end
+
+  describe "to_map / from_map round-trip preserves all fields" do
+    test "timeout with details" do
+      original =
+        FailureSemantics.timeout("task_timeout", "timed out at 10s", %{
+          duration_ms: 10_000,
+          attempt: 2
+        })
+
+      assert ^original = original |> FailureSemantics.to_map() |> FailureSemantics.from_map()
+    end
+
+    test "policy_block without details (empty details map omitted from JSON, restored as empty)" do
+      original = FailureSemantics.policy_block("gate_denied", "gate 'review' denied")
+      round_tripped = original |> FailureSemantics.to_map() |> FailureSemantics.from_map()
+
+      # to_map drops empty details for compactness; from_map restores it as %{}.
+      # Both are semantically empty — assert structural equality on every field.
+      assert round_tripped.class == original.class
+      assert round_tripped.retryable == original.retryable
+      assert round_tripped.source == original.source
+      assert round_tripped.reason == original.reason
+      assert round_tripped.message == original.message
+      assert round_tripped.details == %{}
+    end
+  end
 end

--- a/core/test/sykli/occurrence/enrichment_test.exs
+++ b/core/test/sykli/occurrence/enrichment_test.exs
@@ -392,6 +392,23 @@ defmodule Sykli.Occurrence.EnrichmentTest do
       assert step["error"]["failure_semantics"]["class"] == "runtime_failure"
     end
 
+    test "unknown-shape error (string/atom/tuple) still produces error + failure_semantics block",
+         %{workdir: workdir} do
+      occ = make_occurrence("run-step-other-err", "ci.run.failed", "failure")
+      graph = %{"test" => %{command: "mix test"}}
+
+      results =
+        {:error,
+         [%TaskResult{name: "test", status: :failed, duration_ms: 50, error: "raw string boom"}]}
+
+      enriched = Enrichment.enrich(occ, graph, results, workdir)
+      step = hd(enriched.history["steps"])
+
+      assert step["error"]["code"] == "unknown"
+      assert step["error"]["what_failed"] =~ "raw string boom"
+      assert step["error"]["failure_semantics"]["class"] == "unknown"
+    end
+
     test "step timestamps are offset from base timestamp", %{workdir: workdir} do
       occ = make_occurrence("run-ts", "ci.run.passed", "success")
       graph = %{}

--- a/core/test/sykli/occurrence/enrichment_test.exs
+++ b/core/test/sykli/occurrence/enrichment_test.exs
@@ -358,6 +358,14 @@ defmodule Sykli.Occurrence.EnrichmentTest do
 
       outcomes = Enum.map(steps, & &1["outcome"])
       assert outcomes == ["success", "failure", "error", "success", "skipped", "failure"]
+
+      tasks_by_name = Map.new(enriched.data["tasks"], &{&1["name"], &1})
+      assert get_in(tasks_by_name, ["fail", "failure_semantics", "class"]) == "runtime_failure"
+      assert get_in(tasks_by_name, ["err", "failure_semantics", "class"]) == "timeout"
+      assert get_in(tasks_by_name, ["skip", "failure_semantics", "class"]) == "skipped"
+
+      assert get_in(tasks_by_name, ["block", "failure_semantics", "class"]) ==
+               "dependency_failure"
     end
 
     test "failed task step includes error info", %{workdir: workdir} do
@@ -381,6 +389,7 @@ defmodule Sykli.Occurrence.EnrichmentTest do
 
       assert step["error"]["code"] == "task_failed"
       assert step["error"]["what_failed"] =~ "test"
+      assert step["error"]["failure_semantics"]["class"] == "runtime_failure"
     end
 
     test "step timestamps are offset from base timestamp", %{workdir: workdir} do

--- a/core/test/sykli/query/history_test.exs
+++ b/core/test/sykli/query/history_test.exs
@@ -26,6 +26,7 @@ defmodule Sykli.Query.HistoryTest do
       assert result.data.task == "build"
       assert result.data.status == :failed
       assert result.data.error == "exit code 1"
+      assert result.data.failure_semantics["class"] == "runtime_failure"
     end
 
     test "returns error when task has not failed", %{workdir: workdir} do
@@ -74,7 +75,13 @@ defmodule Sykli.Query.HistoryTest do
   defp save_run(workdir, overall, timestamp, task_results) do
     tasks =
       Enum.map(task_results, fn {name, status, duration_ms, error} ->
-        %TaskResult{name: name, status: status, duration_ms: duration_ms, error: error}
+        %TaskResult{
+          name: name,
+          status: status,
+          duration_ms: duration_ms,
+          error: error,
+          failure_semantics: failure_semantics(status, error)
+        }
       end)
 
     run = %Run{
@@ -88,4 +95,9 @@ defmodule Sykli.Query.HistoryTest do
 
     RunHistory.save(run, path: workdir)
   end
+
+  defp failure_semantics(:failed, _error),
+    do: Sykli.FailureSemantics.runtime_failure("command_failed", "task command failed")
+
+  defp failure_semantics(status, error), do: Sykli.FailureSemantics.for_result(status, error)
 end

--- a/core/test/sykli/query/runs_test.exs
+++ b/core/test/sykli/query/runs_test.exs
@@ -16,15 +16,16 @@ defmodule Sykli.Query.RunsTest do
 
   describe "latest" do
     test "returns the most recent run", %{workdir: workdir} do
-      save_run(workdir, :passed, ~U[2026-02-20 10:00:00Z], [
-        {"test", :passed, 3000}
+      save_run(workdir, :failed, ~U[2026-02-20 10:00:00Z], [
+        {"test", :failed, 3000, "exit code 1"}
       ])
 
       {:ok, result} = Runs.execute(:latest, workdir)
 
       assert result.type == :runs
-      assert result.data.run.overall == :passed
+      assert result.data.run.overall == :failed
       assert length(result.data.run.tasks) == 1
+      assert hd(result.data.run.tasks).failure_semantics["class"] == "runtime_failure"
     end
 
     test "returns error when no runs exist", %{workdir: workdir} do
@@ -35,11 +36,11 @@ defmodule Sykli.Query.RunsTest do
   describe "last_good" do
     test "returns the most recent passing run", %{workdir: workdir} do
       save_run(workdir, :passed, ~U[2026-02-20 10:00:00Z], [
-        {"test", :passed, 3000}
+        {"test", :passed, 3000, nil}
       ])
 
       save_run(workdir, :failed, ~U[2026-02-21 10:00:00Z], [
-        {"test", :failed, 3000}
+        {"test", :failed, 3000, nil}
       ])
 
       {:ok, result} = Runs.execute(:last_good, workdir)
@@ -50,7 +51,7 @@ defmodule Sykli.Query.RunsTest do
   describe "recent" do
     test "returns runs from last 7 days", %{workdir: workdir} do
       save_run(workdir, :passed, DateTime.utc_now(), [
-        {"test", :passed, 3000}
+        {"test", :passed, 3000, nil}
       ])
 
       {:ok, result} = Runs.execute(:recent, workdir)
@@ -62,8 +63,14 @@ defmodule Sykli.Query.RunsTest do
 
   defp save_run(workdir, overall, timestamp, task_results) do
     tasks =
-      Enum.map(task_results, fn {name, status, duration_ms} ->
-        %TaskResult{name: name, status: status, duration_ms: duration_ms}
+      Enum.map(task_results, fn {name, status, duration_ms, error} ->
+        %TaskResult{
+          name: name,
+          status: status,
+          duration_ms: duration_ms,
+          error: error,
+          failure_semantics: failure_semantics(status, error)
+        }
       end)
 
     run = %Run{
@@ -77,4 +84,9 @@ defmodule Sykli.Query.RunsTest do
 
     RunHistory.save(run, path: workdir)
   end
+
+  defp failure_semantics(:failed, _error),
+    do: Sykli.FailureSemantics.runtime_failure("command_failed", "task command failed")
+
+  defp failure_semantics(status, error), do: Sykli.FailureSemantics.for_result(status, error)
 end

--- a/core/test/sykli/run_history_test.exs
+++ b/core/test/sykli/run_history_test.exs
@@ -34,6 +34,40 @@ defmodule Sykli.RunHistoryTest do
       assert loaded.contract_hash == "sha256:abc"
     end
 
+    test "round-trips task failure semantics", %{tmp_dir: tmp_dir} do
+      run = %RunHistory.Run{
+        id: "failure-semantics-run",
+        timestamp: ~U[2024-01-15 10:30:00Z],
+        git_ref: "abc1234",
+        git_branch: "main",
+        tasks: [
+          %RunHistory.TaskResult{
+            name: "test",
+            status: :failed,
+            duration_ms: 100,
+            error: "success_criteria_failed: task failed success_criteria",
+            failure_semantics:
+              Sykli.FailureSemantics.criteria_failure(
+                "success_criteria_failed",
+                "task failed success_criteria"
+              )
+          }
+        ],
+        overall: :failed
+      }
+
+      assert :ok = RunHistory.save(run, path: tmp_dir)
+      assert {:ok, loaded} = RunHistory.load_latest(path: tmp_dir)
+      [task] = loaded.tasks
+
+      assert %Sykli.FailureSemantics{
+               class: :criteria_failure,
+               source: :criteria,
+               retryable: false,
+               reason: "success_criteria_failed"
+             } = task.failure_semantics
+    end
+
     test "creates latest.json symlink", %{tmp_dir: tmp_dir} do
       run = %RunHistory.Run{
         id: "test-run-2",

--- a/docs/agent-contract-semantics.md
+++ b/docs/agent-contract-semantics.md
@@ -12,6 +12,10 @@ rules and definitions are binding.
 JSON remains the canonical wire format. The JSON Schema remains the canonical
 machine contract.
 
+Runtime result classification is documented separately in
+`docs/failure-semantics.md`. `failure_semantics` is produced by Sykli after
+execution; it is not an SDK-emitted pipeline field.
+
 ## Thesis
 
 Phase 3 moves Sykli from "describes how to run a graph" to "describes what the

--- a/docs/failure-semantics.md
+++ b/docs/failure-semantics.md
@@ -1,0 +1,57 @@
+# Typed Failure Semantics
+
+Sykli records a normalized `failure_semantics` object beside existing task
+status and error fields. This is not a pipeline SDK field and does not change
+the contract schema. It is result metadata produced by the executor so humans
+and agents can tell what kind of law was violated.
+
+Shape:
+
+```json
+{
+  "class": "criteria_failure",
+  "retryable": false,
+  "source": "criteria",
+  "reason": "success_criteria_failed",
+  "message": "task 'test' failed success_criteria",
+  "details": {
+    "code": "success_criteria_failed",
+    "task": "test",
+    "step": "run"
+  }
+}
+```
+
+V1 classes:
+
+- `runtime_failure` — command or target execution failed.
+- `contract_failure` — non-criteria contract behavior failed, such as a review
+  primitive result.
+- `criteria_failure` — the command completed successfully, but declared
+  `success_criteria` failed.
+- `unsupported_target` — the selected target cannot evaluate the declared
+  contract.
+- `timeout` — execution or a gate timed out.
+- `dependency_failure` — the task could not run because required upstream work,
+  inputs, or configuration were missing.
+- `policy_block` — gate or policy logic blocked progress.
+- `skipped` — the task intentionally did not run.
+- `internal_error` — Sykli itself could not complete the step.
+- `unknown` — Sykli cannot classify this result yet.
+
+Reserved for later contract slices:
+
+- `missing_evidence`
+- `agent_variance_failure`
+
+V1 writes failure semantics to executor task results, run history, enriched
+FALSE Protocol occurrences, CLI JSON run output, generated context, and MCP run
+tool output where those paths already expose task result data.
+
+Non-goals:
+
+- no SDK or pipeline schema fields
+- no `evidence_required`
+- no agent metadata or expected variance
+- no gate decision type split
+- no failure-mode learning store

--- a/schemas/sykli-pipeline.schema.json
+++ b/schemas/sykli-pipeline.schema.json
@@ -105,7 +105,7 @@
       }
     },
     "successCriterion": {
-      "description": "One declared success criterion. Criteria are conjunctive: all criteria in success_criteria must pass when engine checking is implemented.",
+      "description": "One declared success criterion. Criteria are conjunctive: all criteria in success_criteria must pass when evaluated by the active target.",
       "oneOf": [
         {
           "$ref": "#/$defs/exitCodeCriterion"
@@ -338,7 +338,7 @@
           ]
         },
         "success_criteria": {
-          "description": "Declared verification metadata for executable task success beyond command completion. Requires top-level version == \"3\". Rejected on review nodes. Metadata only in Phase 3C-1; the engine does not evaluate these criteria yet.",
+          "description": "Declared verification rules for executable task success beyond command completion. Requires top-level version == \"3\". Rejected on review nodes. The executor asks the active target to evaluate these criteria after a successful command.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/successCriterion"


### PR DESCRIPTION
## Summary
- Adds Sykli.FailureSemantics as the normalized task result classification for runtime, criteria, unsupported target, timeout, dependency, policy, skipped, internal, and unknown outcomes.
- Threads failure_semantics through executor task results, run history, occurrence enrichment, CLI/report/context JSON, query output, and MCP run tool output.
- Documents the V1 semantics and keeps SDK/pipeline schema shape unchanged.

## Why
Sykli needs to stop collapsing every bad result into "something failed." This PR gives executor output and persisted evidence a stable classification so agents and humans can distinguish runtime failure, contract/criteria failure, unsupported target behavior, timeout, dependency blockage, policy blockage, and skipped work.

## Classified now
- command execution failure -> runtime_failure
- success_criteria failure -> criteria_failure
- unsupported success criteria/target capability -> unsupported_target
- task and gate timeouts -> timeout
- skipped tasks -> skipped
- dependency/input/secret blockers -> dependency_failure
- gate denial -> policy_block
- review primitive failures -> contract_failure
- unclassified failures -> unknown/internal_error without pretending precision

## Intentionally not included
- No new pipeline schema version
- No SDK parity changes
- No evidence_required
- No agent_metadata
- No expected_variance
- No gate approval redesign
- No coordinator upload of logs/artifacts
- No failure-mode learning store
- No large CLI redesign

## Tests run
- mix format --check-formatted
- mix credo --strict
- mix test

Note: one full mix test run first hit an unrelated StreamData duplicate-generation failure in mesh/transport/sim/event_queue_test.exs; rerunning mix test passed cleanly.