### PR TITLE
fix(security): refuse plaintext bearer-token transmission (Phase C, C1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Coordinator client refuses plaintext token transmission (Monster Phase C, C1).**
+  `Sykli.Coordinator.Client` now refuses to send the Team Mode bearer token over
+  plaintext HTTP to a non-loopback host — it returns `{:error, {:insecure_transport,
+  url}}` and logs an error instead of leaking the token on the wire. HTTPS and
+  loopback hosts are unaffected; `SYKLI_COORDINATOR_INSECURE=1` is an explicit
+  opt-in (with a loud warning). All token-bearing paths (work/run/gate clients and
+  daemon join) route through this client; `Sykli.HTTP.check_token_transport/1` is
+  the shared decision.
 - **OTP hardening (Monster Phase E).**
   - Fire-and-forget side effects (GitHub commit-status updates, async S3 cache
     writes) use `Task.Supervisor.start_child` instead of `async_nolink`, so

--- a/core/lib/sykli/coordinator/client.ex
+++ b/core/lib/sykli/coordinator/client.ex
@@ -15,6 +15,25 @@ defmodule Sykli.Coordinator.Client do
 
   def request_json(method, base_url, path, token, body) do
     url = build_url(base_url, path)
+
+    case Sykli.HTTP.check_token_transport(url) do
+      :ok ->
+        warn_if_insecure(url)
+        do_request(method, url, token, body)
+
+      {:error, :insecure_transport} ->
+        require Logger
+
+        Logger.error(
+          "[Coordinator.Client] refusing to send bearer token over plaintext HTTP to " <>
+            "#{url} — use https, a loopback host, or set SYKLI_COORDINATOR_INSECURE=1 to override"
+        )
+
+        {:error, {:insecure_transport, url}}
+    end
+  end
+
+  defp do_request(method, url, token, body) do
     headers = headers(token)
     request = request_tuple(method, url, headers, body)
     http_opts = [{:timeout, @timeout_ms}] ++ Sykli.HTTP.ssl_opts(url)
@@ -25,6 +44,17 @@ defmodule Sykli.Coordinator.Client do
 
       {:error, reason} ->
         {:error, {:coordinator_unavailable, reason}}
+    end
+  end
+
+  defp warn_if_insecure(url) do
+    unless Sykli.HTTP.secure_transport?(url) or Sykli.HTTP.loopback_url?(url) do
+      require Logger
+
+      Logger.warning(
+        "[Coordinator.Client] sending bearer token over plaintext HTTP to #{url} " <>
+          "(SYKLI_COORDINATOR_INSECURE is set)"
+      )
     end
   end
 

--- a/core/lib/sykli/http.ex
+++ b/core/lib/sykli/http.ex
@@ -29,4 +29,38 @@ defmodule Sykli.HTTP do
         []
     end
   end
+
+  @insecure_opt_in_env "SYKLI_COORDINATOR_INSECURE"
+
+  @doc """
+  Decides whether `url` is safe to send a bearer token over.
+
+  Returns `:ok` for HTTPS, for loopback hosts (local development), or when the
+  `SYKLI_COORDINATOR_INSECURE` opt-in is set; otherwise `{:error, :insecure_transport}`.
+  A bearer token sent over plaintext HTTP to a remote host is observable on the
+  wire, so callers must refuse rather than leak it.
+  """
+  @spec check_token_transport(String.t()) :: :ok | {:error, :insecure_transport}
+  def check_token_transport(url) do
+    cond do
+      secure_transport?(url) -> :ok
+      loopback_url?(url) -> :ok
+      insecure_opt_in?() -> :ok
+      true -> {:error, :insecure_transport}
+    end
+  end
+
+  @doc "True when `url` uses HTTPS."
+  @spec secure_transport?(String.t()) :: boolean()
+  def secure_transport?(url), do: URI.parse(url).scheme == "https"
+
+  @doc "True when `url`'s host is a loopback address."
+  @spec loopback_url?(String.t()) :: boolean()
+  def loopback_url?(url) do
+    URI.parse(url).host in ["localhost", "127.0.0.1", "::1", "[::1]"]
+  end
+
+  @doc "True when the operator has explicitly opted into plaintext token transport."
+  @spec insecure_opt_in?() :: boolean()
+  def insecure_opt_in?, do: System.get_env(@insecure_opt_in_env) in ["1", "true"]
 end

--- a/core/test/sykli/http_test.exs
+++ b/core/test/sykli/http_test.exs
@@ -1,0 +1,46 @@
+defmodule Sykli.HTTPTest do
+  use ExUnit.Case, async: false
+
+  alias Sykli.HTTP
+
+  describe "check_token_transport/1" do
+    setup do
+      System.delete_env("SYKLI_COORDINATOR_INSECURE")
+      on_exit(fn -> System.delete_env("SYKLI_COORDINATOR_INSECURE") end)
+      :ok
+    end
+
+    test "allows https to a remote host" do
+      assert :ok = HTTP.check_token_transport("https://coord.example.com/v1/runs")
+    end
+
+    test "allows plaintext http to loopback (local development)" do
+      assert :ok = HTTP.check_token_transport("http://127.0.0.1:4000/v1/runs")
+      assert :ok = HTTP.check_token_transport("http://localhost:4000/v1/runs")
+    end
+
+    test "refuses a bearer token over plaintext http to a remote host" do
+      assert {:error, :insecure_transport} =
+               HTTP.check_token_transport("http://coord.example.com/v1/runs")
+    end
+
+    test "allows plaintext http to a remote host only with explicit opt-in" do
+      assert {:error, :insecure_transport} =
+               HTTP.check_token_transport("http://coord.internal/v1/runs")
+
+      System.put_env("SYKLI_COORDINATOR_INSECURE", "1")
+      assert :ok = HTTP.check_token_transport("http://coord.internal/v1/runs")
+    end
+  end
+
+  describe "ssl_opts/1" do
+    test "returns verify_peer options for https" do
+      opts = HTTP.ssl_opts("https://example.com")
+      assert get_in(opts, [:ssl])[:verify] == :verify_peer
+    end
+
+    test "returns [] for non-https" do
+      assert [] == HTTP.ssl_opts("http://example.com")
+    end
+  end
+end


### PR DESCRIPTION
**Monster Phase C — item C1** (audit S1, High) from `docs/audit-2026-05-22.md`.

The Team Mode bearer token was sent with no scheme check: `Sykli.HTTP.ssl_opts/1` returns `[]` for non-HTTPS, and `Coordinator.Client` sent `Authorization: Bearer <token>` regardless — so a `http://` coordinator leaked the token in cleartext to any on-path observer (an in-scope adversary per `docs/team-mode-security.md`).

## Fix
- New `Sykli.HTTP.check_token_transport/1`: `:ok` for HTTPS, loopback hosts, or an explicit `SYKLI_COORDINATOR_INSECURE=1` opt-in; otherwise `{:error, :insecure_transport}`.
- `Coordinator.Client.request_json/5` refuses (returns `{:error, {:insecure_transport, url}}` + logs an error) before sending; warns loudly when the opt-in carries a plaintext send. All token-bearing paths — work/run/gate clients and daemon join — route through this client, so one guard covers them.

## Scope note
Phase C is split for focused review. This PR is C1 only. Remaining (with decisions locked):
- **C2** per-team coordinator authz → **enforce per-team tokens** (own PR — auth-model change)
- **C3** mask file/OIDC-resolved secrets (own PR)
- **C4** SSRF allowlist on gate `webhook_url` (`connect_timeout` already present)
- **C5** Shell-runtime trust ADR + GH-004 rewrite (**document Shell = trusted only**)

## Verification
`mix format` / `mix credo` (clean) / `mix test` (**1752, 0 failures**, +6 HTTP tests) / `mix escript.build`; black-box team-sync + COORD cases pass (loopback allowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)