### PR TITLE
fix(security): SSRF-guard gate webhooks (Phase C, C4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Gate webhooks are SSRF-guarded (Monster Phase C, C4).** A pipeline-declared
+  gate `webhook_url` is now resolved and rejected if it points at a loopback,
+  link-local (incl. the cloud metadata range `169.254.0.0/16`), or private
+  address — closing an SSRF/metadata-exfiltration sink. The check is the new
+  shared `Sykli.HTTP.check_ssrf/1`, extracted from the existing notification
+  webhook guard so both paths enforce identical blocking (IPv4 + IPv6).
 - **Coordinator client refuses plaintext token transmission (Monster Phase C, C1).**
   `Sykli.Coordinator.Client` now refuses to send the Team Mode bearer token over
   plaintext HTTP to a non-loopback host — it returns `{:error, {:insecure_transport,

--- a/core/lib/sykli/http.ex
+++ b/core/lib/sykli/http.ex
@@ -4,6 +4,8 @@ defmodule Sykli.HTTP do
   Provides TLS verification options for HTTPS endpoints.
   """
 
+  import Bitwise
+
   @doc """
   Returns SSL options for :httpc that verify server certificates and hostnames.
   """
@@ -80,22 +82,29 @@ defmodule Sykli.HTTP do
 
       host ->
         host_charlist = String.to_charlist(host)
+        v4 = resolve_addrs(host_charlist, :inet)
+        v6 = resolve_addrs(host_charlist, :inet6)
 
-        case :inet.getaddr(host_charlist, :inet) do
-          {:ok, ip} ->
-            if private_ip?(ip), do: {:error, "URL resolves to a private address"}, else: :ok
+        cond do
+          v4 == [] and v6 == [] ->
+            {:error, "cannot resolve host"}
 
-          {:error, _} ->
-            case :inet.getaddr(host_charlist, :inet6) do
-              {:ok, ip6} ->
-                if private_ip6?(ip6),
-                  do: {:error, "URL resolves to a private address"},
-                  else: :ok
+          # Block if ANY resolved address is private. A host can return multiple
+          # A/AAAA records and :httpc re-resolves when it sends, so checking a
+          # single sampled address is not enough for an SSRF guard.
+          Enum.any?(v4, &private_ip?/1) or Enum.any?(v6, &private_ip6?/1) ->
+            {:error, "URL resolves to a private address"}
 
-              {:error, reason} ->
-                {:error, "cannot resolve host: #{inspect(reason)}"}
-            end
+          true ->
+            :ok
         end
+    end
+  end
+
+  defp resolve_addrs(host_charlist, family) do
+    case :inet.getaddrs(host_charlist, family) do
+      {:ok, addrs} -> addrs
+      {:error, _} -> []
     end
   end
 
@@ -107,9 +116,18 @@ defmodule Sykli.HTTP do
   defp private_ip?({0, 0, 0, 0}), do: true
   defp private_ip?(_), do: false
 
+  defp private_ip6?({0, 0, 0, 0, 0, 0, 0, 0}), do: true
   defp private_ip6?({0, 0, 0, 0, 0, 0, 0, 1}), do: true
-  defp private_ip6?({0xFE80, _, _, _, _, _, _, _}), do: true
-  defp private_ip6?({0xFC00, _, _, _, _, _, _, _}), do: true
-  defp private_ip6?({0xFD00, _, _, _, _, _, _, _}), do: true
+
+  # IPv4-mapped (::ffff:a.b.c.d) — check the embedded IPv4 against the v4 ranges
+  # so a mapped private/link-local address can't bypass the guard.
+  defp private_ip6?({0, 0, 0, 0, 0, 0xFFFF, ab, cd}) do
+    private_ip?({ab >>> 8, ab &&& 0xFF, cd >>> 8, cd &&& 0xFF})
+  end
+
+  # Compare the masked first hextet, not exact equality: link-local is fe80::/10
+  # (fe80–febf) and unique-local is fc00::/7 (fc00–fdff).
+  defp private_ip6?({h, _, _, _, _, _, _, _}) when (h &&& 0xFFC0) == 0xFE80, do: true
+  defp private_ip6?({h, _, _, _, _, _, _, _}) when (h &&& 0xFE00) == 0xFC00, do: true
   defp private_ip6?(_), do: false
 end

--- a/core/lib/sykli/http.ex
+++ b/core/lib/sykli/http.ex
@@ -63,4 +63,53 @@ defmodule Sykli.HTTP do
   @doc "True when the operator has explicitly opted into plaintext token transport."
   @spec insecure_opt_in?() :: boolean()
   def insecure_opt_in?, do: System.get_env(@insecure_opt_in_env) in ["1", "true"]
+
+  @doc """
+  SSRF guard for outbound webhook URLs.
+
+  Resolves the URL host and rejects loopback, link-local (incl. the cloud
+  metadata range `169.254.0.0/16`), and private addresses — for both IPv4 and
+  IPv6 — so a pipeline-declared webhook can't be pointed at internal services or
+  the instance metadata endpoint. Returns `:ok` or `{:error, reason}`.
+  """
+  @spec check_ssrf(String.t()) :: :ok | {:error, String.t()}
+  def check_ssrf(url) do
+    case URI.parse(url).host do
+      nil ->
+        {:error, "URL has no host"}
+
+      host ->
+        host_charlist = String.to_charlist(host)
+
+        case :inet.getaddr(host_charlist, :inet) do
+          {:ok, ip} ->
+            if private_ip?(ip), do: {:error, "URL resolves to a private address"}, else: :ok
+
+          {:error, _} ->
+            case :inet.getaddr(host_charlist, :inet6) do
+              {:ok, ip6} ->
+                if private_ip6?(ip6),
+                  do: {:error, "URL resolves to a private address"},
+                  else: :ok
+
+              {:error, reason} ->
+                {:error, "cannot resolve host: #{inspect(reason)}"}
+            end
+        end
+    end
+  end
+
+  defp private_ip?({127, _, _, _}), do: true
+  defp private_ip?({10, _, _, _}), do: true
+  defp private_ip?({172, b, _, _}) when b >= 16 and b <= 31, do: true
+  defp private_ip?({192, 168, _, _}), do: true
+  defp private_ip?({169, 254, _, _}), do: true
+  defp private_ip?({0, 0, 0, 0}), do: true
+  defp private_ip?(_), do: false
+
+  defp private_ip6?({0, 0, 0, 0, 0, 0, 0, 1}), do: true
+  defp private_ip6?({0xFE80, _, _, _, _, _, _, _}), do: true
+  defp private_ip6?({0xFC00, _, _, _, _, _, _, _}), do: true
+  defp private_ip6?({0xFD00, _, _, _, _, _, _, _}), do: true
+  defp private_ip6?(_), do: false
 end

--- a/core/lib/sykli/services/gate_service.ex
+++ b/core/lib/sykli/services/gate_service.ex
@@ -130,40 +130,46 @@ defmodule Sykli.Services.GateService do
 
   defp wait_webhook(%Gate{webhook_url: url, message: message, timeout: timeout})
        when is_binary(url) and url != "" do
-    body =
-      Jason.encode!(%{
-        type: "gate_approval_request",
-        message: message || "Gate approval requested",
-        timestamp: DateTime.to_iso8601(DateTime.utc_now())
-      })
+    # SSRF guard: a pipeline-declared gate webhook must not be pointed at
+    # loopback/link-local/private addresses (e.g. the cloud metadata endpoint).
+    with :ok <- Sykli.HTTP.check_ssrf(url) do
+      body =
+        Jason.encode!(%{
+          type: "gate_approval_request",
+          message: message || "Gate approval requested",
+          timestamp: DateTime.to_iso8601(DateTime.utc_now())
+        })
 
-    url_charlist = String.to_charlist(url)
-    timeout_ms = timeout * 1000
+      url_charlist = String.to_charlist(url)
+      timeout_ms = timeout * 1000
 
-    headers = [
-      {~c"content-type", ~c"application/json"},
-      {~c"accept", ~c"application/json"}
-    ]
+      headers = [
+        {~c"content-type", ~c"application/json"},
+        {~c"accept", ~c"application/json"}
+      ]
 
-    http_opts = [timeout: timeout_ms, connect_timeout: 5_000] ++ Sykli.HTTP.ssl_opts(url)
+      http_opts = [timeout: timeout_ms, connect_timeout: 5_000] ++ Sykli.HTTP.ssl_opts(url)
 
-    case :httpc.request(
-           :post,
-           {url_charlist, headers, ~c"application/json", body},
-           http_opts,
-           []
-         ) do
-      {:ok, {{_, status, _}, _headers, resp_body}} when status in 200..299 ->
-        parse_webhook_response(to_string(resp_body))
+      case :httpc.request(
+             :post,
+             {url_charlist, headers, ~c"application/json", body},
+             http_opts,
+             []
+           ) do
+        {:ok, {{_, status, _}, _headers, resp_body}} when status in 200..299 ->
+          parse_webhook_response(to_string(resp_body))
 
-      {:ok, {{_, status, _}, _headers, _resp_body}} ->
-        {:denied, "webhook returned HTTP #{status}"}
+        {:ok, {{_, status, _}, _headers, _resp_body}} ->
+          {:denied, "webhook returned HTTP #{status}"}
 
-      {:error, :timeout} ->
-        {:timed_out}
+        {:error, :timeout} ->
+          {:timed_out}
 
-      {:error, reason} ->
-        {:denied, "webhook request failed: #{inspect(reason)}"}
+        {:error, reason} ->
+          {:denied, "webhook request failed: #{inspect(reason)}"}
+      end
+    else
+      {:error, reason} -> {:denied, "webhook_url blocked: #{reason}"}
     end
   end
 

--- a/core/lib/sykli/services/notification_service.ex
+++ b/core/lib/sykli/services/notification_service.ex
@@ -78,54 +78,9 @@ defmodule Sykli.Services.NotificationService do
 
   # ----- SSRF GUARD -----
 
-  defp validate_url_not_private(url) do
-    uri = URI.parse(url)
-
-    case uri.host do
-      nil ->
-        {:error, "Webhook URL has no host"}
-
-      host ->
-        host_charlist = String.to_charlist(host)
-
-        case :inet.getaddr(host_charlist, :inet) do
-          {:ok, ip} ->
-            if private_ip?(ip) do
-              {:error, "Webhook URL resolves to a private address"}
-            else
-              :ok
-            end
-
-          {:error, _} ->
-            # Also try IPv6
-            case :inet.getaddr(host_charlist, :inet6) do
-              {:ok, ip6} ->
-                if private_ip6?(ip6) do
-                  {:error, "Webhook URL resolves to a private address"}
-                else
-                  :ok
-                end
-
-              {:error, reason} ->
-                {:error, "Cannot resolve webhook host: #{inspect(reason)}"}
-            end
-        end
-    end
-  end
-
-  defp private_ip?({127, _, _, _}), do: true
-  defp private_ip?({10, _, _, _}), do: true
-  defp private_ip?({172, b, _, _}) when b >= 16 and b <= 31, do: true
-  defp private_ip?({192, 168, _, _}), do: true
-  defp private_ip?({169, 254, _, _}), do: true
-  defp private_ip?({0, 0, 0, 0}), do: true
-  defp private_ip?(_), do: false
-
-  defp private_ip6?({0, 0, 0, 0, 0, 0, 0, 1}), do: true
-  defp private_ip6?({0xFE80, _, _, _, _, _, _, _}), do: true
-  defp private_ip6?({0xFC00, _, _, _, _, _, _, _}), do: true
-  defp private_ip6?({0xFD00, _, _, _, _, _, _, _}), do: true
-  defp private_ip6?(_), do: false
+  # Delegated to the shared Sykli.HTTP.check_ssrf/1 so notification and gate
+  # webhooks enforce identical loopback/link-local/private-address blocking.
+  defp validate_url_not_private(url), do: Sykli.HTTP.check_ssrf(url)
 
   # Auto-detect Slack webhook format
   defp format_payload(url, event) do

--- a/core/test/sykli/http_test.exs
+++ b/core/test/sykli/http_test.exs
@@ -61,8 +61,23 @@ defmodule Sykli.HTTPTest do
       assert {:error, _} = HTTP.check_ssrf("http://172.16.0.1/hook")
     end
 
-    test "allows public addresses" do
+    test "blocks the full IPv6 link-local (fe80::/10) and ULA (fc00::/7) ranges" do
+      # Non-boundary addresses that exact-hextet matching let through.
+      assert {:error, _} = HTTP.check_ssrf("http://[fe90::1]/hook")
+      assert {:error, _} = HTTP.check_ssrf("http://[febf::1]/hook")
+      assert {:error, _} = HTTP.check_ssrf("http://[fc01::1]/hook")
+      assert {:error, _} = HTTP.check_ssrf("http://[fd12:3456::1]/hook")
+      assert {:error, _} = HTTP.check_ssrf("http://[fdff::1]/hook")
+    end
+
+    test "blocks IPv4-mapped IPv6 pointing at private/link-local ranges" do
+      assert {:error, _} = HTTP.check_ssrf("http://[::ffff:169.254.169.254]/hook")
+      assert {:error, _} = HTTP.check_ssrf("http://[::ffff:10.0.0.1]/hook")
+    end
+
+    test "allows public addresses (IPv4 and global IPv6)" do
       assert :ok = HTTP.check_ssrf("https://8.8.8.8/hook")
+      assert :ok = HTTP.check_ssrf("https://[2606:4700:4700::1111]/")
     end
 
     test "rejects a URL with no host" do

--- a/core/test/sykli/http_test.exs
+++ b/core/test/sykli/http_test.exs
@@ -43,4 +43,30 @@ defmodule Sykli.HTTPTest do
       assert [] == HTTP.ssl_opts("http://example.com")
     end
   end
+
+  describe "check_ssrf/1" do
+    # IP-literal hosts so resolution is deterministic and DNS-free.
+    test "blocks loopback" do
+      assert {:error, _} = HTTP.check_ssrf("http://127.0.0.1:8080/hook")
+      assert {:error, _} = HTTP.check_ssrf("http://[::1]/hook")
+    end
+
+    test "blocks link-local / cloud metadata (169.254.0.0/16)" do
+      assert {:error, _} = HTTP.check_ssrf("http://169.254.169.254/latest/meta-data/")
+    end
+
+    test "blocks RFC1918 private ranges" do
+      assert {:error, _} = HTTP.check_ssrf("http://10.0.0.5/hook")
+      assert {:error, _} = HTTP.check_ssrf("http://192.168.1.1/hook")
+      assert {:error, _} = HTTP.check_ssrf("http://172.16.0.1/hook")
+    end
+
+    test "allows public addresses" do
+      assert :ok = HTTP.check_ssrf("https://8.8.8.8/hook")
+    end
+
+    test "rejects a URL with no host" do
+      assert {:error, _} = HTTP.check_ssrf("not-a-url")
+    end
+  end
 end


### PR DESCRIPTION
**Monster Phase C — item C4** from `docs/audit-2026-05-22.md`.

A pipeline-declared gate `webhook_url` was POSTed with no destination validation, so it could be pointed at the cloud metadata endpoint (`169.254.169.254`) or internal services from inside the trust boundary — a classic SSRF / metadata-exfiltration sink.

## Fix
- Extracted the **existing** notification-webhook SSRF guard into a shared `Sykli.HTTP.check_ssrf/1` (resolves the host; blocks loopback, link-local incl. `169.254.0.0/16`, and RFC1918 — IPv4 and IPv6).
- Applied it in `gate_service`'s `wait_webhook` (blocked → `{:denied, "webhook_url blocked: ..."}`).
- `notification_service` now **delegates** to the same helper (DRY — both webhook paths enforce identical blocking).

## Verification
`mix format` / `mix credo` (clean) / `mix test` (**1757, 0 failures**, +5 SSRF tests) / `mix escript.build`; black-box GATE cases pass.

## Phase C remaining
- **C5** Shell-runtime trust ADR + GH-004 rewrite (decision: document Shell = trusted) — own PR (establishes `docs/adr/`)
- **C3** mask file/OIDC-resolved secrets — own PR
- **C2** per-team coordinator authz (decision: enforce per-team tokens) — own PR (auth-model change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)