### PR TITLE
Persist task contract slices in history and occurrences

### DIFF
--- a/core/lib/sykli.ex
+++ b/core/lib/sykli.ex
@@ -277,7 +277,9 @@ defmodule Sykli do
             duration_ms: t.duration_ms,
             cached: t.cached,
             error: t.error,
-            failure_semantics: t.failure_semantics
+            failure_semantics: t.failure_semantics,
+            contract_slice: t.contract_slice,
+            success_criteria_results: t.success_criteria_results
           }
         end)
     }
@@ -453,6 +455,8 @@ defmodule Sykli do
         failure_semantics:
           result.failure_semantics ||
             Sykli.FailureSemantics.for_result(result.status, result.error),
+        contract_slice: Sykli.ContractSlice.from_task(task),
+        success_criteria_results: result.success_criteria_results,
         inputs: inputs,
         streak: streak
       }

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -2121,7 +2121,9 @@ defmodule Sykli.CLI do
                     duration_ms: t.duration_ms,
                     cached: t.cached,
                     error: t.error,
-                    failure_semantics: t.failure_semantics
+                    failure_semantics: t.failure_semantics,
+                    contract_slice: t.contract_slice,
+                    success_criteria_results: t.success_criteria_results
                   }
                 end)
             }
@@ -2424,6 +2426,11 @@ defmodule Sykli.CLI do
           }
           |> maybe_put(:error, t.error)
           |> maybe_put(:failure_semantics, Sykli.FailureSemantics.to_map(t.failure_semantics))
+          |> maybe_put(:contract_slice, t.contract_slice)
+          |> maybe_put(
+            :success_criteria_results,
+            report_success_criteria_results(t.success_criteria_results)
+          )
           |> maybe_put(:likely_cause, t.likely_cause)
         end)
     }
@@ -2432,7 +2439,14 @@ defmodule Sykli.CLI do
   end
 
   defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, []), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp report_success_criteria_results(nil), do: nil
+  defp report_success_criteria_results([]), do: nil
+
+  defp report_success_criteria_results(results),
+    do: Sykli.ContractSlice.success_criteria_results(results)
 
   # ----- HISTORY SUBCOMMAND -----
 

--- a/core/lib/sykli/context.ex
+++ b/core/lib/sykli/context.ex
@@ -234,9 +234,12 @@ defmodule Sykli.Context do
       "duration_ms" => result[:duration_ms],
       "cached" => result[:cached] == true,
       "error" => result[:error],
-      "failure_semantics" => Sykli.FailureSemantics.to_map(result[:failure_semantics])
+      "failure_semantics" => Sykli.FailureSemantics.to_map(result[:failure_semantics]),
+      "contract_slice" => result[:contract_slice],
+      "success_criteria_results" =>
+        Sykli.ContractSlice.success_criteria_results(result[:success_criteria_results])
     }
-    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Enum.reject(fn {_k, v} -> is_nil(v) or v == [] end)
     |> Map.new()
   end
 

--- a/core/lib/sykli/contract_slice.ex
+++ b/core/lib/sykli/contract_slice.ex
@@ -33,6 +33,9 @@ defmodule Sykli.ContractSlice do
     |> empty_to_nil()
   end
 
+  # Keep this raw-map path in sync with the struct path above. The struct path
+  # is canonical for live graph tasks; this path preserves persisted/legacy
+  # history records that are already decoded into maps.
   def from_task(%{} = task) do
     %{}
     |> maybe_put("kind", stringify(task[:kind] || task["kind"]))
@@ -73,7 +76,7 @@ defmodule Sykli.ContractSlice do
 
   def success_criteria_result_to_map(%{} = result) do
     result
-    |> stringify_keys()
+    |> to_json_compatible()
     |> reject_empty()
   end
 
@@ -128,7 +131,7 @@ defmodule Sykli.ContractSlice do
     |> maybe_put("container", task[:container] || task["container"])
     |> maybe_put("workdir", task[:workdir] || task["workdir"])
     |> maybe_put("timeout_seconds", task[:timeout] || task["timeout"])
-    |> maybe_put("requires", non_empty(task[:requires] || task["requires"]))
+    |> maybe_put("requires", normalized_value(non_empty(task[:requires] || task["requires"])))
     |> empty_to_nil()
   end
 
@@ -150,15 +153,15 @@ defmodule Sykli.ContractSlice do
     String.to_existing_atom(value)
   end
 
-  defp parse_status(value) when is_atom(value), do: value
-  defp parse_status(_), do: :failed
+  defp parse_status(value) when value in [:passed, :failed, :unsupported], do: value
+  defp parse_status(_), do: :unknown
 
   defp normalized_map(nil), do: nil
-  defp normalized_map(%{} = map), do: map |> stringify_keys() |> reject_empty()
+  defp normalized_map(%{} = map), do: map |> to_json_compatible() |> reject_empty()
   defp normalized_map(_), do: nil
 
   defp normalized_value(nil), do: nil
-  defp normalized_value(value), do: stringify_keys(value)
+  defp normalized_value(value), do: to_json_compatible(value)
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, _key, []), do: map
@@ -182,14 +185,14 @@ defmodule Sykli.ContractSlice do
   defp stringify(value) when is_atom(value), do: Atom.to_string(value)
   defp stringify(value), do: value
 
-  defp stringify_keys(map) when is_map(map) do
+  defp to_json_compatible(map) when is_map(map) do
     Map.new(map, fn
-      {key, value} when is_atom(key) -> {Atom.to_string(key), stringify_keys(value)}
-      {key, value} -> {key, stringify_keys(value)}
+      {key, value} when is_atom(key) -> {Atom.to_string(key), to_json_compatible(value)}
+      {key, value} -> {key, to_json_compatible(value)}
     end)
   end
 
-  defp stringify_keys(list) when is_list(list), do: Enum.map(list, &stringify_keys/1)
-  defp stringify_keys(value) when is_atom(value), do: Atom.to_string(value)
-  defp stringify_keys(value), do: value
+  defp to_json_compatible(list) when is_list(list), do: Enum.map(list, &to_json_compatible/1)
+  defp to_json_compatible(value) when is_atom(value), do: Atom.to_string(value)
+  defp to_json_compatible(value), do: value
 end

--- a/core/lib/sykli/contract_slice.ex
+++ b/core/lib/sykli/contract_slice.ex
@@ -1,0 +1,195 @@
+defmodule Sykli.ContractSlice do
+  @moduledoc """
+  Small task contract projection stored with result evidence.
+
+  A contract slice is not a pipeline schema field. It is a post-parse snapshot of
+  the already-declared task semantics that explain what law applied to a task
+  result. Keep this reference-sized: no logs, source, artifacts, or raw outputs.
+  """
+
+  alias Sykli.Graph.Task
+  alias Sykli.Graph.Task.{AiHooks, Capability, Gate, Semantic}
+  alias Sykli.SuccessCriteria
+
+  @type t :: map()
+
+  @doc "Builds a compact, JSON-compatible contract slice for a graph task."
+  @spec from_task(Task.t() | map() | nil) :: t() | nil
+  def from_task(nil), do: nil
+  def from_task(%{} = task) when map_size(task) == 0, do: nil
+
+  def from_task(%Task{} = task) do
+    %{}
+    |> maybe_put("kind", Atom.to_string(Task.kind(task)))
+    |> maybe_put("task_type", Task.task_type(task))
+    |> maybe_put("semantic", semantic_map(task))
+    |> maybe_put("ai_hooks", ai_hooks_map(task))
+    |> maybe_put("provides", capability_field(task, "provides"))
+    |> maybe_put("needs", capability_field(task, "needs"))
+    |> maybe_put("success_criteria", non_empty(Task.success_criteria(task)))
+    |> maybe_put("target", target_map(task))
+    |> maybe_put("review", review_map(task))
+    |> maybe_put("gate", gate_map(task))
+    |> empty_to_nil()
+  end
+
+  def from_task(%{} = task) do
+    %{}
+    |> maybe_put("kind", stringify(task[:kind] || task["kind"]))
+    |> maybe_put("task_type", task[:task_type] || task["task_type"])
+    |> maybe_put("semantic", normalized_map(task[:semantic] || task["semantic"]))
+    |> maybe_put("ai_hooks", normalized_map(task[:ai_hooks] || task["ai_hooks"]))
+    |> maybe_put("provides", normalized_value(task[:provides] || task["provides"]))
+    |> maybe_put("needs", normalized_value(task[:needs] || task["needs"]))
+    |> maybe_put(
+      "success_criteria",
+      normalized_value(non_empty(task[:success_criteria] || task["success_criteria"]))
+    )
+    |> maybe_put("target", map_target(task))
+    |> maybe_put("review", normalized_map(task[:review] || task["review"]))
+    |> maybe_put("gate", normalized_map(task[:gate] || task["gate"]))
+    |> empty_to_nil()
+  end
+
+  @doc "Serializes success criteria results to stable string-keyed maps."
+  @spec success_criteria_results([SuccessCriteria.Result.t() | map()] | nil) :: [map()]
+  def success_criteria_results(nil), do: []
+
+  def success_criteria_results(results) when is_list(results) do
+    Enum.map(results, &success_criteria_result_to_map/1)
+  end
+
+  def success_criteria_result_to_map(%SuccessCriteria.Result{} = result) do
+    %{
+      "index" => result.index,
+      "type" => result.type,
+      "status" => stringify(result.status),
+      "message" => result.message,
+      "evidence" => result.evidence,
+      "target" => result.target
+    }
+    |> reject_empty()
+  end
+
+  def success_criteria_result_to_map(%{} = result) do
+    result
+    |> stringify_keys()
+    |> reject_empty()
+  end
+
+  @doc "Decodes persisted success criteria result maps."
+  @spec success_criteria_results_from_maps([map()] | nil) :: [SuccessCriteria.Result.t()]
+  def success_criteria_results_from_maps(nil), do: []
+
+  def success_criteria_results_from_maps(results) when is_list(results) do
+    Enum.map(results, &success_criteria_result_from_map/1)
+  end
+
+  defp success_criteria_result_from_map(%{} = data) do
+    %SuccessCriteria.Result{
+      index: data["index"],
+      type: data["type"],
+      status: parse_status(data["status"]),
+      message: data["message"],
+      evidence: data["evidence"],
+      target: data["target"]
+    }
+  end
+
+  defp semantic_map(%Task{} = task) do
+    if Task.has_semantic?(task), do: Semantic.to_map(Task.semantic(task))
+  end
+
+  defp ai_hooks_map(%Task{} = task) do
+    if Task.has_ai_hooks?(task), do: AiHooks.to_map(Task.ai_hooks(task))
+  end
+
+  defp capability_field(%Task{} = task, field) do
+    task
+    |> Task.capability()
+    |> Capability.to_map()
+    |> case do
+      nil -> nil
+      map -> map[field]
+    end
+  end
+
+  defp target_map(%Task{} = task) do
+    %{}
+    |> maybe_put("container", Task.container(task))
+    |> maybe_put("workdir", Task.workdir(task))
+    |> maybe_put("timeout_seconds", Task.timeout(task))
+    |> maybe_put("requires", non_empty(Task.requires(task)))
+    |> empty_to_nil()
+  end
+
+  defp map_target(%{} = task) do
+    %{}
+    |> maybe_put("container", task[:container] || task["container"])
+    |> maybe_put("workdir", task[:workdir] || task["workdir"])
+    |> maybe_put("timeout_seconds", task[:timeout] || task["timeout"])
+    |> maybe_put("requires", non_empty(task[:requires] || task["requires"]))
+    |> empty_to_nil()
+  end
+
+  defp review_map(%Task{} = task) do
+    if Task.review?(task) do
+      %{}
+      |> maybe_put("primitive", Task.primitive(task))
+      |> maybe_put("agent", Task.agent(task))
+      |> maybe_put("context", non_empty(Task.context(task)))
+      |> maybe_put("deterministic", Task.deterministic?(task))
+      |> empty_to_nil()
+    end
+  end
+
+  defp gate_map(%Task{gate: %Gate{} = gate}), do: Gate.to_map(gate)
+  defp gate_map(_), do: nil
+
+  defp parse_status(value) when value in ["passed", "failed", "unsupported"] do
+    String.to_existing_atom(value)
+  end
+
+  defp parse_status(value) when is_atom(value), do: value
+  defp parse_status(_), do: :failed
+
+  defp normalized_map(nil), do: nil
+  defp normalized_map(%{} = map), do: map |> stringify_keys() |> reject_empty()
+  defp normalized_map(_), do: nil
+
+  defp normalized_value(nil), do: nil
+  defp normalized_value(value), do: stringify_keys(value)
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, []), do: map
+  defp maybe_put(map, _key, value) when value == %{}, do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp non_empty(nil), do: nil
+  defp non_empty([]), do: nil
+  defp non_empty(value), do: value
+
+  defp empty_to_nil(map) when map == %{}, do: nil
+  defp empty_to_nil(map), do: map
+
+  defp reject_empty(map) do
+    map
+    |> Enum.reject(fn {_key, value} -> is_nil(value) or value == [] or value == %{} end)
+    |> Map.new()
+  end
+
+  defp stringify(nil), do: nil
+  defp stringify(value) when is_atom(value), do: Atom.to_string(value)
+  defp stringify(value), do: value
+
+  defp stringify_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), stringify_keys(value)}
+      {key, value} -> {key, stringify_keys(value)}
+    end)
+  end
+
+  defp stringify_keys(list) when is_list(list), do: Enum.map(list, &stringify_keys/1)
+  defp stringify_keys(value) when is_atom(value), do: Atom.to_string(value)
+  defp stringify_keys(value), do: value
+end

--- a/core/lib/sykli/occurrence/enrichment.ex
+++ b/core/lib/sykli/occurrence/enrichment.ex
@@ -531,6 +531,11 @@ defmodule Sykli.Occurrence.Enrichment do
       |> maybe_add("log", task_log_path(result, run_id))
       |> maybe_add("error", error_detail_map(result.error))
       |> maybe_add("failure_semantics", failure_semantics_map(result))
+      |> maybe_add("contract_slice", Sykli.ContractSlice.from_task(task))
+      |> maybe_add(
+        "success_criteria_results",
+        non_empty(Sykli.ContractSlice.success_criteria_results(result.success_criteria_results))
+      )
       |> maybe_add("covers", non_empty(get_semantic_covers(task)))
       |> maybe_add("inputs", non_empty(get_field(task, :inputs)))
       |> maybe_add("depends_on", non_empty(get_field(task, :depends_on)))

--- a/core/lib/sykli/query/history.ex
+++ b/core/lib/sykli/query/history.ex
@@ -62,6 +62,8 @@ defmodule Sykli.Query.History do
              status: :failed,
              error: task.error,
              failure_semantics: Sykli.FailureSemantics.to_map(task.failure_semantics),
+             contract_slice: task.contract_slice,
+             success_criteria_results: success_criteria_results(task.success_criteria_results),
              duration_ms: task.duration_ms,
              run_id: run.id,
              timestamp: DateTime.to_iso8601(run.timestamp),
@@ -93,6 +95,12 @@ defmodule Sykli.Query.History do
       DateTime.to_date(run.timestamp) == today
     end)
   end
+
+  defp success_criteria_results(nil), do: nil
+  defp success_criteria_results([]), do: nil
+
+  defp success_criteria_results(results),
+    do: Sykli.ContractSlice.success_criteria_results(results)
 
   defp metadata(query) do
     %{query: query, timestamp: DateTime.utc_now() |> DateTime.to_iso8601()}

--- a/core/lib/sykli/query/runs.ex
+++ b/core/lib/sykli/query/runs.ex
@@ -81,11 +81,22 @@ defmodule Sykli.Query.Runs do
               cached: t.cached == true
             }
             |> maybe_put(:failure_semantics, Sykli.FailureSemantics.to_map(t.failure_semantics))
+            |> maybe_put(:contract_slice, t.contract_slice)
+            |> maybe_put(
+              :success_criteria_results,
+              non_empty_success_criteria_results(t.success_criteria_results)
+            )
 
           maybe_put(result, :error, t.error)
         end)
     }
   end
+
+  defp non_empty_success_criteria_results(nil), do: nil
+  defp non_empty_success_criteria_results([]), do: nil
+
+  defp non_empty_success_criteria_results(results),
+    do: Sykli.ContractSlice.success_criteria_results(results)
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/core/lib/sykli/run_history.ex
+++ b/core/lib/sykli/run_history.ex
@@ -28,9 +28,11 @@ defmodule Sykli.RunHistory do
       :duration_ms,
       :error,
       :failure_semantics,
+      :contract_slice,
       :inputs,
       :likely_cause,
       :verified_on,
+      success_criteria_results: [],
       cached: false,
       streak: 0
     ]
@@ -42,6 +44,8 @@ defmodule Sykli.RunHistory do
             cached: boolean(),
             error: String.t() | nil,
             failure_semantics: Sykli.FailureSemantics.t() | nil,
+            contract_slice: map() | nil,
+            success_criteria_results: [Sykli.SuccessCriteria.Result.t()],
             inputs: [String.t()] | nil,
             likely_cause: [String.t()] | nil,
             verified_on: String.t() | nil,
@@ -313,10 +317,21 @@ defmodule Sykli.RunHistory do
     }
     |> maybe_add(:error, tr.error)
     |> maybe_add(:failure_semantics, Sykli.FailureSemantics.to_map(tr.failure_semantics))
+    |> maybe_add(:contract_slice, tr.contract_slice)
+    |> maybe_add(
+      :success_criteria_results,
+      non_empty_success_criteria_results(tr.success_criteria_results)
+    )
     |> maybe_add(:inputs, tr.inputs)
     |> maybe_add(:likely_cause, tr.likely_cause)
     |> maybe_add(:verified_on, tr.verified_on)
   end
+
+  defp non_empty_success_criteria_results(nil), do: nil
+  defp non_empty_success_criteria_results([]), do: nil
+
+  defp non_empty_success_criteria_results(results),
+    do: Sykli.ContractSlice.success_criteria_results(results)
 
   defp maybe_add(map, _key, nil), do: map
   defp maybe_add(map, key, value), do: Map.put(map, key, value)
@@ -348,6 +363,9 @@ defmodule Sykli.RunHistory do
       streak: data["streak"] || 0,
       error: data["error"],
       failure_semantics: Sykli.FailureSemantics.from_map(data["failure_semantics"]),
+      contract_slice: data["contract_slice"],
+      success_criteria_results:
+        Sykli.ContractSlice.success_criteria_results_from_maps(data["success_criteria_results"]),
       inputs: data["inputs"],
       likely_cause: data["likely_cause"],
       verified_on: data["verified_on"]

--- a/core/lib/sykli/success_criteria.ex
+++ b/core/lib/sykli/success_criteria.ex
@@ -13,7 +13,7 @@ defmodule Sykli.SuccessCriteria do
     @enforce_keys [:index, :type, :status, :message]
     defstruct [:index, :type, :status, :message, :evidence, :target]
 
-    @type status :: :passed | :failed | :unsupported
+    @type status :: :passed | :failed | :unsupported | :unknown
 
     @type t :: %__MODULE__{
             index: non_neg_integer(),

--- a/core/test/sykli/contract_slice_test.exs
+++ b/core/test/sykli/contract_slice_test.exs
@@ -1,0 +1,126 @@
+defmodule Sykli.ContractSliceTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.ContractSlice
+  alias Sykli.Graph
+  alias Sykli.SuccessCriteria.Result
+
+  test "projects task contract metadata without command or output" do
+    task =
+      parse_task(%{
+        "version" => "3",
+        "tasks" => [
+          %{
+            "name" => "test",
+            "command" => "mix test",
+            "task_type" => "test",
+            "semantic" => %{
+              "intent" => "Verify API behavior",
+              "covers" => ["lib/api/**"],
+              "criticality" => "high"
+            },
+            "ai_hooks" => %{"on_fail" => "analyze", "select" => "smart"},
+            "provides" => [%{"name" => "verified-api", "value" => "yes"}],
+            "needs" => ["deps-built"],
+            "success_criteria" => [%{"type" => "exit_code", "equals" => 0}],
+            "container" => "hexpm/elixir:latest",
+            "workdir" => "apps/api",
+            "timeout" => 60,
+            "requires" => ["linux"]
+          }
+        ]
+      })
+
+    slice = ContractSlice.from_task(task)
+
+    assert slice["kind"] == "task"
+    assert slice["task_type"] == "test"
+    assert slice["semantic"]["intent"] == "Verify API behavior"
+    assert slice["semantic"]["criticality"] == "high"
+    assert slice["ai_hooks"] == %{"on_fail" => "analyze", "select" => "smart"}
+    assert slice["provides"] == [%{"name" => "verified-api", "value" => "yes"}]
+    assert slice["needs"] == ["deps-built"]
+    assert slice["success_criteria"] == [%{"type" => "exit_code", "equals" => 0}]
+    assert slice["target"]["container"] == "hexpm/elixir:latest"
+    assert slice["target"]["workdir"] == "apps/api"
+    assert slice["target"]["timeout_seconds"] == 60
+    assert slice["target"]["requires"] == ["linux"]
+    refute Map.has_key?(slice, "command")
+  end
+
+  test "projects review and gate metadata when declared" do
+    review =
+      parse_task(%{
+        "version" => "3",
+        "tasks" => [
+          %{
+            "name" => "review-api",
+            "kind" => "review",
+            "primitive" => "api_breakage",
+            "agent" => "reviewer",
+            "context" => ["lib/api.ex"],
+            "deterministic" => true
+          }
+        ]
+      })
+
+    gate =
+      parse_task(%{
+        "version" => "3",
+        "tasks" => [
+          %{
+            "name" => "approve",
+            "kind" => "gate",
+            "gate" => %{"strategy" => "env", "timeout" => 30, "env_var" => "APPROVE_DEPLOY"}
+          }
+        ]
+      })
+
+    assert ContractSlice.from_task(review)["review"] == %{
+             "primitive" => "api_breakage",
+             "agent" => "reviewer",
+             "context" => ["lib/api.ex"],
+             "deterministic" => true
+           }
+
+    assert ContractSlice.from_task(gate)["gate"] == %{
+             "strategy" => "env",
+             "timeout" => 30,
+             "env_var" => "APPROVE_DEPLOY"
+           }
+  end
+
+  test "serializes and decodes success criteria results" do
+    results = [
+      %Result{
+        index: 0,
+        type: "exit_code",
+        status: :failed,
+        message: "expected exit code 0, got 1",
+        evidence: %{"actual" => 1},
+        target: "local"
+      }
+    ]
+
+    assert [
+             %{
+               "index" => 0,
+               "type" => "exit_code",
+               "status" => "failed",
+               "message" => "expected exit code 0, got 1",
+               "evidence" => %{"actual" => 1},
+               "target" => "local"
+             }
+           ] = ContractSlice.success_criteria_results(results)
+
+    assert [%Result{status: :failed, type: "exit_code"}] =
+             ContractSlice.success_criteria_results_from_maps(
+               ContractSlice.success_criteria_results(results)
+             )
+  end
+
+  defp parse_task(pipeline) do
+    {:ok, graph} = pipeline |> Jason.encode!() |> Graph.parse()
+    graph |> Map.values() |> hd()
+  end
+end

--- a/core/test/sykli/contract_slice_test.exs
+++ b/core/test/sykli/contract_slice_test.exs
@@ -48,6 +48,33 @@ defmodule Sykli.ContractSliceTest do
     refute Map.has_key?(slice, "command")
   end
 
+  test "projects legacy raw-map task contract metadata" do
+    slice =
+      ContractSlice.from_task(%{
+        kind: :task,
+        task_type: "test",
+        semantic: %{intent: "Verify API behavior", criticality: :high},
+        ai_hooks: %{on_fail: :analyze},
+        provides: [%{name: :verified_api, value: "yes"}],
+        needs: [:deps_built],
+        success_criteria: [%{type: "exit_code", equals: 0}],
+        container: "hexpm/elixir:latest",
+        workdir: "apps/api",
+        timeout: 60,
+        requires: [:linux]
+      })
+
+    assert slice["kind"] == "task"
+    assert slice["task_type"] == "test"
+    assert slice["semantic"] == %{"intent" => "Verify API behavior", "criticality" => "high"}
+    assert slice["ai_hooks"] == %{"on_fail" => "analyze"}
+    assert slice["provides"] == [%{"name" => "verified_api", "value" => "yes"}]
+    assert slice["needs"] == ["deps_built"]
+    assert slice["success_criteria"] == [%{"type" => "exit_code", "equals" => 0}]
+    assert slice["target"]["container"] == "hexpm/elixir:latest"
+    assert slice["target"]["requires"] == ["linux"]
+  end
+
   test "projects review and gate metadata when declared" do
     review =
       parse_task(%{
@@ -117,6 +144,18 @@ defmodule Sykli.ContractSliceTest do
              ContractSlice.success_criteria_results_from_maps(
                ContractSlice.success_criteria_results(results)
              )
+  end
+
+  test "decodes unknown persisted success criteria status as unknown" do
+    assert [%Result{status: :unknown}] =
+             ContractSlice.success_criteria_results_from_maps([
+               %{"type" => "exit_code", "status" => "future_status"}
+             ])
+
+    assert [%Result{status: :unknown}] =
+             ContractSlice.success_criteria_results_from_maps([
+               %{"type" => "exit_code"}
+             ])
   end
 
   defp parse_task(pipeline) do

--- a/core/test/sykli/occurrence/enrichment_test.exs
+++ b/core/test/sykli/occurrence/enrichment_test.exs
@@ -45,6 +45,55 @@ defmodule Sykli.Occurrence.EnrichmentTest do
       assert enriched.data["summary"]["failed"] == 0
     end
 
+    test "task details include contract slice and success criteria results", %{workdir: workdir} do
+      occ = make_occurrence("run-contract-slice", "ci.run.failed", "failure")
+
+      graph = %{
+        "test" => %{
+          kind: :task,
+          command: "mix test",
+          task_type: "test",
+          semantic: %{intent: "Verify API", covers: ["lib/api/**"], criticality: :high},
+          ai_hooks: %{on_fail: :analyze, select: :smart},
+          success_criteria: [%{"type" => "exit_code", "equals" => 0}],
+          depends_on: ["build"],
+          inputs: ["lib/**/*.ex"]
+        }
+      }
+
+      results =
+        {:error,
+         [
+           %TaskResult{
+             name: "test",
+             status: :failed,
+             duration_ms: 200,
+             success_criteria_results: [
+               %Sykli.SuccessCriteria.Result{
+                 index: 0,
+                 type: "exit_code",
+                 status: :failed,
+                 message: "expected exit code 0, got 1",
+                 target: "local"
+               }
+             ]
+           }
+         ]}
+
+      enriched = Enrichment.enrich(occ, graph, results, workdir)
+      [task] = enriched.data["tasks"]
+
+      assert task["contract_slice"]["task_type"] == "test"
+      assert task["contract_slice"]["semantic"]["intent"] == "Verify API"
+
+      assert task["contract_slice"]["success_criteria"] == [
+               %{"type" => "exit_code", "equals" => 0}
+             ]
+
+      assert [%{"status" => "failed", "target" => "local"}] =
+               task["success_criteria_results"]
+    end
+
     test "enriches a failing run with error, reasoning, and history blocks", %{workdir: workdir} do
       occ = make_occurrence("run-fail", "ci.run.failed", "failure")
 

--- a/core/test/sykli/run_history_test.exs
+++ b/core/test/sykli/run_history_test.exs
@@ -68,6 +68,47 @@ defmodule Sykli.RunHistoryTest do
              } = task.failure_semantics
     end
 
+    test "round-trips contract slice and success criteria results", %{tmp_dir: tmp_dir} do
+      run = %RunHistory.Run{
+        id: "contract-slice-run",
+        timestamp: ~U[2024-01-15 10:30:00Z],
+        git_ref: "abc1234",
+        git_branch: "main",
+        tasks: [
+          %RunHistory.TaskResult{
+            name: "test",
+            status: :failed,
+            duration_ms: 100,
+            contract_slice: %{
+              "task_type" => "test",
+              "semantic" => %{"intent" => "Verify behavior"},
+              "success_criteria" => [%{"type" => "exit_code", "equals" => 0}]
+            },
+            success_criteria_results: [
+              %Sykli.SuccessCriteria.Result{
+                index: 0,
+                type: "exit_code",
+                status: :failed,
+                message: "expected exit code 0, got 1",
+                target: "local"
+              }
+            ]
+          }
+        ],
+        overall: :failed
+      }
+
+      assert :ok = RunHistory.save(run, path: tmp_dir)
+      assert {:ok, loaded} = RunHistory.load_latest(path: tmp_dir)
+      [task] = loaded.tasks
+
+      assert task.contract_slice["task_type"] == "test"
+      assert task.contract_slice["semantic"]["intent"] == "Verify behavior"
+
+      assert [%Sykli.SuccessCriteria.Result{status: :failed, target: "local"}] =
+               task.success_criteria_results
+    end
+
     test "creates latest.json symlink", %{tmp_dir: tmp_dir} do
       run = %RunHistory.Run{
         id: "test-run-2",
@@ -197,6 +238,37 @@ defmodule Sykli.RunHistoryTest do
     end
   end
 
+  describe "execution history contract slices" do
+    test "Sykli.run persists task contract slice and criteria results", %{tmp_dir: tmp_dir} do
+      json =
+        Jason.encode!(%{
+          "version" => "3",
+          "tasks" => [
+            %{
+              "name" => "test",
+              "command" => "echo ok",
+              "task_type" => "test",
+              "semantic" => %{"intent" => "Verify behavior", "covers" => ["lib/**"]},
+              "success_criteria" => [%{"type" => "exit_code", "equals" => 0}]
+            }
+          ]
+        })
+
+      File.write!(Path.join(tmp_dir, "sykli.exs"), "IO.puts(#{inspect(json)})")
+
+      assert {:ok, _results} = Sykli.run(tmp_dir)
+      assert {:ok, run} = RunHistory.load_latest(path: tmp_dir)
+      [task] = run.tasks
+
+      assert task.contract_slice["task_type"] == "test"
+      assert task.contract_slice["semantic"]["intent"] == "Verify behavior"
+      assert task.contract_slice["success_criteria"] == [%{"type" => "exit_code", "equals" => 0}]
+
+      assert [%Sykli.SuccessCriteria.Result{status: :passed, type: "exit_code"}] =
+               task.success_criteria_results
+    end
+  end
+
   describe "load_latest/1" do
     test "returns latest run", %{tmp_dir: tmp_dir} do
       run = %RunHistory.Run{
@@ -213,6 +285,37 @@ defmodule Sykli.RunHistoryTest do
       assert {:ok, loaded} = RunHistory.load_latest(path: tmp_dir)
       assert loaded.id == "test-run-5"
       assert loaded.git_ref == "abc1234"
+    end
+
+    test "loads old run history without contract slices", %{tmp_dir: tmp_dir} do
+      runs_dir = Path.join([tmp_dir, ".sykli", "runs"])
+      File.mkdir_p!(runs_dir)
+
+      File.write!(
+        Path.join(runs_dir, "latest.json"),
+        Jason.encode!(%{
+          "id" => "old-run",
+          "timestamp" => "2024-01-15T10:30:00Z",
+          "git_ref" => "abc1234",
+          "git_branch" => "main",
+          "overall" => "failed",
+          "tasks" => [
+            %{
+              "name" => "test",
+              "status" => "failed",
+              "duration_ms" => 100,
+              "cached" => false,
+              "streak" => 0,
+              "error" => "task_failed: task failed"
+            }
+          ]
+        })
+      )
+
+      assert {:ok, loaded} = RunHistory.load_latest(path: tmp_dir)
+      [task] = loaded.tasks
+      assert task.contract_slice == nil
+      assert task.success_criteria_results == []
     end
 
     test "returns error when no runs exist", %{tmp_dir: tmp_dir} do

--- a/docs/agent-contract-semantics.md
+++ b/docs/agent-contract-semantics.md
@@ -16,6 +16,10 @@ Runtime result classification is documented separately in
 `docs/failure-semantics.md`. `failure_semantics` is produced by Sykli after
 execution; it is not an SDK-emitted pipeline field.
 
+Historical result contract snapshots are documented in
+`docs/result-contract-slices.md`. `contract_slice` is also produced by Sykli
+after parsing/execution; it is not an SDK-emitted pipeline field.
+
 ## Thesis
 
 Phase 3 moves Sykli from "describes how to run a graph" to "describes what the

--- a/docs/result-contract-slices.md
+++ b/docs/result-contract-slices.md
@@ -1,0 +1,35 @@
+# Result Contract Slices
+
+Sykli stores a compact `contract_slice` beside task result evidence. The slice
+is not a pipeline SDK field and does not change the contract schema. It is a
+post-parse projection of contract fields that already exist, captured so agents
+can inspect historical results and see what law applied.
+
+Current slice fields are optional and reference-sized:
+
+- `kind`
+- `task_type`
+- `semantic`
+- `ai_hooks`
+- `provides`
+- `needs`
+- `success_criteria`
+- `target`
+- `review`
+- `gate`
+
+Run history also stores `success_criteria_results` beside the slice. Occurrence
+task details include both the declared `success_criteria` in `contract_slice`
+and the evaluated `success_criteria_results`.
+
+The slice intentionally excludes command output, logs, source code, prompts,
+artifacts, and raw generated content. Evidence remains local/reference-oriented.
+
+V1 does not add:
+
+- new SDK or pipeline schema fields
+- evidence requirements
+- risk/effects
+- agent metadata or variance
+- gate decision type changes
+- failure-mode learning


### PR DESCRIPTION
## Summary
- Adds Sykli.ContractSlice, a compact result-time projection of existing task contract fields.
- Persists contract_slice and success_criteria_results in run history while keeping old history readable.
- Emits contract slices and criteria results through occurrence task details, context/report/query JSON paths that already expose historical task data.

## Why
Typed failure semantics says what kind of failure happened. This PR adds the adjacent contract context: what task_type, semantic intent, criteria, capability declarations, gate/review metadata, and target-relevant settings applied when that result was produced. This supports Sykli is the law by making historical evidence explain the contract being enforced, not only the result.

## What changed
- core/lib/sykli/contract_slice.ex: new compact projection helpers and success_criteria result serialization.
- core/lib/sykli/run_history.ex: optional contract_slice plus success_criteria_results on task records; old records still load with nil/empty values.
- core/lib/sykli.ex: records contract slices and criteria results during run-history conversion.
- core/lib/sykli/occurrence/enrichment.ex: includes contract_slice and success_criteria_results in enriched task details.
- core/lib/sykli/cli.ex, context.ex, query/history.ex, query/runs.ex: carry the new history fields through existing machine-readable surfaces.
- docs/result-contract-slices.md and docs/agent-contract-semantics.md: document the result-time projection.

## Compatibility
- No pipeline schema changes.
- No SDK changes.
- Old run history without contract_slice or success_criteria_results still decodes.
- Existing status/error/failure_semantics fields are preserved.

## Tests
- mix format --check-formatted
- mix credo --strict
- mix test
- targeted: mix test test/sykli/contract_slice_test.exs test/sykli/run_history_test.exs test/sykli/occurrence/enrichment_test.exs test/sykli/query/history_test.exs test/sykli/query/runs_test.exs

## Non-goals
- No evidence_required model.
- No risk/effects model.
- No agent metadata or variance model.
- No gate decision redesign.
- No failure-mode learning store.
- No raw log/source/artifact/prompt storage.
- No coordinator upload changes.

## Known follow-ups
- Next PR: expose consistent agent-readable failure/contract output across CLI and MCP, with simple derived agent hints based only on failure_semantics.