### PR TITLE
fix(team): unblock remote gate decisions after PR 201

### DIFF
--- a/core/lib/sykli/cli/gate.ex
+++ b/core/lib/sykli/cli/gate.ex
@@ -168,7 +168,10 @@ defmodule Sykli.CLI.Gate do
           IO.puts("No team gates")
         else
           IO.puts("Team gates:")
-          Enum.each(gates, fn gate -> IO.puts("  #{gate["id"]}  #{gate["status"]}") end)
+
+          Enum.each(gates, fn gate ->
+            IO.puts("  #{gate["id"]}  #{gate["status"]}  #{gate["node_id"] || "-"}")
+          end)
         end
       end)
     else

--- a/core/lib/sykli/daemon/join.ex
+++ b/core/lib/sykli/daemon/join.ex
@@ -9,6 +9,10 @@ defmodule Sykli.Daemon.Join do
   alias Sykli.Error
   alias Sykli.Error.Formatter
 
+  require Logger
+
+  @gate_apply_retry_cap 10
+
   def run(args, runtime_opts \\ []) do
     case parse(args) do
       {:ok, :help, _opts} ->
@@ -84,8 +88,21 @@ defmodule Sykli.Daemon.Join do
     |> Enum.reduce({:ok, []}, fn
       decision, {:ok, acked} when is_map(decision) ->
         case Sykli.Gate.Store.apply_remote_decision(decision, opts) do
-          {:ok, _gate, _mode} -> {:ok, [decision["id"] | acked]}
-          {:error, _reason} -> {:ok, acked}
+          {:ok, _gate, _mode} ->
+            reset_gate_apply_failures(decision, opts)
+            {:ok, [decision["id"] | acked]}
+
+          {:error, reason} ->
+            if record_gate_apply_failure(decision, reason, opts) > @gate_apply_retry_cap do
+              Logger.error("dropping gate decision after repeated local apply failures",
+                id: decision["id"],
+                reason: inspect(reason)
+              )
+
+              {:ok, [decision["id"] | acked]}
+            else
+              {:ok, acked}
+            end
         end
 
       _decision, {:ok, acked} ->
@@ -94,6 +111,36 @@ defmodule Sykli.Daemon.Join do
     |> case do
       {:ok, ids} -> {:ok, Enum.reverse(Enum.reject(ids, &is_nil/1))}
     end
+  end
+
+  defp record_gate_apply_failure(decision, reason, opts) do
+    id = decision["id"]
+    key = gate_apply_failure_key(id, opts)
+    count = Process.get(key, 0) + 1
+    Process.put(key, count)
+
+    Logger.warning("failed to apply remote gate decision",
+      id: id,
+      reason: inspect(reason),
+      attempt: count
+    )
+
+    Sykli.Occurrence.PubSub.team_gate_apply_failed(decision["run_id"] || "unknown", %{
+      "id" => id,
+      "reason" => inspect(reason)
+    })
+
+    count
+  end
+
+  defp reset_gate_apply_failures(decision, opts) do
+    Process.delete(gate_apply_failure_key(decision["id"], opts))
+    :ok
+  end
+
+  defp gate_apply_failure_key(id, opts) do
+    session_id = Keyword.get(opts, :session_id, :default)
+    {__MODULE__, :gate_apply_failure, session_id, id}
   end
 
   defp persist_session(opts, payload, data, runtime_opts) do

--- a/core/lib/sykli/executor.ex
+++ b/core/lib/sykli/executor.ex
@@ -1323,10 +1323,9 @@ defmodule Sykli.Executor do
       summary = Sykli.TeamCoordinator.GateDecisionSummary.from_gate_decision(gate)
       encoded_summary = Sykli.TeamCoordinator.GateDecisionSummary.encode(summary)
 
-      OccPubSub.team_gate_requested(run_id, encoded_summary)
-
       case team_gate_client().publish_waiting(session, token, summary) do
         {:ok, _published} ->
+          OccPubSub.team_gate_requested(run_id, encoded_summary)
           {:ok, gate}
 
         {:error, _reason} ->
@@ -1337,6 +1336,7 @@ defmodule Sykli.Executor do
             |> Map.put("daemon_session_id", session["session_id"])
 
           :ok = Sykli.Outbox.enqueue("gates", payload, path: workdir)
+          OccPubSub.team_gate_requested(run_id, payload)
           OccPubSub.team_gate_sync_deferred(run_id, payload)
           {:ok, gate}
       end
@@ -1366,27 +1366,18 @@ defmodule Sykli.Executor do
   end
 
   defp team_gate_id(run_id, task_name) do
-    raw = "#{run_id}-#{task_name}"
+    id = "#{run_id}:#{task_name}"
 
-    sanitized =
-      ~r/[^A-Za-z0-9_.-]/
-      |> Regex.replace(raw, "-")
-      |> ensure_gate_id_prefix()
-
-    if String.length(sanitized) <= 128 do
-      sanitized
+    if String.length(id) <= 128 do
+      id
     else
       hash =
-        :crypto.hash(:sha256, raw)
+        :crypto.hash(:sha256, id)
         |> Base.encode16(case: :lower)
         |> binary_part(0, 16)
 
-      String.slice(sanitized, 0, 111) <> "-" <> hash
+      String.slice(id, 0, 111) <> "-" <> hash
     end
-  end
-
-  defp ensure_gate_id_prefix(<<first::binary-size(1), _rest::binary>> = id) do
-    if Regex.match?(~r/[A-Za-z0-9]/, first), do: id, else: "g-" <> id
   end
 
   defp team_gate_client do

--- a/core/lib/sykli/gate/store.ex
+++ b/core/lib/sykli/gate/store.ex
@@ -115,6 +115,7 @@ defmodule Sykli.Gate.Store do
         {:changed, updated} ->
           :ok = save(updated, opts)
           emit_decision_received(updated, payload)
+          broadcast_gate_decision(updated)
           {:ok, updated, :changed}
 
         {:unchanged, gate} ->
@@ -192,6 +193,14 @@ defmodule Sykli.Gate.Store do
       "decided_at" => gate.decided_at,
       "reason" => gate.reason
     })
+  end
+
+  defp broadcast_gate_decision(%GateDecision{} = gate) do
+    Phoenix.PubSub.broadcast(
+      Sykli.PubSub,
+      "gate:" <> gate.id,
+      {:gate_decided, gate.status, gate.decided_by || "team"}
+    )
   end
 
   defp required_string(map, field) do

--- a/core/lib/sykli/gate_decision.ex
+++ b/core/lib/sykli/gate_decision.ex
@@ -161,7 +161,7 @@ defmodule Sykli.GateDecision do
   def from_map(_), do: {:error, {:invalid_gate_decision, :not_object}}
 
   def validate_id(id) when is_binary(id) do
-    if Regex.match?(~r/^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/, id) do
+    if Regex.match?(~r/^[A-Za-z0-9][A-Za-z0-9_.: -]{0,127}$/, id) do
       :ok
     else
       {:error, {:invalid_gate_id, id}}

--- a/core/lib/sykli/occurrence.ex
+++ b/core/lib/sykli/occurrence.ex
@@ -34,6 +34,7 @@ defmodule Sykli.Occurrence do
       ci.team.run.sync_deferred — run summary queued for later sync
       ci.team.gate.requested — gate request published to coordinator
       ci.team.gate.decision_received — gate decision received from coordinator
+      ci.team.gate.apply_failed — gate decision failed to apply locally
       ci.team.gate.sync_deferred — gate request queued for later sync
       ci.team.outbox.drained — coordinator outbox drained on heartbeat/status
 
@@ -238,6 +239,10 @@ defmodule Sykli.Occurrence do
 
   def team_gate_decision_received(run_id, data, opts \\ []) do
     new("ci.team.gate.decision_received", run_id, data, severity: :info, opts: opts)
+  end
+
+  def team_gate_apply_failed(run_id, data, opts \\ []) do
+    new("ci.team.gate.apply_failed", run_id, data, severity: :warning, opts: opts)
   end
 
   def team_gate_sync_deferred(run_id, data, opts \\ []) do

--- a/core/lib/sykli/occurrence/pubsub.ex
+++ b/core/lib/sykli/occurrence/pubsub.ex
@@ -170,6 +170,12 @@ defmodule Sykli.Occurrence.PubSub do
     occ
   end
 
+  def team_gate_apply_failed(run_id, data) do
+    occ = Occurrence.team_gate_apply_failed(run_id, mask_team_data(data))
+    broadcast(occ)
+    occ
+  end
+
   def team_gate_sync_deferred(run_id, data) do
     occ = Occurrence.team_gate_sync_deferred(run_id, mask_team_data(data))
     broadcast(occ)

--- a/core/lib/sykli/services/gate_service.ex
+++ b/core/lib/sykli/services/gate_service.ex
@@ -29,10 +29,9 @@ defmodule Sykli.Services.GateService do
   @spec wait_team(String.t(), keyword()) :: approval_result()
   def wait_team(id, opts \\ []) when is_binary(id) do
     timeout = Keyword.get(opts, :timeout, 3600)
-    poll_interval = Keyword.get(opts, :poll_interval_ms, 250)
     deadline = System.monotonic_time(:millisecond) + timeout * 1000
 
-    do_wait_team(id, opts, poll_interval, deadline)
+    wait_team_pubsub(id, opts, deadline)
   end
 
   defp wait_prompt(%Gate{message: message, timeout: timeout}) do
@@ -170,30 +169,68 @@ defmodule Sykli.Services.GateService do
 
   defp wait_webhook(_), do: {:denied, "webhook strategy requires webhook_url to be set"}
 
-  defp do_wait_team(id, opts, poll_interval, deadline) do
-    if System.monotonic_time(:millisecond) > deadline do
-      {:timed_out}
-    else
-      case Sykli.Gate.Store.get(id, opts) do
-        {:ok, %{status: "approved"} = gate} ->
-          {:approved, gate.decided_by || "team"}
+  defp wait_team_pubsub(id, opts, deadline) do
+    topic = "gate:" <> id
 
-        {:ok, %{status: "rejected"} = gate} ->
-          {:denied, gate.reason || "team gate rejected"}
+    case team_gate_status(id, opts) do
+      {:terminal, result} ->
+        result
 
-        {:ok, %{status: "expired"}} ->
-          {:timed_out}
+      :waiting ->
+        :ok = Phoenix.PubSub.subscribe(Sykli.PubSub, topic)
 
-        {:ok, _gate} ->
-          Process.sleep(poll_interval)
-          do_wait_team(id, opts, poll_interval, deadline)
-
-        {:error, _reason} ->
-          Process.sleep(poll_interval)
-          do_wait_team(id, opts, poll_interval, deadline)
-      end
+        try do
+          case team_gate_status(id, opts) do
+            {:terminal, result} -> result
+            :waiting -> receive_team_gate_decision(id, opts, deadline)
+          end
+        after
+          Phoenix.PubSub.unsubscribe(Sykli.PubSub, topic)
+        end
     end
   end
+
+  defp receive_team_gate_decision(id, opts, deadline) do
+    timeout = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:gate_decided, status, decided_by} ->
+        gate_result(status, decided_by)
+
+      _other ->
+        receive_team_gate_decision(id, opts, deadline)
+    after
+      timeout ->
+        case team_gate_status(id, opts) do
+          {:terminal, result} -> result
+          :waiting -> {:timed_out}
+        end
+    end
+  end
+
+  defp team_gate_status(id, opts) do
+    case Sykli.Gate.Store.get(id, opts) do
+      {:ok, %{status: "approved"} = gate} ->
+        {:terminal, {:approved, gate.decided_by || "team"}}
+
+      {:ok, %{status: "rejected"} = gate} ->
+        {:terminal, {:denied, gate.decided_by || gate.reason || "team gate rejected"}}
+
+      {:ok, %{status: "expired"} = gate} ->
+        {:terminal, {:denied, gate.decided_by || "team gate expired"}}
+
+      {:ok, _gate} ->
+        :waiting
+
+      {:error, _reason} ->
+        :waiting
+    end
+  end
+
+  defp gate_result("approved", decided_by), do: {:approved, decided_by || "team"}
+  defp gate_result("rejected", decided_by), do: {:denied, decided_by || "team"}
+  defp gate_result("expired", decided_by), do: {:denied, decided_by || "team gate expired"}
+  defp gate_result(_status, _decided_by), do: {:timed_out}
 
   defp parse_webhook_response(body) do
     case Jason.decode(body) do

--- a/core/lib/sykli/team_coordinator/gate_decision_summary.ex
+++ b/core/lib/sykli/team_coordinator/gate_decision_summary.ex
@@ -8,7 +8,7 @@ defmodule Sykli.TeamCoordinator.GateDecisionSummary do
 
   alias Sykli.GateDecision
 
-  @fields ~w(id run_id work_item_id status decided_by decided_at reason)
+  @fields ~w(id run_id node_id work_item_id status decided_by decided_at reason)
 
   @enforce_keys [:gate]
   defstruct gate: %{}
@@ -18,6 +18,7 @@ defmodule Sykli.TeamCoordinator.GateDecisionSummary do
       gate: %{
         "id" => gate.id,
         "run_id" => gate.run_id,
+        "node_id" => gate.node_id,
         "work_item_id" => gate.work_item_id,
         "status" => gate.status,
         "decided_by" => gate.decided_by,
@@ -32,6 +33,7 @@ defmodule Sykli.TeamCoordinator.GateDecisionSummary do
          {:ok, id} <- required_string(map, "id"),
          :ok <- GateDecision.validate_id(id),
          {:ok, run_id} <- required_string(map, "run_id"),
+         :ok <- validate_optional_string(map["node_id"]),
          :ok <- validate_optional_string(map["work_item_id"]),
          :ok <- GateDecision.validate_status(map["status"]),
          :ok <- validate_optional_string(map["decided_by"]),

--- a/core/lib/sykli/team_coordinator/store.ex
+++ b/core/lib/sykli/team_coordinator/store.ex
@@ -710,11 +710,11 @@ defmodule Sykli.TeamCoordinator.Store do
   end
 
   defp gate_payload_fields do
-    ~w(id run_id work_item_id status decided_by decided_at reason)
+    ~w(id run_id node_id work_item_id status decided_by decided_at reason)
   end
 
   defp gate_publish_fields do
-    ~w(org_slug team_slug daemon_session_id id run_id work_item_id status decided_by decided_at reason)
+    ~w(org_slug team_slug daemon_session_id id run_id node_id work_item_id status decided_by decided_at reason)
   end
 
   defp gate_public_map(gate), do: Map.take(gate, gate_payload_fields())

--- a/core/test/sykli/cli/gate_test.exs
+++ b/core/test/sykli/cli/gate_test.exs
@@ -222,7 +222,11 @@ defmodule Sykli.CLI.GateTest do
         )
 
       assert result["data"]["source"] == "team"
-      assert result["data"]["gates"] == [%{"id" => "gate_001", "status" => "waiting"}]
+
+      assert result["data"]["gates"] == [
+               %{"id" => "gate_001", "node_id" => "approve", "status" => "waiting"}
+             ]
+
       assert_received {:list_team_gates, "secret"}
     end
   end
@@ -271,7 +275,7 @@ defmodule Sykli.CLI.GateTest do
   defmodule FakeGateClient do
     def list(_session, token, _opts) do
       send(self(), {:list_team_gates, token})
-      {:ok, [%{"id" => "gate_001", "status" => "waiting"}]}
+      {:ok, [%{"id" => "gate_001", "node_id" => "approve", "status" => "waiting"}]}
     end
 
     def record_decision(_session, token, id, decision, _opts) do

--- a/core/test/sykli/daemon/join_test.exs
+++ b/core/test/sykli/daemon/join_test.exs
@@ -139,7 +139,53 @@ defmodule Sykli.Daemon.JoinTest do
       "reason" => "Reviewed"
     }
 
+    Sykli.Occurrence.PubSub.subscribe("run_001")
+
     assert {:ok, []} = Join.apply_heartbeat_response(%{"decisions" => [decision]}, path: tmp)
+    assert_receive %Sykli.Occurrence{type: "ci.team.gate.apply_failed"}, 500
+  end
+
+  test "heartbeat response drops a gate decision after repeated apply failures" do
+    tmp =
+      Path.join(
+        System.tmp_dir!(),
+        "sykli-join-gate-retry-cap-test-#{System.unique_integer([:positive])}"
+      )
+
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    decision = %{
+      "id" => "missing_gate_retry",
+      "run_id" => "run_001",
+      "status" => "approved",
+      "decided_by" => "member:reviewer",
+      "decided_at" => @now,
+      "reason" => "Reviewed"
+    }
+
+    Sykli.Occurrence.PubSub.subscribe("run_001")
+
+    for _ <- 1..10 do
+      assert {:ok, []} =
+               Join.apply_heartbeat_response(%{"decisions" => [decision]},
+                 path: tmp,
+                 session_id: "sess_001"
+               )
+    end
+
+    assert {:ok, ["missing_gate_retry"]} =
+             Join.apply_heartbeat_response(%{"decisions" => [decision]},
+               path: tmp,
+               session_id: "sess_001"
+             )
+
+    for _ <- 1..11 do
+      assert_receive %Sykli.Occurrence{
+                       type: "ci.team.gate.apply_failed",
+                       data: %{"id" => "missing_gate_retry"}
+                     },
+                     500
+    end
   end
 
   defmodule FakeClient do

--- a/core/test/sykli/gate_decision_test.exs
+++ b/core/test/sykli/gate_decision_test.exs
@@ -43,6 +43,11 @@ defmodule Sykli.GateDecisionTest do
                "evidence_refs" => [%{"type" => "occurrence", "uri" => "occ://1"}]
              }
     end
+
+    test "accepts per-run gate ids with colon separators" do
+      assert {:ok, gate} = GateDecision.new(id: "run_001:approve", now: @now)
+      assert gate.id == "run_001:approve"
+    end
   end
 
   describe "decision transitions" do

--- a/core/test/sykli/team_coordinator/gate_outbox_test.exs
+++ b/core/test/sykli/team_coordinator/gate_outbox_test.exs
@@ -1,6 +1,9 @@
 defmodule Sykli.TeamCoordinator.GateOutboxTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
+  alias Sykli.Daemon.SessionStore
+  alias Sykli.Executor
+  alias Sykli.Occurrence.PubSub
   alias Sykli.Outbox
   alias Sykli.TeamCoordinator.Store
 
@@ -62,6 +65,54 @@ defmodule Sykli.TeamCoordinator.GateOutboxTest do
     assert Enum.any?(events, &(&1["action"] == "gate.requested"))
   end
 
+  test "deferred executor gate publish emits requested and sync_deferred occurrences", %{
+    tmp_dir: tmp_dir
+  } do
+    old_client = Application.get_env(:sykli, :team_gate_client)
+    old_token = System.get_env("SYKLI_TEAM_TOKEN")
+
+    Application.put_env(:sykli, :team_gate_client, __MODULE__.FailingGateClient)
+    System.put_env("SYKLI_TEAM_TOKEN", "secret")
+
+    on_exit(fn ->
+      restore_app_env(:team_gate_client, old_client)
+      restore_env("SYKLI_TEAM_TOKEN", old_token)
+    end)
+
+    assert {:ok, _session} =
+             SessionStore.write(
+               %{
+                 "coordinator" => "http://coordinator.test",
+                 "org" => "false-systems",
+                 "team" => "platform",
+                 "daemon_id" => "daemon-x",
+                 "session_id" => "sess_001",
+                 "team_id" => "team_001",
+                 "labels" => [],
+                 "capabilities" => ["local"]
+               },
+               path: Path.join(tmp_dir, ".sykli")
+             )
+
+    task = %Sykli.Graph.Task{
+      name: "approve",
+      depends_on: [],
+      gate: %Sykli.Graph.Task.Gate{strategy: :env, timeout: 1, env_var: "NEVER_SET"}
+    }
+
+    PubSub.subscribe("run_001")
+
+    assert {:error, [%Executor.TaskResult{name: "approve", status: :failed}]} =
+             Executor.run([task], %{"approve" => task},
+               target: Sykli.Target.Local,
+               workdir: tmp_dir,
+               run_id: "run_001"
+             )
+
+    assert_receive %Sykli.Occurrence{type: "ci.team.gate.requested"}, 500
+    assert_receive %Sykli.Occurrence{type: "ci.team.gate.sync_deferred"}, 500
+  end
+
   defp id_sequence(ids) do
     {:ok, agent} = Agent.start_link(fn -> ids end)
 
@@ -71,5 +122,15 @@ defmodule Sykli.TeamCoordinator.GateOutboxTest do
         [] -> flunk("id sequence exhausted")
       end)
     end
+  end
+
+  defp restore_app_env(key, nil), do: Application.delete_env(:sykli, key)
+  defp restore_app_env(key, value), do: Application.put_env(:sykli, key, value)
+
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
+
+  defmodule FailingGateClient do
+    def publish_waiting(_session, _token, _summary), do: {:error, :unreachable}
   end
 end

--- a/core/test/sykli/team_coordinator/gate_sync_test.exs
+++ b/core/test/sykli/team_coordinator/gate_sync_test.exs
@@ -17,7 +17,7 @@ defmodule Sykli.TeamCoordinator.GateSyncTest do
         now: fn -> @now end,
         id:
           id_sequence(
-            ~w(org_001 audit_001 team_001 audit_002 team_002 audit_003 sess_x audit_004 sess_y audit_005 sess_other audit_006 gate_audit_001 decision_audit_001 hb_audit_001 hb_audit_002 hb_audit_003 sess_new audit_007 hb_audit_004)
+            ~w(org_001 audit_001 team_001 audit_002 team_002 audit_003 sess_x audit_004 sess_y audit_005 sess_other audit_006 gate_audit_001 decision_audit_001 hb_audit_001 hb_audit_002 hb_audit_003 sess_new audit_007 hb_audit_004 gate_audit_002 decision_audit_002 hb_audit_005 gate_audit_003 decision_audit_003 hb_audit_006 gate_audit_004 hb_audit_007)
           )
       )
 
@@ -90,8 +90,6 @@ defmodule Sykli.TeamCoordinator.GateSyncTest do
     assert {:ok, ["gate_001"]} =
              Join.apply_heartbeat_response(%{"decisions" => [decision]}, path: tmp)
 
-    assert_receive %Sykli.Occurrence{type: "ci.team.gate.decision_received"}, 500
-
     assert {:ok, local_gate} = GateStore.get("gate_001", path: tmp)
     assert local_gate.status == "approved"
     assert local_gate.decided_by == "member:reviewer-y"
@@ -110,7 +108,8 @@ defmodule Sykli.TeamCoordinator.GateSyncTest do
     assert {:ok, ["gate_001"]} =
              Join.apply_heartbeat_response(%{"decisions" => [decision]}, path: tmp)
 
-    refute_receive %Sykli.Occurrence{type: "ci.team.gate.decision_received"}, 100
+    assert [%Sykli.Occurrence{type: "ci.team.gate.decision_received"}] =
+             collect_decision_received_occurrences(500)
 
     assert {:ok, unchanged} = GateStore.get("gate_001", path: tmp)
     assert unchanged.decided_at == @later
@@ -151,7 +150,7 @@ defmodule Sykli.TeamCoordinator.GateSyncTest do
     }
 
     run_id = "run_001"
-    gate_id = "run_001-approve-deploy"
+    gate_id = "run_001:approve deploy"
     PubSub.subscribe(run_id)
 
     executor =
@@ -196,6 +195,137 @@ defmodule Sykli.TeamCoordinator.GateSyncTest do
     assert {:ok, local_gate} = GateStore.get(gate_id, path: tmp)
     assert local_gate.status == "approved"
     assert local_gate.decided_by == "member:reviewer-y"
+  end
+
+  test "executor returns immediately when team decision arrived before wait starts", %{
+    store: store,
+    daemon_x: daemon_x
+  } do
+    tmp = tmp_dir()
+    install_fake_gate_client(store)
+    put_team_token("secret")
+    write_session(tmp, daemon_x)
+
+    run_id = "run_race"
+    gate_id = "run_race:approve"
+
+    assert {:ok, _local_gate} =
+             GateStore.create(
+               path: tmp,
+               id: gate_id,
+               run_id: run_id,
+               node_id: "approve",
+               status: "approved",
+               decided_by: "member:reviewer-y",
+               now: @now
+             )
+
+    task = gate_task("approve", 5)
+    started_at = System.monotonic_time(:millisecond)
+
+    assert {:ok, [%Executor.TaskResult{name: "approve", status: :passed}]} =
+             Executor.run([task], %{"approve" => task},
+               target: Sykli.Target.Local,
+               workdir: tmp,
+               run_id: run_id
+             )
+
+    assert System.monotonic_time(:millisecond) - started_at < 500
+  end
+
+  test "executor team gate timeout is still respected", %{store: store, daemon_x: daemon_x} do
+    tmp = tmp_dir()
+    install_fake_gate_client(store)
+    put_team_token("secret")
+    write_session(tmp, daemon_x)
+
+    task = gate_task("approve", 1)
+    started_at = System.monotonic_time(:millisecond)
+
+    assert {:error, [%Executor.TaskResult{name: "approve", status: :failed}]} =
+             Executor.run([task], %{"approve" => task},
+               target: Sykli.Target.Local,
+               workdir: tmp,
+               run_id: "run_timeout"
+             )
+
+    duration = System.monotonic_time(:millisecond) - started_at
+    assert duration >= 900
+    assert duration < 2_000
+  end
+
+  test "gate ids are isolated by run id when the same gate node is rerun", %{
+    store: store,
+    daemon_x: daemon_x
+  } do
+    tmp = tmp_dir()
+    install_fake_gate_client(store)
+    put_team_token("secret")
+    write_session(tmp, daemon_x)
+
+    task = gate_task("approve", 2)
+    run1_id = "run_one"
+    run2_id = "run_two"
+    gate1_id = "run_one:approve"
+    gate2_id = "run_two:approve"
+
+    executor =
+      Task.async(fn ->
+        Executor.run([task], %{"approve" => task},
+          target: Sykli.Target.Local,
+          workdir: tmp,
+          run_id: run1_id
+        )
+      end)
+
+    assert_receive {:publish_waiting, "secret", ^gate1_id}, 1_000
+
+    assert {:ok, _decided} =
+             Store.record_gate_decision(store, gate1_id, %{
+               "org_slug" => "false-systems",
+               "team_slug" => "platform",
+               "status" => "approved",
+               "decided_by" => "member:reviewer-y",
+               "decided_at" => @later,
+               "reason" => "Evidence reviewed"
+             })
+
+    assert {:ok, heartbeat, _session} =
+             Store.heartbeat_daemon_session(store, daemon_x["id"], %{
+               "session_id" => daemon_x["id"],
+               "status" => "available"
+             })
+
+    assert [%{"id" => ^gate1_id} = decision] = heartbeat["decisions"]
+
+    assert {:ok, [^gate1_id]} =
+             Join.apply_heartbeat_response(%{"decisions" => [decision]}, path: tmp)
+
+    assert {:ok, {:ok, [%Executor.TaskResult{status: :passed}]}} = Task.yield(executor, 1_000)
+
+    assert {:ok, run1_gate} = GateStore.get(gate1_id, path: tmp)
+    assert run1_gate.decided_at == @later
+    assert run1_gate.decided_by == "member:reviewer-y"
+
+    executor2 =
+      Task.async(fn ->
+        Executor.run([task], %{"approve" => task},
+          target: Sykli.Target.Local,
+          workdir: tmp,
+          run_id: run2_id
+        )
+      end)
+
+    assert_receive {:publish_waiting, "secret", ^gate2_id}, 1_000
+    assert {:ok, run2_gate} = GateStore.get(gate2_id, path: tmp)
+    assert run2_gate.status == "waiting"
+    assert run2_gate.node_id == "approve"
+
+    assert {:ok, reloaded_run1} = GateStore.get(gate1_id, path: tmp)
+    assert reloaded_run1.decided_at == @later
+    assert reloaded_run1.decided_by == "member:reviewer-y"
+
+    Task.shutdown(executor2, :brutal_kill)
   end
 
   test "publish validates session routing and claimed team", %{
@@ -275,12 +405,22 @@ defmodule Sykli.TeamCoordinator.GateSyncTest do
       "daemon_session_id" => session["id"],
       "id" => "gate_001",
       "run_id" => "run_001",
+      "node_id" => "approve",
       "work_item_id" => nil,
       "status" => "waiting",
       "decided_by" => nil,
       "decided_at" => nil,
       "reason" => nil
     }
+  end
+
+  defp collect_decision_received_occurrences(timeout) do
+    receive do
+      %Sykli.Occurrence{type: "ci.team.gate.decision_received"} = occurrence ->
+        [occurrence | collect_decision_received_occurrences(100)]
+    after
+      timeout -> []
+    end
   end
 
   defp tmp_dir do
@@ -303,6 +443,31 @@ defmodule Sykli.TeamCoordinator.GateSyncTest do
       restore_app_env(:test_gate_store, old_store)
       restore_app_env(:test_gate_recorder, old_pid)
     end)
+  end
+
+  defp write_session(tmp, session) do
+    assert {:ok, _session} =
+             SessionStore.write(
+               %{
+                 "coordinator" => "http://coordinator.test",
+                 "org" => "false-systems",
+                 "team" => "platform",
+                 "daemon_id" => "daemon-x",
+                 "session_id" => session["id"],
+                 "team_id" => session["team_id"],
+                 "labels" => [],
+                 "capabilities" => ["local"]
+               },
+               path: Path.join(tmp, ".sykli")
+             )
+  end
+
+  defp gate_task(name, timeout) do
+    %Sykli.Graph.Task{
+      name: name,
+      depends_on: [],
+      gate: %Sykli.Graph.Task.Gate{strategy: :env, timeout: timeout, env_var: "NEVER_SET"}
+    }
   end
 
   defp put_team_token(token) do


### PR DESCRIPTION
## Summary
- Fixes PR #201 review blockers C1-C3 and high items H1/H3 after PR #201 was already merged.
- Uses Option A for C1: heartbeat-applied remote decisions broadcast on per-gate PubSub topics, and team gate waits check the local gate file before subscribing.
- Isolates gate records by run_id:node_id, keeps node_id in team gate summaries/list output, and makes daemon decision acks fail closed with a retry cap.
- Files deferred follow-ups for H2/M1/M2/M3: #205, #203, #202, #204.

## Verification
- cd core && mix format
- cd core && mix test
- cd core && mix credo
- git diff --check
