### PR TITLE
fix(otp): harden async side-effects, Coordinator calls, ETS ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **OTP hardening (Monster Phase E).**
+  - Fire-and-forget side effects (GitHub commit-status updates, async S3 cache
+    writes) use `Task.Supervisor.start_child` instead of `async_nolink`, so
+    long-lived callers (e.g. the MCP server) no longer accumulate unconsumed
+    `{ref, result}`/`{:DOWN, ...}` task reply messages.
+  - `Sykli.Coordinator.connected_nodes/0` derives connectivity from `Node.list/0`
+    instead of blocking `Node.ping/1` inside a GenServer callback, which could
+    wedge the coordinator past the call timeout and cascade `:timeout` crashes.
+  - Webhook replay-protection and installation-token ETS tables are created at
+    application start (owned by a long-lived process) rather than lazily by a
+    transient request process — they no longer silently reset on request churn.
+  - `Sykli.Reporter`'s moduledoc now states it is wired into no supervisor (the
+    Trusted-LAN-mesh occurrence-forwarding path is inactive pending a wire-vs-retire
+    decision); the code no longer implies a running capability.
 - **`sykli cache stats --json` now returns a JSON envelope.** The cache stats
   command supports `--json` through `Sykli.CLI.JsonResponse`, and the black-box
   suite asserts the JSON shape instead of only checking for absent ANSI output.

--- a/core/lib/sykli/application.ex
+++ b/core/lib/sykli/application.ex
@@ -19,6 +19,13 @@ defmodule Sykli.Application do
 
   @impl true
   def start(_type, _args) do
+    # Create the public ETS tables from this long-lived process (the application
+    # master) rather than letting them be created lazily inside a transient
+    # request process — a table owned by a request process dies with it, silently
+    # resetting webhook replay protection and the installation-token cache.
+    Sykli.GitHub.Webhook.Deliveries.setup()
+    Sykli.GitHub.App.Cache.setup()
+    Sykli.Mesh.Roles.setup()
     Sykli.Mesh.Roles.bootstrap_local_roles()
 
     children = [

--- a/core/lib/sykli/cache/tiered_repository.ex
+++ b/core/lib/sykli/cache/tiered_repository.ex
@@ -147,7 +147,9 @@ defmodule Sykli.Cache.TieredRepository do
 
   defp async_l2(fun) do
     if circuit_closed?() do
-      Task.Supervisor.async_nolink(Sykli.TaskSupervisor, fn ->
+      # Fire-and-forget: start_child (not async_nolink) so the caller's mailbox
+      # never accumulates unconsumed {ref, result}/{:DOWN, ...} reply messages.
+      Task.Supervisor.start_child(Sykli.TaskSupervisor, fn ->
         try do
           fun.()
           record_success()

--- a/core/lib/sykli/coordinator.ex
+++ b/core/lib/sykli/coordinator.ex
@@ -124,10 +124,15 @@ defmodule Sykli.Coordinator do
 
   @impl true
   def handle_call(:connected_nodes, _from, state) do
+    # Determine connectivity from the BEAM's current connection set (Node.list/0,
+    # a fast local BIF) rather than Node.ping/1, which does blocking network I/O.
+    # A single unreachable node would otherwise wedge this GenServer past the
+    # default call timeout, cascading :timeout crashes into every caller.
+    connected = MapSet.new(Node.list())
+
     nodes =
-      state.nodes
-      |> Enum.map(fn {node, last_seen} ->
-        %{node: node, last_seen: last_seen, connected: Node.ping(node) == :pong}
+      Enum.map(state.nodes, fn {node, last_seen} ->
+        %{node: node, last_seen: last_seen, connected: MapSet.member?(connected, node)}
       end)
 
     {:reply, nodes, state}

--- a/core/lib/sykli/executor.ex
+++ b/core/lib/sykli/executor.ex
@@ -1196,7 +1196,10 @@ defmodule Sykli.Executor do
   end
 
   defp maybe_github_status(task_name, state) do
-    Task.Supervisor.async_nolink(Sykli.TaskSupervisor, fn ->
+    # Fire-and-forget: start_child (not async_nolink) so the spawning process
+    # never accumulates {ref, result}/{:DOWN, ...} reply messages it never
+    # consumes. Matters for long-lived callers like the MCP server.
+    Task.Supervisor.start_child(Sykli.TaskSupervisor, fn ->
       case Sykli.SCM.update_status(task_name, state) do
         :ok ->
           :ok

--- a/core/lib/sykli/github/app/cache.ex
+++ b/core/lib/sykli/github/app/cache.ex
@@ -27,6 +27,14 @@ defmodule Sykli.GitHub.App.Cache do
     :ok
   end
 
+  @doc false
+  # Eagerly create the table from a long-lived owner (the application master,
+  # via Sykli.Application.start/2) so it outlives transient request processes.
+  def setup do
+    ensure_table()
+    :ok
+  end
+
   defp ensure_table do
     case :ets.whereis(@table) do
       :undefined ->

--- a/core/lib/sykli/github/webhook/deliveries.ex
+++ b/core/lib/sykli/github/webhook/deliveries.ex
@@ -72,6 +72,14 @@ defmodule Sykli.GitHub.Webhook.Deliveries do
     end
   end
 
+  @doc false
+  # Eagerly create the table from a long-lived owner (the application master,
+  # via Sykli.Application.start/2) so it outlives transient request processes.
+  def setup do
+    ensure_table()
+    :ok
+  end
+
   defp ensure_table do
     case :ets.whereis(@table) do
       :undefined ->

--- a/core/lib/sykli/mesh/roles.ex
+++ b/core/lib/sykli/mesh/roles.ex
@@ -73,6 +73,14 @@ defmodule Sykli.Mesh.Roles do
     :ok
   end
 
+  @doc false
+  # Eagerly create the table from a long-lived owner (the application master,
+  # via Sykli.Application.start/2) so it outlives transient request processes.
+  def setup do
+    ensure_table()
+    :ok
+  end
+
   defp ensure_table do
     case :ets.whereis(@table) do
       :undefined ->

--- a/core/lib/sykli/reporter.ex
+++ b/core/lib/sykli/reporter.ex
@@ -1,6 +1,19 @@
 defmodule Sykli.Reporter do
   @moduledoc """
-  Forwards local occurrences to the coordinator node.
+  Forwards local occurrences to the coordinator node (Trusted LAN mesh / mode 2).
+
+  > ## Status: defined but NOT wired into any supervisor
+  >
+  > This implements the BEAM-mesh worker→coordinator occurrence-forwarding path
+  > for the Trusted LAN mesh coordination mode, but it is started **nowhere** —
+  > so the forwarding does not run. The consumer (`Sykli.Coordinator`) IS started
+  > in daemon coordinator/full mode (`daemon.ex`) yet currently has no producer.
+  > Completing mode 2 means adding this to the worker/full daemon children (and
+  > making its connectivity check non-blocking, like `Coordinator.connected_nodes`);
+  > retiring it means deleting this module and the Coordinator's `{:occurrence}`
+  > ingestion. That wire-vs-retire choice is a pending decision — see
+  > `docs/coordination-modes.md`. (Mode 3, the self-hosted HTTP coordinator, is a
+  > separate path and already works.)
 
   The Reporter subscribes to all local occurrences and forwards them
   to the Coordinator GenServer on the coordinator node. Occurrences

--- a/core/test/sykli/coordinator_test.exs
+++ b/core/test/sykli/coordinator_test.exs
@@ -125,6 +125,21 @@ defmodule Sykli.CoordinatorTest do
       nodes = Coordinator.connected_nodes()
       assert is_list(nodes)
     end
+
+    test "reports connectivity without blocking on unreachable nodes" do
+      # Inject a node that is not actually connected (tests run non-distributed).
+      send(Coordinator, {:nodeup, :"fake@127.0.0.1"})
+      sync_coordinator()
+
+      nodes = Coordinator.connected_nodes()
+
+      entry = Enum.find(nodes, &(&1.node == :"fake@127.0.0.1"))
+      assert entry, "expected the injected node to be tracked"
+      # Connectivity is derived from Node.list/0 (a local BIF), so an unreachable
+      # node is simply absent from the set. The previous Node.ping/1 here did
+      # blocking network I/O and would wedge the GenServer past the call timeout.
+      refute entry.connected
+    end
   end
 
   describe "task occurrences" do

--- a/core/test/sykli/github/webhook/deliveries_test.exs
+++ b/core/test/sykli/github/webhook/deliveries_test.exs
@@ -39,4 +39,22 @@ defmodule Sykli.GitHub.Webhook.DeliveriesTest do
     assert :ok = Deliveries.evict(nil)
     assert :ok = Deliveries.evict(:atom)
   end
+
+  test "replay table is created at startup and owned by a long-lived process" do
+    assert :ets.whereis(:sykli_github_webhook_deliveries) != :undefined
+
+    owner = :ets.info(:sykli_github_webhook_deliveries, :owner)
+    assert is_pid(owner) and Process.alive?(owner)
+    # Owned by the application master (created in Sykli.Application.start/2), not
+    # by this transient test process — so it outlives request/test processes and
+    # replay protection is not silently reset when a caller exits.
+    refute owner == self()
+  end
+
+  test "setup/0 is idempotent and does not reset existing entries" do
+    assert :ok = Deliveries.setup()
+    assert :ok = Deliveries.accept("setup-idempotent", 1_000)
+    assert :ok = Deliveries.setup()
+    assert {:error, :duplicate_delivery} = Deliveries.accept("setup-idempotent", 1_100)
+  end
 end


### PR DESCRIPTION
**Monster Phase E** (OTP hardening) of the audit-remediation program (`docs/audit-2026-05-22.md`). Branches directly off `main` (no stack).

Each finding was re-verified against current `main` before fixing — and one audit finding was already stale (see below).

## Fixes
- **E2 (High) — `Node.ping` out of a GenServer callback.** `Coordinator.connected_nodes/0` did blocking per-node `Node.ping/1` inside `handle_call`; an unreachable node could wedge the coordinator past the 5s call timeout and cascade `:timeout` crashes into callers. Now derives connectivity from `Node.list/0` (a local BIF). *Test: injects an unreachable node, asserts it's reported disconnected without blocking.*
- **E1 (Medium) — `async_nolink` orphan-message leak.** `maybe_github_status` (executor) and `async_l2` (tiered cache S3 write) spawned `async_nolink` but never consumed the `{ref, result}`/`{:DOWN, ...}` replies, leaking into long-lived caller mailboxes (the MCP server). Switched to `Task.Supervisor.start_child` (the existing fire-and-forget pattern at `webhook/receiver.ex:240`).
- **E3 (Medium) — ETS tables owned by transient processes.** Webhook replay-protection and installation-token tables were created lazily by the first caller — often a transient request process, so the table died with it, silently resetting replay protection / token cache. Now created at `Application.start/2` (owned by the long-lived application master); lazy `ensure_table` stays as fallback. *Tests: table owned by a live non-test process; `setup/0` idempotent.*
- **E4 (Medium) — `Reporter` dead code.** It's a BEAM-mesh worker→coordinator forwarder started by no supervisor (its consumer `Coordinator` *is* started in daemon mode, so the mode-2 path is half-wired). Whether to **wire** it (completes Trusted-LAN-mesh forwarding) or **retire** it is an architecture decision, not an OTP bug — so I documented the status honestly in the moduledoc and deferred the choice rather than guessing. (Mode 3, the HTTP coordinator, is separate and works.)

## Stale audit finding (corrected)
The audit listed `maybe_sync_run_summary` in `sykli.ex` as a second `async_nolink` leak — it no longer uses `async_nolink`, so there was nothing to fix there.

## Verification
`mix format` / `mix credo` (clean) / `mix test` (**1759, 0 failures**) / `mix escript.build`; black-box **0 failed** (only GH-004 expected-red, deferred to Phase C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)