### PR TITLE
fix(security): mask resolved run secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   work items, run summaries, gates, or daemon sessions. Gate decisions
   require `owner` or `approver`; `member` tokens receive
   `coordinator.forbidden`.
+- **Runtime-resolved secrets are masked (Monster Phase C, C3).** The engine now
+  carries per-run resolved secret values from `secret_refs`, OIDC credential
+  exchange, and literal secret-like task env keys into occurrence persistence,
+  notification payloads, run-summary sync/outbox payloads, and SLSA
+  attestations. Secret-pattern matching is centralized and structured payloads
+  also redact values under secret-like keys.
 - **Runtime trust model documented; GH-004 reframed (Monster Phase C, C5).** New
   `docs/runtime-trust-model.md` states the trust boundary: the Shell runtime is
   **not** a security sandbox (it runs trusted repository code with the invoking

--- a/core/lib/sykli.ex
+++ b/core/lib/sykli.ex
@@ -11,6 +11,7 @@ defmodule Sykli do
   alias Sykli.Occurrence.Enrichment
   alias Sykli.Occurrence.HistoryAnalyzer
   alias Sykli.Services.CausalityService
+  alias Sykli.Services.SecretPatterns
 
   @doc """
   Run the sykli pipeline.
@@ -239,7 +240,7 @@ defmodule Sykli do
 
     # save/2 uses File.write! so it raises on error (caught by rescue below)
     RunHistory.save(run, path: path)
-    maybe_sync_run_summary(path, run)
+    maybe_sync_run_summary(path, run, run_secret_values(result))
 
     # Generate AI context file
     generate_context(path, graph, run)
@@ -526,15 +527,24 @@ defmodule Sykli do
 
   defp format_error_for_history(other), do: inspect(other)
 
-  defp maybe_sync_run_summary(path, %RunHistory.Run{} = run) do
+  defp maybe_sync_run_summary(path, %RunHistory.Run{} = run, secret_values) do
     case Sykli.Daemon.SessionStore.read(path: Path.join(path, ".sykli")) do
       {:ok, session} ->
         summary = RunSummary.from_run(run, session: session, path: path)
-        payload = RunSummary.encode(summary)
-        prequeued? = Sykli.Outbox.enqueue("runs", payload, path: path) == :ok
+        payload = RunSummary.encode(summary, secrets: secret_values)
+
+        prequeued? =
+          Sykli.Outbox.enqueue("runs", payload, path: path, secrets: secret_values) == :ok
 
         Task.Supervisor.async_nolink(Sykli.TaskSupervisor, fn ->
-          publish_or_enqueue_run_summary(session, summary, payload, path, prequeued?)
+          publish_or_enqueue_run_summary(
+            session,
+            summary,
+            payload,
+            path,
+            prequeued?,
+            secret_values
+          )
         end)
 
         :ok
@@ -544,10 +554,10 @@ defmodule Sykli do
     end
   end
 
-  defp publish_or_enqueue_run_summary(session, summary, payload, path, prequeued?) do
+  defp publish_or_enqueue_run_summary(session, summary, payload, path, prequeued?, secret_values) do
     case System.get_env("SYKLI_TEAM_TOKEN") do
       token when is_binary(token) and token != "" ->
-        case RunClient.publish(session, token, summary) do
+        case RunClient.publish(session, token, summary, secrets: secret_values) do
           {:ok, _stored} ->
             if prequeued?, do: Sykli.Outbox.delete("runs", payload, path: path)
 
@@ -576,6 +586,20 @@ defmodule Sykli do
       "reason" => inspect(reason)
     })
   end
+
+  defp run_secret_values(result) do
+    result
+    |> executor_results()
+    |> Enum.flat_map(fn
+      %Executor.TaskResult{secret_values: values} -> values || []
+      _other -> []
+    end)
+    |> SecretPatterns.normalize_values()
+  end
+
+  defp executor_results({:ok, results}) when is_list(results), do: results
+  defp executor_results({:error, results}) when is_list(results), do: results
+  defp executor_results(_other), do: []
 
   defp get_previous_streaks(path) do
     case RunHistory.load_latest(path: path) do

--- a/core/lib/sykli/executor.ex
+++ b/core/lib/sykli/executor.ex
@@ -29,6 +29,7 @@ defmodule Sykli.Executor do
   alias Sykli.Services.OIDCService
   alias Sykli.Services.PredictiveWarnings
   alias Sykli.Services.ProgressTracker
+  alias Sykli.Services.SecretPatterns
   alias Sykli.Services.SecretValidator
 
   # Note: we DON'T alias Sykli.Graph.Task because it shadows Elixir's Task module
@@ -57,6 +58,7 @@ defmodule Sykli.Executor do
       :command,
       :failure_semantics,
       :review_result,
+      secret_values: [],
       success_criteria_results: [],
       evidence_results: []
     ]
@@ -71,6 +73,7 @@ defmodule Sykli.Executor do
             command: String.t() | nil,
             failure_semantics: Sykli.FailureSemantics.t() | nil,
             review_result: Sykli.ReviewPrimitive.Result.t() | nil,
+            secret_values: [String.t()],
             success_criteria_results: [Sykli.SuccessCriteria.Result.t()],
             evidence_results: [Sykli.EvidenceRequirement.Result.t()]
           }
@@ -140,6 +143,7 @@ defmodule Sykli.Executor do
       :target,
       :timeout,
       :run_id,
+      :oidc_service,
       # nil means unconstrained on a bare struct; run/3 replaces it with the computed default.
       max_parallel: nil,
       continue_on_failure: false
@@ -149,6 +153,7 @@ defmodule Sykli.Executor do
             target: module(),
             timeout: pos_integer(),
             run_id: String.t() | nil,
+            oidc_service: module(),
             max_parallel: pos_integer(),
             continue_on_failure: boolean()
           }
@@ -172,6 +177,7 @@ defmodule Sykli.Executor do
     target = Keyword.get(opts, :target) || Keyword.get(opts, :executor, @default_target)
     timeout = Keyword.get(opts, :timeout, @default_timeout)
     run_id = Keyword.get(opts, :run_id)
+    oidc_service = Keyword.get(opts, :oidc_service, OIDCService)
     max_parallel = Keyword.get(opts, :max_parallel, default_max_parallel())
     continue_on_failure = Keyword.get(opts, :continue_on_failure, false)
     start_time = System.monotonic_time(:millisecond)
@@ -181,6 +187,7 @@ defmodule Sykli.Executor do
       target: target,
       timeout: timeout,
       run_id: run_id,
+      oidc_service: oidc_service,
       max_parallel: max_parallel,
       continue_on_failure: continue_on_failure
     }
@@ -395,7 +402,14 @@ defmodule Sykli.Executor do
                 :ok ->
                   %TaskResult{} =
                     result =
-                    run_single(task, state, {task_num, total}, config.target, config.run_id)
+                    run_single(
+                      task,
+                      state,
+                      {task_num, total},
+                      config.target,
+                      config.run_id,
+                      config.oidc_service
+                    )
 
                   duration = System.monotonic_time(:millisecond) - start_time
                   %TaskResult{result | duration_ms: duration}
@@ -612,10 +626,11 @@ defmodule Sykli.Executor do
           map(),
           {pos_integer(), pos_integer()},
           module(),
-          String.t() | nil
+          String.t() | nil,
+          module()
         ) ::
           TaskResult.t()
-  defp run_single(%Sykli.Graph.Task{} = task, state, progress, target, run_id) do
+  defp run_single(%Sykli.Graph.Task{} = task, state, progress, target, run_id, oidc_service) do
     start_time = System.monotonic_time(:millisecond)
 
     cond do
@@ -628,13 +643,27 @@ defmodule Sykli.Executor do
       true ->
         # Check condition first
         if should_run?(task) do
+          # Keep this list in sync with every path that injects secrets into task.env.
+          literal_secret_values = SecretPatterns.values_from_pairs(task.env || %{})
+
           # Resolve secret_refs before execution
-          task = resolve_secret_refs(task)
+          {task, ref_secret_values} = resolve_secret_refs(task)
+
+          secret_values =
+            SecretPatterns.normalize_values(literal_secret_values ++ ref_secret_values)
 
           # OIDC credential exchange (if configured)
           try do
-            case OIDCService.exchange(task, state) do
+            case oidc_service.exchange(task, state) do
               {:ok, oidc_env} ->
+                oidc_secret_values =
+                  oidc_env
+                  |> Map.values()
+                  |> SecretPatterns.normalize_values()
+
+                run_secret_values =
+                  SecretPatterns.normalize_values(secret_values ++ oidc_secret_values)
+
                 # Merge OIDC env vars into task env
                 task =
                   if map_size(oidc_env) > 0 do
@@ -646,7 +675,9 @@ defmodule Sykli.Executor do
                 # Validate required secrets are present (via target)
                 case validate_secrets(task, state, target) do
                   :ok ->
-                    run_task_with_cache(task, state, progress, target, start_time, run_id)
+                    task
+                    |> run_task_with_cache(state, progress, target, start_time, run_id)
+                    |> with_secret_values(run_secret_values)
 
                   {:error, missing} ->
                     Output.missing_secrets(task.name, missing)
@@ -663,6 +694,7 @@ defmodule Sykli.Executor do
                       failure_semantics: Sykli.FailureSemantics.for_error(error),
                       command: task.command
                     }
+                    |> with_secret_values(run_secret_values)
                 end
 
               {:error, reason} ->
@@ -679,9 +711,10 @@ defmodule Sykli.Executor do
                   failure_semantics: Sykli.FailureSemantics.for_error(error),
                   command: task.command
                 }
+                |> with_secret_values(secret_values)
             end
           after
-            OIDCService.cleanup_temp_files()
+            oidc_service.cleanup_temp_files()
           end
         else
           Output.task_skipped("", task.name, "condition not met")
@@ -703,6 +736,11 @@ defmodule Sykli.Executor do
           }
         end
     end
+  end
+
+  defp with_secret_values(%TaskResult{} = result, values) do
+    values = SecretPatterns.normalize_values((result.secret_values || []) ++ values)
+    %TaskResult{result | secret_values: values}
   end
 
   defp run_review(%Sykli.Graph.Task{} = task, state, progress) do
@@ -1228,10 +1266,10 @@ defmodule Sykli.Executor do
         end
       end)
 
-    %{task | env: Map.merge(task.env || %{}, resolved)}
+    {%{task | env: Map.merge(task.env || %{}, resolved)}, Map.values(resolved)}
   end
 
-  defp resolve_secret_refs(task), do: task
+  defp resolve_secret_refs(task), do: {task, []}
 
   defp resolve_single_secret_ref(%{source: "env", key: key}) do
     case System.get_env(key) do

--- a/core/lib/sykli/occurrence/enrichment.ex
+++ b/core/lib/sykli/occurrence/enrichment.ex
@@ -17,6 +17,8 @@ defmodule Sykli.Occurrence.Enrichment do
   alias Sykli.Occurrence.Store
   alias Sykli.RunHistory
   alias Sykli.Services.CausalityService
+  alias Sykli.Services.SecretMasker
+  alias Sykli.Services.SecretPatterns
 
   @max_output_lines 200
 
@@ -35,18 +37,18 @@ defmodule Sykli.Occurrence.Enrichment do
           :ok | {:error, term()}
   def enrich_and_persist(%Occurrence{} = occ, graph, executor_result, workdir) do
     enriched = enrich(occ, graph, executor_result, workdir)
-    result = persist(enriched, workdir)
+    secrets = secrets_for_result(executor_result)
+    result = persist(enriched, workdir, secrets)
 
     # Generate SLSA provenance attestation for terminal events
     if occ.type in ["ci.run.passed", "ci.run.failed"] do
-      persist_attestation(enriched, graph, workdir)
+      persist_attestation(enriched, graph, workdir, secrets)
     end
 
     # Fire-and-forget webhook notification for terminal events (masked)
     if occ.type in ["ci.run.passed", "ci.run.failed"] do
-      secrets = collect_secrets_from_env()
-      masked = Sykli.Services.SecretMasker.mask_deep(to_persistence_map(enriched), secrets)
-      Sykli.Services.NotificationService.notify(masked)
+      masked = SecretMasker.mask_deep(to_persistence_map(enriched), secrets)
+      notification_service().notify(masked)
     end
 
     result
@@ -610,18 +612,9 @@ defmodule Sykli.Occurrence.Enrichment do
 
   @max_json_occurrences 20
 
-  defp persist(%Occurrence{} = occ, workdir) do
+  defp persist(%Occurrence{} = occ, workdir, secrets) do
     occurrence_map = to_persistence_map(occ)
-
-    # Mask any resolved secrets from the occurrence data before persisting
-    secrets = collect_secrets_from_env()
-
-    occurrence_map =
-      if secrets != [] do
-        Sykli.Services.SecretMasker.mask_deep(occurrence_map, secrets)
-      else
-        occurrence_map
-      end
+    occurrence_map = SecretMasker.mask_deep(occurrence_map, secrets)
 
     dir = Path.join(workdir, ".sykli")
 
@@ -729,13 +722,13 @@ defmodule Sykli.Occurrence.Enrichment do
   # SLSA ATTESTATION
   # ─────────────────────────────────────────────────────────────────────────────
 
-  defp persist_attestation(enriched, graph, workdir) do
+  defp persist_attestation(enriched, graph, workdir, secrets) do
     dir = Path.join(workdir, ".sykli")
 
     # Per-run attestation
     case Sykli.Attestation.generate(enriched, graph, workdir) do
       {:ok, attestation} ->
-        write_attestation(attestation, Path.join(dir, "attestation.json"))
+        write_attestation(attestation, Path.join(dir, "attestation.json"), secrets)
 
       {:error, :no_subjects} ->
         :ok
@@ -751,7 +744,7 @@ defmodule Sykli.Occurrence.Enrichment do
         :ok ->
           Enum.each(per_task, fn {task_name, attestation} ->
             safe_name = String.replace(task_name, "/", ":")
-            write_attestation(attestation, Path.join(att_dir, "#{safe_name}.json"))
+            write_attestation(attestation, Path.join(att_dir, "#{safe_name}.json"), secrets)
           end)
 
         {:error, _} ->
@@ -761,7 +754,8 @@ defmodule Sykli.Occurrence.Enrichment do
   end
 
   # Write attestation as DSSE envelope (signed if key available, unsigned otherwise)
-  defp write_attestation(attestation, path) do
+  defp write_attestation(attestation, path, secrets) do
+    attestation = SecretMasker.mask_deep(attestation, secrets)
     {:ok, envelope} = Sykli.Attestation.Envelope.wrap(attestation)
 
     envelope =
@@ -797,6 +791,20 @@ defmodule Sykli.Occurrence.Enrichment do
   defp extract_results({:ok, results}) when is_list(results), do: results
   defp extract_results({:error, results}) when is_list(results), do: results
   defp extract_results(_), do: []
+
+  defp secrets_for_result(executor_result) do
+    executor_result
+    |> extract_results()
+    |> Enum.flat_map(fn
+      %TaskResult{secret_values: values} -> values || []
+      _other -> []
+    end)
+    |> SecretPatterns.all_values()
+  end
+
+  defp notification_service do
+    Application.get_env(:sykli, :notification_service, Sykli.Services.NotificationService)
+  end
 
   defp get_field(%{} = task, field), do: Map.get(task, field)
 
@@ -844,32 +852,5 @@ defmodule Sykli.Occurrence.Enrichment do
     map
     |> Enum.reject(fn {_k, v} -> is_nil(v) or v == [] end)
     |> Map.new()
-  end
-
-  # Collect secret values from env vars for masking.
-  # Matches common patterns (_TOKEN, _SECRET, _KEY, etc.) and connection
-  # string env vars (DATABASE_URL, REDIS_DSN, etc.).
-  @secret_env_patterns [
-    "_TOKEN",
-    "_SECRET",
-    "_KEY",
-    "_PASSWORD",
-    "_PASS",
-    "_API_KEY",
-    "_CREDENTIAL",
-    "_AUTH",
-    "_URL",
-    "_DSN",
-    "_URI",
-    "_CONN"
-  ]
-  defp collect_secrets_from_env do
-    System.get_env()
-    |> Enum.filter(fn {key, _val} ->
-      Enum.any?(@secret_env_patterns, &String.contains?(key, &1))
-    end)
-    |> Enum.map(fn {_key, val} -> val end)
-    |> Enum.uniq()
-    |> Enum.filter(&(byte_size(&1) >= 4))
   end
 end

--- a/core/lib/sykli/outbox.ex
+++ b/core/lib/sykli/outbox.ex
@@ -5,11 +5,13 @@ defmodule Sykli.Outbox do
   @max_drain 100
 
   def enqueue(kind, payload, opts \\ []) when is_map(payload) do
+    secrets = Sykli.Services.SecretPatterns.all_values(Keyword.get(opts, :secrets, []))
+
     with {:ok, dir} <- kind_dir(kind, opts),
          :ok <- File.mkdir_p(dir),
          {:ok, id} <- payload_id(payload),
          {:ok, json} <-
-           Jason.encode(Sykli.Services.SecretMasker.mask_deep(payload, secrets())) do
+           Jason.encode(Sykli.Services.SecretMasker.mask_deep(payload, secrets)) do
       atomic_write(Path.join(dir, "#{id}.json"), json)
     end
   end
@@ -148,32 +150,5 @@ defmodule Sykli.Outbox do
         File.rm(tmp_path)
         {:error, {:team_outbox_write_failed, reason}}
     end
-  end
-
-  defp secrets do
-    System.get_env()
-    |> Enum.filter(fn {key, _val} ->
-      Enum.any?(secret_env_patterns(), &String.contains?(key, &1))
-    end)
-    |> Enum.map(fn {_key, value} -> value end)
-    |> Enum.uniq()
-    |> Enum.filter(&(is_binary(&1) and byte_size(&1) >= 4))
-  end
-
-  defp secret_env_patterns do
-    [
-      "_TOKEN",
-      "_SECRET",
-      "_KEY",
-      "_PASSWORD",
-      "_PASS",
-      "_API_KEY",
-      "_CREDENTIAL",
-      "_AUTH",
-      "_URL",
-      "_DSN",
-      "_URI",
-      "_CONN"
-    ]
   end
 end

--- a/core/lib/sykli/services/secret_masker.ex
+++ b/core/lib/sykli/services/secret_masker.ex
@@ -6,6 +6,8 @@ defmodule Sykli.Services.SecretMasker do
   webhook payloads, or CLI output.
   """
 
+  alias Sykli.Services.SecretPatterns
+
   @mask "***MASKED***"
   @min_secret_length 4
 
@@ -29,11 +31,19 @@ defmodule Sykli.Services.SecretMasker do
   Recursively mask secret values in maps, lists, and strings.
   """
   @spec mask_deep(term(), [String.t()]) :: term()
-  def mask_deep(data, []), do: data
   def mask_deep(data, secrets) when is_binary(data), do: mask_string(data, secrets)
 
   def mask_deep(data, secrets) when is_map(data) do
-    Map.new(data, fn {k, v} -> {k, mask_deep(v, secrets)} end)
+    Map.new(data, fn {key, value} ->
+      value =
+        if SecretPatterns.secret_key?(key) do
+          mask_value(value)
+        else
+          mask_deep(value, secrets)
+        end
+
+      {key, value}
+    end)
   end
 
   def mask_deep(data, secrets) when is_list(data) do
@@ -41,4 +51,14 @@ defmodule Sykli.Services.SecretMasker do
   end
 
   def mask_deep(data, _secrets), do: data
+
+  defp mask_value(value) when is_binary(value), do: @mask
+
+  defp mask_value(value) when is_map(value) do
+    Map.new(value, fn {key, nested} -> {key, mask_value(nested)} end)
+  end
+
+  defp mask_value(value) when is_list(value), do: Enum.map(value, &mask_value/1)
+  defp mask_value(value) when is_nil(value), do: nil
+  defp mask_value(_value), do: @mask
 end

--- a/core/lib/sykli/services/secret_patterns.ex
+++ b/core/lib/sykli/services/secret_patterns.ex
@@ -1,0 +1,82 @@
+defmodule Sykli.Services.SecretPatterns do
+  @moduledoc false
+
+  @min_secret_length 4
+
+  @patterns [
+    "_TOKEN",
+    "_SECRET",
+    "_KEY",
+    "_PASSWORD",
+    "_PASS",
+    "_API_KEY",
+    "_CREDENTIAL",
+    "_AUTH",
+    "_URL",
+    "_DSN",
+    "_URI",
+    "_CONN"
+  ]
+
+  @bare_names [
+    "TOKEN",
+    "SECRET",
+    "KEY",
+    "PASSWORD",
+    "PASS",
+    "API_KEY",
+    "CREDENTIAL",
+    "AUTH"
+  ]
+
+  def patterns, do: @patterns
+
+  def secret_key?(key) when is_atom(key), do: key |> Atom.to_string() |> secret_key?()
+
+  def secret_key?(key) when is_binary(key) do
+    key = key |> String.upcase() |> String.replace("-", "_")
+    key in @bare_names or Enum.any?(@patterns, &String.contains?(key, &1))
+  end
+
+  def secret_key?(_key), do: false
+
+  def values_from_env do
+    System.get_env()
+    |> values_from_pairs()
+  end
+
+  def values_from_pairs(nil), do: []
+
+  def values_from_pairs(pairs) when is_map(pairs) or is_list(pairs) do
+    pairs
+    |> Enum.flat_map(fn
+      {key, value} ->
+        if secret_key?(key), do: normalize_values(value), else: []
+
+      _other ->
+        []
+    end)
+    |> normalize_values()
+  end
+
+  def values_from_pairs(_pairs), do: []
+
+  def all_values(extra_values \\ []) do
+    [values_from_env(), extra_values]
+    |> List.flatten()
+    |> normalize_values()
+  end
+
+  def normalize_values(values) when is_list(values) do
+    values
+    |> Enum.flat_map(&normalize_values/1)
+    |> Enum.uniq()
+  end
+
+  def normalize_values(value) when is_binary(value) do
+    value = String.trim(value)
+    if byte_size(value) >= @min_secret_length, do: [value], else: []
+  end
+
+  def normalize_values(_value), do: []
+end

--- a/core/lib/sykli/team_coordinator/run_client.ex
+++ b/core/lib/sykli/team_coordinator/run_client.ex
@@ -5,7 +5,12 @@ defmodule Sykli.TeamCoordinator.RunClient do
   alias Sykli.TeamCoordinator.RunSummary
 
   def publish(session, token, %RunSummary{} = summary, opts \\ []) do
-    publish_raw(session, token, RunSummary.encode(summary), opts)
+    publish_raw(
+      session,
+      token,
+      RunSummary.encode(summary, secrets: Keyword.get(opts, :secrets, [])),
+      opts
+    )
   end
 
   def publish_raw(session, token, payload, opts \\ []) when is_map(payload) do

--- a/core/lib/sykli/team_coordinator/run_summary.ex
+++ b/core/lib/sykli/team_coordinator/run_summary.ex
@@ -21,6 +21,8 @@ defmodule Sykli.TeamCoordinator.RunSummary do
   """
 
   alias Sykli.RunHistory
+  alias Sykli.Services.SecretMasker
+  alias Sykli.Services.SecretPatterns
 
   @version "1"
 
@@ -66,7 +68,9 @@ defmodule Sykli.TeamCoordinator.RunSummary do
     }
   end
 
-  def encode(%__MODULE__{} = summary) do
+  def encode(%__MODULE__{} = summary, opts \\ []) do
+    secrets = SecretPatterns.all_values(Keyword.get(opts, :secrets, []))
+
     %{
       "version" => summary.version,
       "run" => summary.run,
@@ -76,6 +80,7 @@ defmodule Sykli.TeamCoordinator.RunSummary do
       "gates" => summary.gates,
       "evidence_refs" => summary.evidence_refs
     }
+    |> SecretMasker.mask_deep(secrets)
   end
 
   defp run_node(%RunHistory.TaskResult{} = task) do

--- a/core/test/sykli/executor/secret_masking_test.exs
+++ b/core/test/sykli/executor/secret_masking_test.exs
@@ -1,0 +1,300 @@
+defmodule Sykli.Executor.SecretMaskingTest do
+  use ExUnit.Case, async: false
+
+  alias Sykli.Executor
+  alias Sykli.Graph.Task
+  alias Sykli.Graph.Task.CredentialBinding
+  alias Sykli.Daemon.SessionStore
+
+  setup do
+    Application.delete_env(:sykli, :notification_service)
+    Application.delete_env(:sykli, :notification_test_pid)
+    Application.delete_env(:sykli, :secret_masking_test_pid)
+
+    old_team_token = System.get_env("SYKLI_TEAM_TOKEN")
+
+    on_exit(fn ->
+      Application.delete_env(:sykli, :notification_service)
+      Application.delete_env(:sykli, :notification_test_pid)
+      Application.delete_env(:sykli, :secret_masking_test_pid)
+
+      case old_team_token do
+        nil -> System.delete_env("SYKLI_TEAM_TOKEN")
+        value -> System.put_env("SYKLI_TEAM_TOKEN", value)
+      end
+    end)
+
+    :ok
+  end
+
+  defmodule EchoEnvTarget do
+    @behaviour Sykli.Target.Behaviour
+
+    @impl true
+    def name, do: "echo-env"
+
+    @impl true
+    def available?, do: {:ok, %{mode: :test}}
+
+    @impl true
+    def setup(opts), do: {:ok, %{workdir: Keyword.get(opts, :workdir, ".")}}
+
+    @impl true
+    def teardown(_state), do: :ok
+
+    @impl true
+    def resolve_secret(_name, _state), do: {:error, :not_found}
+
+    @impl true
+    def create_volume(_name, _opts, _state),
+      do: {:ok, %{id: "mock", host_path: nil, reference: "mock"}}
+
+    @impl true
+    def artifact_path(_task, _artifact, _workdir, _state), do: "/mock/path"
+
+    @impl true
+    def copy_artifact(_src, _dest, _workdir, _state), do: :ok
+
+    @impl true
+    def start_services(_name, _services, _state), do: {:ok, nil}
+
+    @impl true
+    def stop_services(_info, _state), do: :ok
+
+    @impl true
+    def run_task(task, _state, _opts) do
+      {:ok,
+       "file=#{task.env["FILE_SECRET"]} literal=#{task.env["API_TOKEN"]} oidc=#{task.env["AWS_SESSION_TOKEN"]}"}
+    end
+  end
+
+  defmodule EgressTarget do
+    @behaviour Sykli.Target.Behaviour
+
+    @impl true
+    def name, do: "egress"
+
+    @impl true
+    def available?, do: {:ok, %{mode: :test}}
+
+    @impl true
+    def setup(opts), do: {:ok, %{workdir: Keyword.get(opts, :workdir, ".")}}
+
+    @impl true
+    def teardown(_state), do: :ok
+
+    @impl true
+    def resolve_secret(_name, _state), do: {:error, :not_found}
+
+    @impl true
+    def create_volume(_name, _opts, _state),
+      do: {:ok, %{id: "mock", host_path: nil, reference: "mock"}}
+
+    @impl true
+    def artifact_path(_task, _artifact, _workdir, _state), do: "/mock/path"
+
+    @impl true
+    def copy_artifact(_src, _dest, _workdir, _state), do: :ok
+
+    @impl true
+    def start_services(_name, _services, _state), do: {:ok, nil}
+
+    @impl true
+    def stop_services(_info, _state), do: :ok
+
+    @impl true
+    def run_task(task, _state, _opts) do
+      {:ok,
+       "file=#{task.env["FILE_SECRET"]} literal=#{task.env["API_TOKEN"]} oidc=#{task.env["AWS_SESSION_TOKEN"]}"}
+    end
+
+    @impl true
+    def evaluate_success_criteria(task, criteria, _state, _opts) do
+      message =
+        "criterion saw file=#{task.env["FILE_SECRET"]} literal=#{task.env["API_TOKEN"]} oidc=#{task.env["AWS_SESSION_TOKEN"]}"
+
+      results =
+        Enum.with_index(criteria || [], fn criterion, index ->
+          %Sykli.SuccessCriteria.Result{
+            index: index,
+            type: criterion["type"],
+            status: :failed,
+            message: message,
+            target: "egress"
+          }
+        end)
+
+      error = %Sykli.Error{
+        code: "success_criteria_failed",
+        type: :execution,
+        message: message,
+        output: message
+      }
+
+      {:error, error, results}
+    end
+  end
+
+  defmodule FakeOIDCService do
+    def exchange(%{oidc: nil}, _state), do: {:ok, %{}}
+
+    def exchange(%{oidc: %Sykli.Graph.Task.CredentialBinding{}}, _state) do
+      {:ok, %{"AWS_SESSION_TOKEN" => "oidc-session-token-789"}}
+    end
+
+    def cleanup_temp_files, do: :ok
+  end
+
+  defmodule NotificationProbe do
+    def notify(payload) do
+      send(Application.fetch_env!(:sykli, :notification_test_pid), {:notification, payload})
+      :ok
+    end
+  end
+
+  defmodule CoordinatorCapture do
+    import Plug.Conn
+
+    def init(opts), do: opts
+
+    def call(conn, _opts) do
+      {:ok, body, conn} = read_body(conn)
+      decoded = Jason.decode!(body)
+      send(Application.fetch_env!(:sykli, :secret_masking_test_pid), {:run_summary_wire, body})
+
+      run_id = get_in(decoded, ["run", "id"]) || "run_001"
+
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(201, Jason.encode!(%{"ok" => true, "data" => %{"run" => %{"id" => run_id}}}))
+    end
+  end
+
+  test "task results carry file-sourced, literal, and OIDC secret values for later masking" do
+    file_secret = "file-secret-value-123"
+    literal_secret = "literal-token-value-456"
+    oidc_secret = "oidc-session-token-789"
+    secret_path = Path.join(File.cwd!(), "tmp_secret_#{System.unique_integer([:positive])}")
+
+    File.write!(secret_path, file_secret)
+    on_exit(fn -> File.rm(secret_path) end)
+
+    task = %Task{
+      name: "build",
+      command: "echo secrets",
+      depends_on: [],
+      env: %{"API_TOKEN" => literal_secret},
+      secret_refs: [%{name: "FILE_SECRET", source: "file", key: secret_path}],
+      oidc: %CredentialBinding{provider: :aws, role_arn: "arn:aws:iam::123456789012:role/test"}
+    }
+
+    assert {:ok, [result]} =
+             Executor.run([task], %{"build" => task},
+               target: EchoEnvTarget,
+               workdir: File.cwd!(),
+               oidc_service: FakeOIDCService
+             )
+
+    assert result.output == "file=#{file_secret} literal=#{literal_secret} oidc=#{oidc_secret}"
+
+    assert Enum.sort(result.secret_values) ==
+             Enum.sort([file_secret, literal_secret, oidc_secret])
+  end
+
+  test "run-scoped secrets are masked in occurrence, webhook, run-summary wire, and attestation" do
+    workdir =
+      Path.join(System.tmp_dir!(), "sykli-secret-egress-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(workdir)
+    on_exit(fn -> File.rm_rf(workdir) end)
+
+    file_secret = "file-secret-value-123"
+    literal_secret = "literal-token-value-456"
+    oidc_secret = "oidc-session-token-789"
+    secrets = [file_secret, literal_secret, oidc_secret]
+
+    port = free_port()
+    {:ok, server} = Bandit.start_link(plug: CoordinatorCapture, port: port, startup_log: false)
+
+    on_exit(fn -> Process.exit(server, :normal) end)
+
+    Application.put_env(:sykli, :notification_service, NotificationProbe)
+    Application.put_env(:sykli, :notification_test_pid, self())
+    Application.put_env(:sykli, :secret_masking_test_pid, self())
+    System.put_env("SYKLI_TEAM_TOKEN", "team-token")
+
+    File.write!(Path.join(workdir, "secret.txt"), file_secret)
+
+    {:ok, _session} =
+      SessionStore.write(
+        %{
+          "coordinator" => "http://127.0.0.1:#{port}",
+          "session_id" => "sess_001",
+          "org_slug" => "false-systems",
+          "team_slug" => "platform",
+          "team_id" => "team_001"
+        },
+        path: Path.join(workdir, ".sykli")
+      )
+
+    json =
+      Jason.encode!(%{
+        "version" => "3",
+        "tasks" => [
+          %{
+            "name" => "deploy",
+            "command" =>
+              "deploy --file #{file_secret} --literal #{literal_secret} --oidc #{oidc_secret}",
+            "env" => %{"API_TOKEN" => literal_secret},
+            "secret_refs" => [
+              %{"name" => "FILE_SECRET", "source" => "file", "key" => "secret.txt"}
+            ],
+            "oidc" => %{
+              "provider" => "aws",
+              "role_arn" => "arn:aws:iam::123456789012:role/test"
+            },
+            "success_criteria" => [%{"type" => "exit_code", "equals" => 0}]
+          }
+        ]
+      })
+
+    File.write!(Path.join(workdir, "sykli.exs"), "IO.puts(#{inspect(json)})")
+
+    result =
+      File.cd!(workdir, fn ->
+        Sykli.run(workdir, target: EgressTarget, oidc_service: FakeOIDCService)
+      end)
+
+    assert {:error, [task_result]} = result
+    assert Enum.sort(task_result.secret_values) == Enum.sort(secrets)
+
+    occurrence_json = File.read!(Path.join([workdir, ".sykli", "occurrence.json"]))
+    assert_masked(occurrence_json, secrets)
+
+    assert_received {:notification, notification_payload}
+    assert_masked(Jason.encode!(notification_payload), secrets)
+
+    assert_receive {:run_summary_wire, wire_body}, 2_000
+    assert_masked(wire_body, secrets)
+
+    envelope =
+      Path.join([workdir, ".sykli", "attestation.json"])
+      |> File.read!()
+      |> Jason.decode!()
+
+    assert {:ok, attestation} = Sykli.Attestation.Envelope.decode_payload(envelope)
+    assert_masked(Jason.encode!(attestation), secrets)
+  end
+
+  defp assert_masked(serialized, secrets) do
+    Enum.each(secrets, fn secret -> refute serialized =~ secret end)
+    assert serialized =~ "***MASKED***"
+  end
+
+  defp free_port do
+    {:ok, socket} = :gen_tcp.listen(0, [:binary, active: false])
+    {:ok, port} = :inet.port(socket)
+    :gen_tcp.close(socket)
+    port
+  end
+end

--- a/core/test/sykli/occurrence/enrichment_test.exs
+++ b/core/test/sykli/occurrence/enrichment_test.exs
@@ -7,12 +7,21 @@ defmodule Sykli.Occurrence.EnrichmentTest do
 
   @tmp_dir System.tmp_dir!()
 
+  defmodule NotificationProbe do
+    def notify(payload) do
+      send(Application.fetch_env!(:sykli, :notification_test_pid), {:notification, payload})
+      :ok
+    end
+  end
+
   setup do
     test_dir = Path.join(@tmp_dir, "enrichment_test_#{:erlang.unique_integer([:positive])}")
     File.mkdir_p!(test_dir)
 
     on_exit(fn ->
       File.rm_rf!(test_dir)
+      Application.delete_env(:sykli, :notification_service)
+      Application.delete_env(:sykli, :notification_test_pid)
     end)
 
     {:ok, workdir: test_dir}
@@ -589,6 +598,60 @@ defmodule Sykli.Occurrence.EnrichmentTest do
       binary = File.read!(etf)
       decoded_etf = :erlang.binary_to_term(binary)
       assert decoded_etf["id"] == "run-write"
+    end
+
+    test "masks run-scoped secrets in occurrence and attestation files", %{workdir: workdir} do
+      secret = "file-sourced-secret-value"
+      occ = make_occurrence("run-secret", "ci.run.failed", "failure")
+
+      graph = %{
+        "build" => %{command: "deploy --token #{secret}", container: nil, outputs: []}
+      }
+
+      error = %Sykli.Error{
+        code: "task_failed",
+        message: "command printed #{secret}",
+        output: "stderr contained #{secret}",
+        exit_code: 1
+      }
+
+      results =
+        {:error,
+         [
+           %TaskResult{
+             name: "build",
+             status: :failed,
+             duration_ms: 100,
+             error: error,
+             output: "stderr contained #{secret}",
+             secret_values: [secret]
+           }
+         ]}
+
+      Application.put_env(:sykli, :notification_service, NotificationProbe)
+      Application.put_env(:sykli, :notification_test_pid, self())
+
+      assert :ok = Enrichment.enrich_and_persist(occ, graph, results, workdir)
+
+      occurrence = Path.join([workdir, ".sykli", "occurrence.json"]) |> File.read!()
+      refute occurrence =~ secret
+      assert occurrence =~ "***MASKED***"
+
+      assert_received {:notification, payload}
+      payload_json = Jason.encode!(payload)
+      refute payload_json =~ secret
+      assert payload_json =~ "***MASKED***"
+
+      envelope =
+        Path.join([workdir, ".sykli", "attestation.json"])
+        |> File.read!()
+        |> Jason.decode!()
+
+      assert {:ok, attestation} = Sykli.Attestation.Envelope.decode_payload(envelope)
+      attestation_json = Jason.encode!(attestation)
+
+      refute attestation_json =~ secret
+      assert attestation_json =~ "***MASKED***"
     end
   end
 

--- a/core/test/sykli/outbox_test.exs
+++ b/core/test/sykli/outbox_test.exs
@@ -74,4 +74,21 @@ defmodule Sykli.OutboxTest do
     assert {:error, :team_outbox_invalid_kind} =
              Sykli.Outbox.enqueue("../runs", @payload, path: tmp_dir)
   end
+
+  test "enqueue masks explicit run secrets before writing payload", %{tmp_dir: tmp_dir} do
+    payload = %{
+      "version" => "1",
+      "run" => %{"id" => "run_secret", "error_code" => "leaked-from-output"},
+      "nodes" => [%{"name" => "build", "message" => "token leaked-from-output"}]
+    }
+
+    assert :ok =
+             Sykli.Outbox.enqueue("runs", payload, path: tmp_dir, secrets: ["leaked-from-output"])
+
+    path = Path.join([tmp_dir, ".sykli", "outbox", "runs", "run_secret.json"])
+    decoded = path |> File.read!() |> Jason.decode!()
+
+    assert decoded["run"]["error_code"] == "***MASKED***"
+    assert decoded["nodes"] == [%{"name" => "build", "message" => "token ***MASKED***"}]
+  end
 end

--- a/core/test/sykli/services/secret_masker_test.exs
+++ b/core/test/sykli/services/secret_masker_test.exs
@@ -50,8 +50,24 @@ defmodule Sykli.Services.SecretMaskerTest do
     end
 
     test "handles empty secrets list" do
-      data = %{"a" => "b"}
+      data = %{"detail" => "b"}
       assert SecretMasker.mask_deep(data, []) == data
+    end
+
+    test "redacts values under secret-like keys even without known secret values" do
+      data = %{
+        "password" => "literal-from-config",
+        :api_key => "atom-key-secret",
+        "nested" => %{"DATABASE_URL" => "postgres://user:pass@example/db"},
+        "details" => "literal-from-config"
+      }
+
+      result = SecretMasker.mask_deep(data, [])
+
+      assert result["password"] == "***MASKED***"
+      assert result[:api_key] == "***MASKED***"
+      assert result["nested"]["DATABASE_URL"] == "***MASKED***"
+      assert result["details"] == "literal-from-config"
     end
 
     test "masks strings in deeply nested structures (map inside list inside map)" do
@@ -122,13 +138,13 @@ defmodule Sykli.Services.SecretMaskerTest do
     end
 
     test "handles list of mixed types" do
-      data = ["text with secret_value_here", 42, nil, %{"key" => "has secret_value_here too"}]
+      data = ["text with secret_value_here", 42, nil, %{"detail" => "has secret_value_here too"}]
       result = SecretMasker.mask_deep(data, ["secret_value_here"])
 
       assert Enum.at(result, 0) == "text with ***MASKED***"
       assert Enum.at(result, 1) == 42
       assert Enum.at(result, 2) == nil
-      assert Enum.at(result, 3) == %{"key" => "has ***MASKED*** too"}
+      assert Enum.at(result, 3) == %{"detail" => "has ***MASKED*** too"}
     end
   end
 

--- a/core/test/sykli/team_coordinator/run_client_test.exs
+++ b/core/test/sykli/team_coordinator/run_client_test.exs
@@ -23,6 +23,24 @@ defmodule Sykli.TeamCoordinator.RunClientTest do
     assert_received {:post, "https://sykli.internal", "/v1/runs", "secret", %{"run" => _}}
   end
 
+  test "publish masks explicit secrets in encoded summary" do
+    summary =
+      struct!(RunSummary,
+        run: %{"id" => "run_001", "status" => "failed", "error_code" => "token leaked-value"},
+        nodes: [%{"name" => "build", "message" => "leaked-value"}]
+      )
+
+    assert {:ok, %{"id" => "run_001"}} =
+             RunClient.publish(@session, "secret", summary,
+               client: __MODULE__.FakeClient,
+               secrets: ["leaked-value"]
+             )
+
+    assert_received {:post, _, _, _, body}
+    assert body["run"]["error_code"] == "token ***MASKED***"
+    assert body["nodes"] == [%{"name" => "build", "message" => "***MASKED***"}]
+  end
+
   test "publish_raw list and show use run endpoints" do
     assert {:ok, %{"id" => "run_001"}} =
              RunClient.publish_raw(@session, "secret", @payload, client: __MODULE__.FakeClient)


### PR DESCRIPTION
## Summary
- collect per-run resolved secret values from literal secret-like task env, secret_refs, and OIDC credentials
- centralize secret-pattern matching and redact structured values under secret-like keys
- apply engine-env plus run-scoped masking to occurrences, notifications, attestations, run summaries, and outbox payloads
- rebased onto current main after C2 (#219) so the PR includes the latest coordinator authz baseline

## Review fixes
- added OIDC credential collection coverage using an injected fake OIDC service
- added a full egress regression test that runs a pipeline and asserts file/literal/OIDC secrets are masked in .sykli/occurrence.json, notification webhook payload, run-summary HTTP wire body, and attestation.json
- confirmed key-name redaction is already covered by SecretMaskerTest
- added a collection-site comment marking the task.env injection contract

## Verification
- cd core && mix format
- cd core && mix test (1770 tests, 0 failures, 1 skipped, 13 excluded)
- cd core && mix credo
- cd core && mix escript.build
- test/blackbox/run.sh (168 passed, 0 expected-red, 0 failed)

## Audit note
Verified S3 against current code: occurrence enrichment and outbox only collected engine env values, while secret_refs, OIDC credentials, and literal task env secrets were injected at execution time and not threaded into masking boundaries.