### PR TITLE
docs(security): Shell-runtime trust model + GH-004 reframe (Phase C, C5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ docs/*
 !docs/local-state-plane.md
 !docs/mcp-tools.md
 !docs/review-primitives.md
+!docs/runtime-trust-model.md
 !docs/runtimes.md
 !docs/sdk-schema.md
 !docs/self-hosted-coordinator.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Runtime trust model documented; GH-004 reframed (Monster Phase C, C5).** New
+  `docs/runtime-trust-model.md` states the trust boundary: the Shell runtime is
+  **not** a security sandbox (it runs trusted repository code with the invoking
+  user's privileges; use a container runtime for untrusted pipelines), while
+  Sykli's *own* file operations stay path-contained. The black-box `GH-004` case
+  now asserts that real guarantee — a `success_criteria` path that traverses the
+  workdir is rejected with `path escapes task workdir` — instead of an unmet
+  command-sandboxing assumption. This retires the **last** `expected_failure`
+  case; the black-box suite now has zero known-broken cases.
 - **Gate webhooks are SSRF-guarded (Monster Phase C, C4).** A pipeline-declared
   gate `webhook_url` is now resolved and rejected if it points at a loopback,
   link-local (incl. the cloud metadata range `169.254.0.0/16`), or private

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ eval/harness/run.sh --case 001 --dry-run    # preview without running
 - `docs/review-primitives.md` — review-node dispatch contract and the `review_result` shape.
 - `docs/failure-semantics.md` / `docs/result-contract-slices.md` / `docs/agent-readable-failure-output.md` — typed failure classification, the result contract slice, and how both surface to agents.
 - `docs/runtimes.md` — runtime selection priority chain.
+- `docs/runtime-trust-model.md` — the Shell runtime is not a security sandbox (trusted repo code only; use a container runtime for untrusted pipelines); Sykli's own file ops are path-contained. Normative for `GH-004`.
 - `examples/` and `test_projects/` — runnable sample pipelines for manual testing.
 
 Before every commit: `mix format && mix test && mix escript.build`

--- a/docs/runtime-trust-model.md
+++ b/docs/runtime-trust-model.md
@@ -1,0 +1,56 @@
+# Runtime trust model
+
+Sykli executes the commands a pipeline declares. **Where** those commands run
+(`Sykli.Target`) and **how** they run (`Sykli.Runtime`) determine what isolation,
+if any, applies. This document states the trust boundary so operators know what
+Sykli does and does not protect against.
+
+## The Shell runtime is not a security sandbox
+
+Under the **Shell runtime** (the default local runtime), a task command runs as a
+child process of the Sykli engine, with the **same operating-system privileges as
+the user who invoked Sykli**. It can read, write, and execute anything that user
+can — including files outside the workspace such as `/etc/passwd`, environment
+secrets, and the network.
+
+This is by design: the Shell runtime is for **trusted repository code** — the same
+trust you already extend to `make`, `npm test`, or any build script in the repo.
+It is *not* a boundary for running untrusted or third-party pipelines.
+
+> **If you need to run untrusted code, use a container runtime** (Docker, Podman,
+> or the Kubernetes target). Containers provide the process/filesystem isolation
+> the Shell runtime does not. Select one via the runtime priority chain (see
+> `docs/runtimes.md`).
+
+## What Sykli *does* guarantee: path containment on its own file operations
+
+Independent of the runtime's command isolation, **Sykli's own file handling is
+contained to the task workspace.** Operations the *engine* performs — not the
+user's command — reject paths that escape the workdir or are absolute, and refuse
+to follow symlinks out of it:
+
+- artifact/output copy (`Sykli.Target.Local.copy_artifact/4`),
+- container/K8s mount sources,
+- `success_criteria` file paths (`file_exists` / `file_non_empty`),
+- `evidence_required` local file refs,
+
+all resolve through `Path.expand` + a `path_within?(resolved, workdir <> "/")`
+check (the trailing slash prevents prefix tricks) and reject symlinks. A relative
+path that traverses out (`../../etc/passwd`) or an absolute path is refused with a
+structured error (`path escapes task workdir` / `path must be relative to task
+workdir`), not silently followed.
+
+This is the containment guarantee the 0.2.0 path-traversal fix established, and it
+is what the black-box `GH-004` case asserts — Sykli does not let a *declared
+contract field* read or write outside the workspace. It is distinct from, and does
+not imply, sandboxing of the *user's command* under the Shell runtime.
+
+## Summary
+
+| Concern | Shell runtime | Container/K8s runtime |
+|---|---|---|
+| User command can touch host files / network | **Yes** (trusted code only) | Isolated by the container |
+| Sykli's *own* file ops escape the workspace | No — contained + symlink-rejecting | No — contained + symlink-rejecting |
+
+Run untrusted pipelines in a container runtime. Treat the Shell runtime the way
+you treat any build script you already run on your machine.

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -1866,16 +1866,16 @@
     },
     {
       "id": "GH-004",
-      "name": "Absolute host path read from task command fails safely",
-      "fixture": "path_traversal_command",
-      "command": "sykli >/dev/null 2>&1 || true; test ! -s escaped.txt",
-      "shell": true,
-      "expect_exit": 0,
-      "source": "CLAUDE.md §Runtime isolation and path containment; CHANGELOG 0.2.0 path traversal vulnerability fix",
-      "validated_by": "Injected bug: execute task commands directly on host with unrestricted absolute paths; escaped file assertion fails.",
-      "findings": "Currently fails under local shell runtime if task commands can read /etc/passwd into the workspace.",
-      "issue": "https://github.com/false-systems/sykli/issues/209",
-      "expected_failure": true
+      "name": "Engine contains success-criteria paths that escape the workdir",
+      "fixture": "path_traversal_criterion",
+      "command": "sykli --json",
+      "expect_exit": 1,
+      "expect_json_jq": [
+        ".data.tasks[0].status == \"failed\"",
+        ".data.tasks[0].success_criteria_results[0].message == \"path escapes task workdir\""
+      ],
+      "source": "docs/runtime-trust-model.md; CLAUDE.md §Runtime isolation and path containment; CHANGELOG 0.2.0 path traversal fix",
+      "validated_by": "Injected bug: skip path containment on criterion paths; the traversing ../etc/passwd path would resolve outside the workdir instead of being rejected. Asserts Sykli's own path containment (per the trust model: the Shell runtime is not a command sandbox, but the engine contains its own file ops)."
     }
   ]
 }

--- a/test/blackbox/fixtures/path_traversal_command/sykli.exs
+++ b/test/blackbox/fixtures/path_traversal_command/sykli.exs
@@ -1,1 +1,0 @@
-IO.puts(~s({"version":"1","tasks":[{"name":"escape","command":"cat /etc/passwd > escaped.txt"}]}))

--- a/test/blackbox/fixtures/path_traversal_criterion/sykli.exs
+++ b/test/blackbox/fixtures/path_traversal_criterion/sykli.exs
@@ -1,0 +1,1 @@
+IO.puts(~s({"version":"3","tasks":[{"name":"contained","command":"echo hi","success_criteria":[{"type":"file_exists","path":"../../../../../../etc/passwd"}]}]}))


### PR DESCRIPTION
**Monster Phase C — item C5** from `docs/audit-2026-05-22.md`. Decision: **document Shell = trusted**.

## Note on "ADR"
The option was framed as an ADR, but ADRs were intentionally **removed** from this repo (#153, "remove ADR system"). So this is a regular doc — re-establishing `docs/adr/` would contradict that decision. The substance (document the trust model) is unchanged.

## Changes
- **`docs/runtime-trust-model.md`** (new): the Shell runtime is **not** a security sandbox — it runs trusted repo code with the invoking user's privileges; untrusted pipelines need a container runtime. Sykli's *own* file ops (copy, mounts, `success_criteria`/`evidence_required` paths) stay path-contained (`Path.expand` + `path_within?` + symlink rejection).
- **GH-004 reframed** to assert the guarantee Sykli actually makes: a `success_criteria` path that traverses the workdir is rejected at runtime (`resolve_criterion_path` → `path escapes task workdir`), proving the engine contains its *own* file access. The old case asserted command-sandboxing the Shell runtime never provided. Fixture renamed `path_traversal_command` → `path_traversal_criterion`.
- Closes **#209**.

## Milestone
GH-004 was the **last** `expected_failure` case. The black-box suite is now **167 passed / 0 expected-red / 0 failed** — zero known-broken cases (the audit's original 12 flags are all resolved across phases A, B, and C).

## Note
`.gitignore` uses a docs allowlist; added `!docs/runtime-trust-model.md` so the new doc is actually tracked (same trap as the Phase A untracked files).

## Verification
No Elixir source changed. Black-box: **all 167 pass, 0 expected-red**. JSON dataset validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)