### PR TITLE
fix(team): enforce per-team coordinator authz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-team coordinator authorization (Monster Phase C, C2).** The
+  self-hosted coordinator now supports stateless signed team tokens via
+  `sykli coordinator mint-token --org <slug> --team <slug> --role
+  <role>`. The existing coordinator token remains the admin bootstrap
+  token, while team tokens are scoped to their org/team and role.
 - **Monster Phase A CI foundation.** CI now runs the full evaluation pyramid:
   Credo, black-box CLI tests, cross-SDK conformance, and merge-to-main oracle
   evals. Local developers can reproduce the same path with `cd core && mix verify`
@@ -43,6 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Coordinator team isolation is enforced (Monster Phase C, C2).** Team
+  tokens can no longer widen list filters or read/mutate another team's
+  work items, run summaries, gates, or daemon sessions. Gate decisions
+  require `owner` or `approver`; `member` tokens receive
+  `coordinator.forbidden`.
 - **Runtime trust model documented; GH-004 reframed (Monster Phase C, C5).** New
   `docs/runtime-trust-model.md` states the trust boundary: the Shell runtime is
   **not** a security sandbox (it runs trusted repository code with the invoking

--- a/core/lib/sykli/cli/coordinator.ex
+++ b/core/lib/sykli/cli/coordinator.ex
@@ -9,6 +9,7 @@ defmodule Sykli.CLI.Coordinator do
   alias Sykli.CLI.JsonResponse
   alias Sykli.Error
   alias Sykli.Error.Formatter
+  alias Sykli.TeamCoordinator.Auth
 
   @default_port 8620
   @default_bind "127.0.0.1"
@@ -21,6 +22,9 @@ defmodule Sykli.CLI.Coordinator do
 
       {:ok, :start, opts} ->
         start(opts)
+
+      {:ok, :mint_token, opts} ->
+        mint_token(opts)
 
       {:error, reason, opts} ->
         output_error(reason, Keyword.get(opts, :json, false))
@@ -75,6 +79,9 @@ defmodule Sykli.CLI.Coordinator do
       positionals == ["start"] ->
         {:ok, :start, opts}
 
+      positionals == ["mint-token"] ->
+        {:ok, :mint_token, opts}
+
       true ->
         {:error, {:invalid_coordinator_command, Enum.join(positionals, " ")}, opts}
     end
@@ -110,6 +117,24 @@ defmodule Sykli.CLI.Coordinator do
   defp parse_flags([<<"--token=", value::binary>> | rest], opts, positionals),
     do: parse_flags(rest, [{:token, value} | opts], positionals)
 
+  defp parse_flags(["--org", value | rest], opts, positionals),
+    do: parse_flags(rest, [{:org, value} | opts], positionals)
+
+  defp parse_flags([<<"--org=", value::binary>> | rest], opts, positionals),
+    do: parse_flags(rest, [{:org, value} | opts], positionals)
+
+  defp parse_flags(["--team", value | rest], opts, positionals),
+    do: parse_flags(rest, [{:team, value} | opts], positionals)
+
+  defp parse_flags([<<"--team=", value::binary>> | rest], opts, positionals),
+    do: parse_flags(rest, [{:team, value} | opts], positionals)
+
+  defp parse_flags(["--role", value | rest], opts, positionals),
+    do: parse_flags(rest, [{:role, value} | opts], positionals)
+
+  defp parse_flags([<<"--role=", value::binary>> | rest], opts, positionals),
+    do: parse_flags(rest, [{:role, value} | opts], positionals)
+
   defp parse_flags([<<"--", _::binary>> = flag | rest], opts, positionals) do
     opts =
       if "--json" in rest do
@@ -128,6 +153,36 @@ defmodule Sykli.CLI.Coordinator do
     case Keyword.get(opts, :token) || System.get_env("SYKLI_COORDINATOR_TOKEN") do
       value when is_binary(value) and value != "" -> {:ok, value}
       _ -> {:error, :coordinator_token_required}
+    end
+  end
+
+  defp mint_token(opts) do
+    json? = Keyword.get(opts, :json, false)
+
+    with {:ok, admin_token} <- token(opts),
+         {:ok, org} <- required_option(opts, :org),
+         {:ok, team} <- required_option(opts, :team),
+         {:ok, role} <- required_option(opts, :role),
+         {:ok, token} <-
+           Auth.mint_team_token(%{"org" => org, "team" => team, "role" => role},
+             token: admin_token
+           ) do
+      if json? do
+        IO.puts(JsonResponse.ok(%{token: token, org: org, team: team, role: role}))
+      else
+        IO.puts(token)
+      end
+
+      0
+    else
+      {:error, reason} -> output_error(reason, json?)
+    end
+  end
+
+  defp required_option(opts, key) do
+    case Keyword.get(opts, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, {:missing_coordinator_option, key}}
     end
   end
 
@@ -174,6 +229,26 @@ defmodule Sykli.CLI.Coordinator do
       message: "coordinator start requires a token",
       step: :setup,
       hints: ["set SYKLI_COORDINATOR_TOKEN or pass --token <token>"]
+    }
+  end
+
+  defp coordinator_error({:missing_coordinator_option, key}) do
+    %Error{
+      code: "coordinator.invalid_command",
+      type: :validation,
+      message: "missing coordinator option: --#{String.replace(to_string(key), "_", "-")}",
+      step: :validate,
+      hints: ["use: sykli coordinator mint-token --org <slug> --team <slug> --role <role>"]
+    }
+  end
+
+  defp coordinator_error(:coordinator_invalid_token_claims) do
+    %Error{
+      code: "coordinator.invalid_command",
+      type: :validation,
+      message: "invalid coordinator token claims",
+      step: :validate,
+      hints: ["role must be one of: owner, member, approver"]
     }
   end
 
@@ -246,10 +321,14 @@ defmodule Sykli.CLI.Coordinator do
 
     Commands:
       sykli coordinator start --token TOKEN [--port PORT] [--bind ADDRESS]
+      sykli coordinator mint-token --org ORG --team TEAM --role ROLE --token TOKEN
 
     Options:
       --json          Output startup status as JSON before serving
       --token TOKEN   Bearer token required for non-health API endpoints
+      --org ORG       Org slug for mint-token
+      --team TEAM     Team slug for mint-token
+      --role ROLE     Team token role: owner, member, or approver
       --port PORT     HTTP port (default: #{@default_port})
       --bind ADDRESS  Listen address (default: #{@default_bind}; use 0.0.0.0 only intentionally)
 

--- a/core/lib/sykli/team_coordinator/auth.ex
+++ b/core/lib/sykli/team_coordinator/auth.ex
@@ -1,12 +1,23 @@
 defmodule Sykli.TeamCoordinator.Auth do
   @moduledoc """
-  Minimal bearer-token auth for the self-hosted Team Mode coordinator.
+  Bearer-token auth for the self-hosted Team Mode coordinator.
 
-  This is intentionally small: Phase 4 only needs an authenticated API
-  boundary. Team tokens, OIDC, GitHub org mapping, and RBAC are future layers.
+  The configured coordinator token is the admin bootstrap token. Team-scoped
+  tokens are stateless HMAC-signed claims bound to an org, team, and role.
   """
 
   import Plug.Conn
+
+  @team_token_prefix "sykli_team_"
+  @version "1"
+  @roles ~w(owner member approver)
+
+  defmodule Principal do
+    @moduledoc false
+
+    @enforce_keys [:type, :role]
+    defstruct [:type, :role, :org, :team]
+  end
 
   @doc "Returns the configured coordinator token from opts, app env, or env var."
   def token(opts \\ []) do
@@ -17,18 +28,52 @@ defmodule Sykli.TeamCoordinator.Auth do
     end
   end
 
-  @doc "Checks whether the request carries the configured bearer token."
+  @doc "Checks whether the request carries a valid bearer token."
   def authorize(%Plug.Conn{} = conn, opts \\ []) do
     with {:ok, expected} <- token(opts),
-         {:ok, actual} <- bearer_token(conn),
-         true <- secure_equal?(actual, expected) do
-      :ok
+         {:ok, actual} <- bearer_token(conn) do
+      cond do
+        secure_equal?(actual, expected) ->
+          {:ok, %Principal{type: :admin, role: "owner"}}
+
+        true ->
+          verify_team_token(actual, expected)
+      end
     else
       {:error, :missing_token_config} -> {:error, :coordinator_auth_not_configured}
       {:error, reason} -> {:error, reason}
-      false -> {:error, :coordinator_unauthorized}
     end
   end
+
+  def mint_team_token(claims, opts \\ []) when is_map(claims) do
+    with {:ok, secret} <- token(opts),
+         {:ok, normalized} <- normalize_claims(claims),
+         {:ok, claims_json} <- Jason.encode(normalized) do
+      encoded_claims = Base.url_encode64(claims_json, padding: false)
+      signature = sign(encoded_claims, secret)
+      {:ok, @team_token_prefix <> encoded_claims <> "." <> signature}
+    end
+  end
+
+  def verify_team_token(@team_token_prefix <> token, secret) when is_binary(secret) do
+    with [encoded_claims, signature] <- String.split(token, ".", parts: 2),
+         true <- valid_signature?(encoded_claims, signature, secret),
+         {:ok, claims_json} <- Base.url_decode64(encoded_claims, padding: false),
+         {:ok, claims} <- Jason.decode(claims_json),
+         {:ok, claims} <- normalize_claims(claims) do
+      {:ok,
+       %Principal{
+         type: :team,
+         org: claims["org"],
+         team: claims["team"],
+         role: claims["role"]
+       }}
+    else
+      _ -> {:error, :coordinator_unauthorized}
+    end
+  end
+
+  def verify_team_token(_token, _secret), do: {:error, :coordinator_unauthorized}
 
   defp bearer_token(conn) do
     case get_req_header(conn, "authorization") do
@@ -43,4 +88,42 @@ defmodule Sykli.TeamCoordinator.Auth do
   end
 
   defp secure_equal?(_left, _right), do: false
+
+  defp normalize_claims(claims) do
+    with {:ok, org} <- required_claim(claims, "org"),
+         {:ok, team} <- required_claim(claims, "team"),
+         {:ok, role} <- required_claim(claims, "role"),
+         :ok <- validate_role(role) do
+      {:ok,
+       %{
+         "version" => Map.get(claims, "version", @version),
+         "org" => org,
+         "team" => team,
+         "role" => role
+       }}
+    end
+  end
+
+  defp required_claim(claims, key) do
+    case Map.get(claims, key) || Map.get(claims, String.to_atom(key)) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, :coordinator_invalid_token_claims}
+    end
+  end
+
+  defp validate_role(role) when role in @roles, do: :ok
+  defp validate_role(_role), do: {:error, :coordinator_invalid_token_claims}
+
+  defp sign(encoded_claims, secret) do
+    :hmac
+    |> :crypto.mac(:sha256, secret, encoded_claims)
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp valid_signature?(encoded_claims, signature, secret) when is_binary(signature) do
+    expected = sign(encoded_claims, secret)
+    secure_equal?(signature, expected)
+  end
+
+  defp valid_signature?(_encoded_claims, _signature, _secret), do: false
 end

--- a/core/lib/sykli/team_coordinator/router.ex
+++ b/core/lib/sykli/team_coordinator/router.ex
@@ -11,6 +11,7 @@ defmodule Sykli.TeamCoordinator.Router do
 
   alias Sykli.CLI.JsonResponse
   alias Sykli.TeamCoordinator.{Auth, Store}
+  alias Sykli.TeamCoordinator.Auth.Principal
   alias Sykli.Error
 
   @max_body_bytes 1_000_000
@@ -24,8 +25,9 @@ defmodule Sykli.TeamCoordinator.Router do
   end
 
   def call(%Plug.Conn{path_info: ["v1" | _]} = conn, opts) do
-    with :ok <- Auth.authorize(conn, opts) do
-      route_v1(conn, opts)
+    with {:ok, principal} <- Auth.authorize(conn, opts),
+         {:ok, scope} <- principal_scope(principal, opts) do
+      route_v1(conn, opts, scope)
     else
       {:error, reason} -> send_error(conn, reason)
     end
@@ -33,8 +35,9 @@ defmodule Sykli.TeamCoordinator.Router do
 
   def call(conn, _opts), do: send_error(conn, :coordinator_route_not_found)
 
-  defp route_v1(%Plug.Conn{method: "POST", path_info: ["v1", "orgs"]} = conn, opts) do
-    with {:ok, body, conn} <- read_json(conn),
+  defp route_v1(%Plug.Conn{method: "POST", path_info: ["v1", "orgs"]} = conn, opts, scope) do
+    with :ok <- require_admin(scope),
+         {:ok, body, conn} <- read_json(conn),
          {:ok, org} <- Store.create_org(store(opts), body) do
       send_json(conn, 201, %{org: org})
     else
@@ -42,14 +45,18 @@ defmodule Sykli.TeamCoordinator.Router do
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "orgs"]} = conn, opts) do
-    with {:ok, orgs} <- Store.list_orgs(store(opts)) do
+  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "orgs"]} = conn, opts, scope) do
+    with :ok <- require_admin(scope),
+         {:ok, orgs} <- Store.list_orgs(store(opts)) do
       send_json(conn, 200, %{items: orgs})
+    else
+      {:error, reason} -> send_error(conn, reason)
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "POST", path_info: ["v1", "teams"]} = conn, opts) do
-    with {:ok, body, conn} <- read_json(conn),
+  defp route_v1(%Plug.Conn{method: "POST", path_info: ["v1", "teams"]} = conn, opts, scope) do
+    with :ok <- require_admin(scope),
+         {:ok, body, conn} <- read_json(conn),
          {:ok, team} <- Store.create_team(store(opts), body) do
       send_json(conn, 201, %{team: team})
     else
@@ -57,13 +64,16 @@ defmodule Sykli.TeamCoordinator.Router do
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "teams"]} = conn, opts) do
-    with {:ok, teams} <- Store.list_teams(store(opts)) do
+  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "teams"]} = conn, opts, scope) do
+    with :ok <- require_admin(scope),
+         {:ok, teams} <- Store.list_teams(store(opts)) do
       send_json(conn, 200, %{items: teams})
+    else
+      {:error, reason} -> send_error(conn, reason)
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "work-items"]} = conn, opts) do
+  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "work-items"]} = conn, opts, scope) do
     conn = fetch_query_params(conn)
 
     filters =
@@ -72,13 +82,17 @@ defmodule Sykli.TeamCoordinator.Router do
       |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
       |> Map.new()
 
-    with {:ok, items} <- Store.list_work_items(store(opts), filters) do
+    with {:ok, filters} <- scope_filters(scope, filters),
+         {:ok, items} <- Store.list_work_items(store(opts), filters) do
       send_json(conn, 200, %{items: items})
+    else
+      {:error, reason} -> send_error(conn, reason)
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "POST", path_info: ["v1", "runs"]} = conn, opts) do
+  defp route_v1(%Plug.Conn{method: "POST", path_info: ["v1", "runs"]} = conn, opts, scope) do
     with {:ok, body, conn} <- read_run_json(conn),
+         :ok <- authorize_payload_team(scope, Map.get(body, "run", %{})),
          {:ok, run, mode} <- Store.record_run(store(opts), body) do
       status = if mode == :inserted, do: 201, else: 200
       send_json(conn, status, %{run: run})
@@ -87,30 +101,35 @@ defmodule Sykli.TeamCoordinator.Router do
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "runs"]} = conn, opts) do
+  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "runs"]} = conn, opts, scope) do
     conn = fetch_query_params(conn)
 
     filters =
       conn.query_params
-      |> Map.take(["team_id", "work_item_id", "status"])
+      |> Map.take(["org_id", "team_id", "work_item_id", "status"])
       |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
       |> Map.new()
 
-    with {:ok, runs} <- Store.list_runs(store(opts), filters) do
+    with {:ok, filters} <- scope_filters(scope, filters),
+         {:ok, runs} <- Store.list_runs(store(opts), filters) do
       send_json(conn, 200, %{items: runs})
+    else
+      {:error, reason} -> send_error(conn, reason)
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "runs", id]} = conn, opts) do
-    with {:ok, run} <- Store.get_run(store(opts), id) do
+  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "runs", id]} = conn, opts, scope) do
+    with {:ok, run} <- Store.get_run(store(opts), id),
+         :ok <- authorize_resource(scope, run["run"]) do
       send_json(conn, 200, run)
     else
       {:error, reason} -> send_error(conn, reason)
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "POST", path_info: ["v1", "gates"]} = conn, opts) do
+  defp route_v1(%Plug.Conn{method: "POST", path_info: ["v1", "gates"]} = conn, opts, scope) do
     with {:ok, body, conn} <- read_gate_json(conn),
+         :ok <- authorize_payload_team(scope, body),
          {:ok, gate, mode} <- Store.upsert_gate(store(opts), body) do
       status = if mode == :inserted, do: 201, else: 200
       send_json(conn, status, %{gate: gate})
@@ -119,7 +138,7 @@ defmodule Sykli.TeamCoordinator.Router do
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "gates"]} = conn, opts) do
+  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "gates"]} = conn, opts, scope) do
     conn = fetch_query_params(conn)
 
     filters =
@@ -128,15 +147,17 @@ defmodule Sykli.TeamCoordinator.Router do
       |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
       |> Map.new()
 
-    with {:ok, gates} <- Store.list_gates(store(opts), filters) do
+    with {:ok, filters} <- scope_filters(scope, filters),
+         {:ok, gates} <- Store.list_gates(store(opts), filters) do
       send_json(conn, 200, %{items: gates})
     else
       {:error, reason} -> send_error(conn, reason)
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "gates", id]} = conn, opts) do
-    with {:ok, gate} <- Store.get_gate(store(opts), id) do
+  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "gates", id]} = conn, opts, scope) do
+    with {:ok, gate} <- Store.get_gate(store(opts), id),
+         :ok <- authorize_resource(scope, gate) do
       send_json(conn, 200, %{gate: gate})
     else
       {:error, reason} -> send_error(conn, reason)
@@ -145,9 +166,14 @@ defmodule Sykli.TeamCoordinator.Router do
 
   defp route_v1(
          %Plug.Conn{method: "POST", path_info: ["v1", "gates", id, "decisions"]} = conn,
-         opts
+         opts,
+         scope
        ) do
-    with {:ok, body, conn} <- read_gate_json(conn),
+    with :ok <- require_gate_decider(scope),
+         {:ok, gate} <- Store.get_gate(store(opts), id),
+         :ok <- authorize_resource(scope, gate),
+         {:ok, body, conn} <- read_gate_json(conn),
+         :ok <- authorize_payload_team(scope, body),
          {:ok, gate} <- Store.record_gate_decision(store(opts), id, body) do
       send_json(conn, 200, %{gate: gate})
     else
@@ -155,8 +181,9 @@ defmodule Sykli.TeamCoordinator.Router do
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "POST", path_info: ["v1", "work-items"]} = conn, opts) do
+  defp route_v1(%Plug.Conn{method: "POST", path_info: ["v1", "work-items"]} = conn, opts, scope) do
     with {:ok, body, conn} <- read_json(conn),
+         :ok <- authorize_payload_team(scope, body),
          {:ok, item} <- Store.create_work_item(store(opts), body) do
       send_json(conn, 201, %{work_item: item})
     else
@@ -164,8 +191,13 @@ defmodule Sykli.TeamCoordinator.Router do
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "work-items", id]} = conn, opts) do
-    with {:ok, item} <- Store.get_work_item(store(opts), id) do
+  defp route_v1(
+         %Plug.Conn{method: "GET", path_info: ["v1", "work-items", id]} = conn,
+         opts,
+         scope
+       ) do
+    with {:ok, item} <- Store.get_work_item(store(opts), id),
+         :ok <- authorize_resource(scope, item) do
       send_json(conn, 200, %{work_item: item})
     else
       {:error, reason} -> send_error(conn, reason)
@@ -174,9 +206,12 @@ defmodule Sykli.TeamCoordinator.Router do
 
   defp route_v1(
          %Plug.Conn{method: "POST", path_info: ["v1", "work-items", id, "claim"]} = conn,
-         opts
+         opts,
+         scope
        ) do
-    with {:ok, body, conn} <- read_json(conn),
+    with {:ok, item} <- Store.get_work_item(store(opts), id),
+         :ok <- authorize_resource(scope, item),
+         {:ok, body, conn} <- read_json(conn),
          {:ok, item} <- Store.claim_work_item(store(opts), id, body) do
       send_json(conn, 200, %{work_item: item})
     else
@@ -186,9 +221,12 @@ defmodule Sykli.TeamCoordinator.Router do
 
   defp route_v1(
          %Plug.Conn{method: "POST", path_info: ["v1", "work-items", id, "notes"]} = conn,
-         opts
+         opts,
+         scope
        ) do
-    with {:ok, body, conn} <- read_json(conn),
+    with {:ok, item} <- Store.get_work_item(store(opts), id),
+         :ok <- authorize_resource(scope, item),
+         {:ok, body, conn} <- read_json(conn),
          {:ok, note} <- Store.add_note(store(opts), id, body) do
       send_json(conn, 201, %{note: note})
     else
@@ -196,8 +234,13 @@ defmodule Sykli.TeamCoordinator.Router do
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "POST", path_info: ["v1", "daemon-sessions"]} = conn, opts) do
+  defp route_v1(
+         %Plug.Conn{method: "POST", path_info: ["v1", "daemon-sessions"]} = conn,
+         opts,
+         scope
+       ) do
     with {:ok, body, conn} <- read_json(conn),
+         :ok <- authorize_payload_team(scope, body),
          {:ok, response, _session} <- Store.create_daemon_session(store(opts), body) do
       send_json(conn, 201, response)
     else
@@ -205,7 +248,11 @@ defmodule Sykli.TeamCoordinator.Router do
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "daemon-sessions"]} = conn, opts) do
+  defp route_v1(
+         %Plug.Conn{method: "GET", path_info: ["v1", "daemon-sessions"]} = conn,
+         opts,
+         scope
+       ) do
     conn = fetch_query_params(conn)
 
     filters =
@@ -214,13 +261,21 @@ defmodule Sykli.TeamCoordinator.Router do
       |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
       |> Map.new()
 
-    with {:ok, sessions} <- Store.list_daemon_sessions(store(opts), filters) do
+    with {:ok, filters} <- scope_filters(scope, filters),
+         {:ok, sessions} <- Store.list_daemon_sessions(store(opts), filters) do
       send_json(conn, 200, %{items: sessions})
+    else
+      {:error, reason} -> send_error(conn, reason)
     end
   end
 
-  defp route_v1(%Plug.Conn{method: "GET", path_info: ["v1", "daemon-sessions", id]} = conn, opts) do
-    with {:ok, session} <- Store.get_daemon_session(store(opts), id) do
+  defp route_v1(
+         %Plug.Conn{method: "GET", path_info: ["v1", "daemon-sessions", id]} = conn,
+         opts,
+         scope
+       ) do
+    with {:ok, session} <- Store.get_daemon_session(store(opts), id),
+         :ok <- authorize_resource(scope, session) do
       send_json(conn, 200, %{daemon_session: session})
     else
       {:error, reason} -> send_error(conn, reason)
@@ -230,9 +285,12 @@ defmodule Sykli.TeamCoordinator.Router do
   defp route_v1(
          %Plug.Conn{method: "POST", path_info: ["v1", "daemon-sessions", id, "heartbeat"]} =
            conn,
-         opts
+         opts,
+         scope
        ) do
-    with {:ok, body, conn} <- read_json(conn),
+    with {:ok, session} <- Store.get_daemon_session(store(opts), id),
+         :ok <- authorize_resource(scope, session),
+         {:ok, body, conn} <- read_json(conn),
          {:ok, heartbeat, _session} <- Store.heartbeat_daemon_session(store(opts), id, body) do
       send_json(conn, 200, heartbeat)
     else
@@ -240,7 +298,7 @@ defmodule Sykli.TeamCoordinator.Router do
     end
   end
 
-  defp route_v1(conn, _opts), do: send_error(conn, :coordinator_route_not_found)
+  defp route_v1(conn, _opts, _scope), do: send_error(conn, :coordinator_route_not_found)
 
   defp read_json(conn) do
     case read_body(conn, length: @max_body_bytes, read_timeout: @read_timeout_ms) do
@@ -291,8 +349,81 @@ defmodule Sykli.TeamCoordinator.Router do
 
   defp store(opts), do: Keyword.fetch!(opts, :store)
 
+  defp principal_scope(%Principal{type: :admin}, _opts), do: {:ok, :admin}
+
+  defp principal_scope(%Principal{type: :team, org: org, team: team, role: role}, opts) do
+    with {:ok, scope} <- Store.resolve_team(store(opts), org, team) do
+      {:ok, Map.put(scope, "role", role)}
+    end
+  end
+
+  defp require_admin(:admin), do: :ok
+  defp require_admin(_scope), do: {:error, :coordinator_forbidden}
+
+  defp require_gate_decider(:admin), do: :ok
+
+  defp require_gate_decider(%{"role" => role}) when role in ["owner", "approver"], do: :ok
+  defp require_gate_decider(_scope), do: {:error, :coordinator_forbidden}
+
+  defp scope_filters(:admin, filters), do: {:ok, filters}
+
+  defp scope_filters(scope, filters) do
+    with :ok <- authorize_payload_team(scope, filters) do
+      {:ok,
+       filters
+       |> Map.delete("org_slug")
+       |> Map.delete("team_slug")
+       |> Map.put("org_id", scope["org_id"])
+       |> Map.put("team_id", scope["team_id"])}
+    end
+  end
+
+  defp authorize_resource(:admin, _resource), do: :ok
+
+  defp authorize_resource(scope, resource) when is_map(resource) do
+    if Map.get(resource, "org_id") == scope["org_id"] and
+         Map.get(resource, "team_id") == scope["team_id"] do
+      :ok
+    else
+      {:error, :coordinator_forbidden}
+    end
+  end
+
+  defp authorize_resource(_scope, _resource), do: {:error, :coordinator_forbidden}
+
+  defp authorize_payload_team(:admin, _payload), do: :ok
+
+  defp authorize_payload_team(scope, payload) when is_map(payload) do
+    checks = [
+      {"org_id", scope["org_id"]},
+      {"team_id", scope["team_id"]},
+      {"org_slug", scope["org_slug"]},
+      {"team_slug", scope["team_slug"]},
+      {"org", scope["org_slug"]},
+      {"team", scope["team_slug"]}
+    ]
+
+    if Enum.all?(checks, fn {key, expected} -> absent_or_equal?(payload, key, expected) end) do
+      :ok
+    else
+      {:error, :coordinator_forbidden}
+    end
+  end
+
+  defp authorize_payload_team(_scope, _payload), do: {:error, :coordinator_forbidden}
+
+  defp absent_or_equal?(payload, key, expected) do
+    case Map.get(payload, key) do
+      nil -> true
+      "" -> true
+      ^expected -> true
+      _other -> false
+    end
+  end
+
   defp status_for(:coordinator_unauthorized), do: 401
   defp status_for(:coordinator_malformed_auth), do: 401
+  defp status_for(:coordinator_forbidden), do: 403
   defp status_for(:coordinator_auth_not_configured), do: 503
   defp status_for(:coordinator_invalid_json), do: 400
   defp status_for(:coordinator_invalid_payload), do: 400
@@ -336,6 +467,9 @@ defmodule Sykli.TeamCoordinator.Router do
 
   defp coordinator_error(:coordinator_auth_not_configured),
     do: error("coordinator.auth_not_configured", "coordinator auth token is not configured")
+
+  defp coordinator_error(:coordinator_forbidden),
+    do: error("coordinator.forbidden", "token is not authorized for this team resource")
 
   defp coordinator_error(:coordinator_invalid_json),
     do: error("coordinator.invalid_json", "request body is not valid JSON")

--- a/core/lib/sykli/team_coordinator/store.ex
+++ b/core/lib/sykli/team_coordinator/store.ex
@@ -26,6 +26,10 @@ defmodule Sykli.TeamCoordinator.Store do
   def list_orgs(server), do: GenServer.call(server, :list_orgs)
   def create_team(server, attrs), do: GenServer.call(server, {:create_team, attrs})
   def list_teams(server), do: GenServer.call(server, :list_teams)
+
+  def resolve_team(server, org_slug, team_slug),
+    do: GenServer.call(server, {:resolve_team, org_slug, team_slug})
+
   def create_work_item(server, attrs), do: GenServer.call(server, {:create_work_item, attrs})
 
   def list_work_items(server, filters \\ %{}),
@@ -139,6 +143,22 @@ defmodule Sykli.TeamCoordinator.Store do
 
   def handle_call(:list_teams, _from, state) do
     {:reply, {:ok, sorted_values(state.teams)}, state}
+  end
+
+  def handle_call({:resolve_team, org_slug, team_slug}, _from, state) do
+    result =
+      with {:ok, org_id} <- org_id(state, %{"org_slug" => org_slug}),
+           {:ok, team_id} <- team_id(state, %{"team_slug" => team_slug}, org_id) do
+        {:ok,
+         %{
+           "org_id" => org_id,
+           "team_id" => team_id,
+           "org_slug" => org_slug,
+           "team_slug" => team_slug
+         }}
+      end
+
+    {:reply, result, state}
   end
 
   def handle_call({:create_work_item, attrs}, _from, state) do
@@ -374,7 +394,8 @@ defmodule Sykli.TeamCoordinator.Store do
       |> Enum.filter(fn record ->
         run = record["run"]
 
-        filter_match?(run, "team_id", Map.get(filters, "team_id")) and
+        filter_match?(run, "org_id", Map.get(filters, "org_id")) and
+          filter_match?(run, "team_id", Map.get(filters, "team_id")) and
           filter_match?(run, "work_item_id", Map.get(filters, "work_item_id")) and
           filter_match?(run, "status", Map.get(filters, "status"))
       end)

--- a/core/test/sykli/cli/coordinator_test.exs
+++ b/core/test/sykli/cli/coordinator_test.exs
@@ -4,6 +4,7 @@ defmodule Sykli.CLI.CoordinatorTest do
   import ExUnit.CaptureIO
 
   alias Sykli.CLI.Coordinator
+  alias Sykli.TeamCoordinator.Auth
 
   test "help documents explicit bind behavior" do
     output = capture_io(fn -> assert Coordinator.run(["--help"]) == 0 end)
@@ -24,5 +25,32 @@ defmodule Sykli.CLI.CoordinatorTest do
              "ok" => false,
              "error" => %{"code" => "coordinator.invalid_bind"}
            } = Jason.decode!(output)
+  end
+
+  test "mint-token emits an admin-signed team token as JSON" do
+    output =
+      capture_io(fn ->
+        assert Coordinator.run([
+                 "mint-token",
+                 "--token",
+                 "admin-secret",
+                 "--org",
+                 "false-systems",
+                 "--team",
+                 "platform",
+                 "--role",
+                 "approver",
+                 "--json"
+               ]) == 0
+      end)
+
+    decoded = Jason.decode!(output)
+    token = decoded["data"]["token"]
+
+    assert decoded["data"]["role"] == "approver"
+    assert {:ok, principal} = Auth.verify_team_token(token, "admin-secret")
+    assert principal.org == "false-systems"
+    assert principal.team == "platform"
+    assert principal.role == "approver"
   end
 end

--- a/core/test/sykli/team_coordinator/auth_test.exs
+++ b/core/test/sykli/team_coordinator/auth_test.exs
@@ -30,7 +30,43 @@ defmodule Sykli.TeamCoordinator.AuthTest do
       |> conn("/v1/orgs")
       |> Plug.Conn.put_req_header("authorization", "Bearer secret")
 
-    assert :ok = Auth.authorize(conn, token: "secret")
+    assert {:ok, %{type: :admin, role: "owner"}} = Auth.authorize(conn, token: "secret")
+  end
+
+  test "mints and verifies team-scoped tokens" do
+    assert {:ok, token} =
+             Auth.mint_team_token(
+               %{"org" => "false-systems", "team" => "platform", "role" => "approver"},
+               token: "secret"
+             )
+
+    conn =
+      :get
+      |> conn("/v1/runs")
+      |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+
+    assert {:ok, principal} = Auth.authorize(conn, token: "secret")
+    assert principal.type == :team
+    assert principal.org == "false-systems"
+    assert principal.team == "platform"
+    assert principal.role == "approver"
+  end
+
+  test "rejects tampered team tokens" do
+    assert {:ok, token} =
+             Auth.mint_team_token(
+               %{"org" => "false-systems", "team" => "platform", "role" => "member"},
+               token: "secret"
+             )
+
+    tampered = token <> "x"
+
+    conn =
+      :get
+      |> conn("/v1/runs")
+      |> Plug.Conn.put_req_header("authorization", "Bearer #{tampered}")
+
+    assert {:error, :coordinator_unauthorized} = Auth.authorize(conn, token: "secret")
   end
 
   test "reports missing token configuration" do

--- a/core/test/sykli/team_coordinator/router_test.exs
+++ b/core/test/sykli/team_coordinator/router_test.exs
@@ -4,7 +4,7 @@ defmodule Sykli.TeamCoordinator.RouterTest do
   import Plug.Conn
   import Plug.Test
 
-  alias Sykli.TeamCoordinator.{Router, Store}
+  alias Sykli.TeamCoordinator.{Auth, Router, Store}
 
   @token "test-token"
   @now "2026-05-09T10:00:00Z"
@@ -280,6 +280,128 @@ defmodule Sykli.TeamCoordinator.RouterTest do
     assert [%{"name" => "test"}] = json(show)["data"]["nodes"]
   end
 
+  test "team tokens are scoped to their team for run endpoints" do
+    {:ok, store} =
+      Store.start_link(
+        now: fn -> @now end,
+        id:
+          id_sequence(
+            ~w(org_001 audit_001 team_001 audit_002 team_002 audit_003 audit_004 audit_005)
+          )
+      )
+
+    opts = [store: store, token: @token]
+
+    {:ok, _org} = Store.create_org(store, %{"slug" => "false-systems", "name" => "False Systems"})
+
+    {:ok, _team} =
+      Store.create_team(store, %{
+        "org_id" => "org_001",
+        "slug" => "platform",
+        "name" => "Platform"
+      })
+
+    {:ok, _other} =
+      Store.create_team(store, %{"org_id" => "org_001", "slug" => "infra", "name" => "Infra"})
+
+    {:ok, _run, :inserted} = Store.record_run(store, run_payload("run_platform", "platform"))
+    {:ok, _run, :inserted} = Store.record_run(store, run_payload("run_infra", "infra"))
+
+    {:ok, token} =
+      Auth.mint_team_token(%{"org" => "false-systems", "team" => "platform", "role" => "member"},
+        token: @token
+      )
+
+    own_list = :get |> authed_conn("/v1/runs?team_id=team_001", token) |> call(opts)
+    assert own_list.status == 200
+    assert [%{"id" => "run_platform"}] = json(own_list)["data"]["items"]
+
+    cross_list = :get |> authed_conn("/v1/runs?team_id=team_002", token) |> call(opts)
+    assert cross_list.status == 403
+    assert json(cross_list)["error"]["code"] == "coordinator.forbidden"
+
+    cross_show = :get |> authed_conn("/v1/runs/run_infra", token) |> call(opts)
+    assert cross_show.status == 403
+    assert json(cross_show)["error"]["code"] == "coordinator.forbidden"
+
+    admin_list = :get |> authed_conn("/v1/runs?team_id=team_002") |> call(opts)
+    assert admin_list.status == 200
+    assert [%{"id" => "run_infra"}] = json(admin_list)["data"]["items"]
+  end
+
+  test "team tokens cannot read other team work gates or daemon sessions" do
+    {:ok, store} =
+      Store.start_link(
+        now: fn -> @now end,
+        id:
+          id_sequence(
+            ~w(org_001 audit_001 team_001 audit_002 team_002 audit_003 work_001 audit_004 work_002 audit_005 sess_001 audit_006 sess_002 audit_007 audit_008 audit_009)
+          )
+      )
+
+    opts = [store: store, token: @token]
+    setup_two_teams!(store)
+
+    {:ok, _work} =
+      Store.create_work_item(store, %{
+        "org_id" => "org_001",
+        "team_id" => "team_001",
+        "title" => "Platform work"
+      })
+
+    {:ok, _other_work} =
+      Store.create_work_item(store, %{
+        "org_id" => "org_001",
+        "team_id" => "team_002",
+        "title" => "Infra work"
+      })
+
+    {:ok, _join, platform_session} =
+      Store.create_daemon_session(store, daemon_payload("daemon-platform", "platform"))
+
+    {:ok, _join, infra_session} =
+      Store.create_daemon_session(store, daemon_payload("daemon-infra", "infra"))
+
+    {:ok, _gate, :inserted} =
+      Store.upsert_gate(
+        store,
+        gate_payload("gate_platform", platform_session["session_id"], "platform")
+      )
+
+    {:ok, _gate, :inserted} =
+      Store.upsert_gate(store, gate_payload("gate_infra", infra_session["session_id"], "infra"))
+
+    {:ok, token} =
+      Auth.mint_team_token(%{"org" => "false-systems", "team" => "platform", "role" => "member"},
+        token: @token
+      )
+
+    for path <- [
+          "/v1/work-items?team_id=team_002",
+          "/v1/work-items/work_002",
+          "/v1/daemon-sessions?team_id=team_002",
+          "/v1/daemon-sessions/sess_002",
+          "/v1/gates?team_id=team_002",
+          "/v1/gates/gate_infra"
+        ] do
+      conn = :get |> authed_conn(path, token) |> call(opts)
+      assert conn.status == 403
+      assert json(conn)["error"]["code"] == "coordinator.forbidden"
+    end
+
+    member_decision =
+      :post
+      |> authed_json_conn(
+        "/v1/gates/gate_platform/decisions",
+        gate_decision_payload("platform"),
+        token
+      )
+      |> call(opts)
+
+    assert member_decision.status == 403
+    assert json(member_decision)["error"]["code"] == "coordinator.forbidden"
+  end
+
   test "publishes lists and decides gates through JSON API", %{opts: opts} do
     :post
     |> authed_json_conn("/v1/orgs", %{"slug" => "false-systems", "name" => "False Systems"})
@@ -400,9 +522,13 @@ defmodule Sykli.TeamCoordinator.RouterTest do
   end
 
   defp authed_conn(method, path) do
+    authed_conn(method, path, @token)
+  end
+
+  defp authed_conn(method, path, token) do
     method
     |> conn(path)
-    |> put_req_header("authorization", "Bearer #{@token}")
+    |> put_req_header("authorization", "Bearer #{token}")
   end
 
   defp json_conn(method, path, body) do
@@ -412,9 +538,81 @@ defmodule Sykli.TeamCoordinator.RouterTest do
   end
 
   defp authed_json_conn(method, path, body) do
+    authed_json_conn(method, path, body, @token)
+  end
+
+  defp authed_json_conn(method, path, body, token) do
     method
     |> json_conn(path, body)
-    |> put_req_header("authorization", "Bearer #{@token}")
+    |> put_req_header("authorization", "Bearer #{token}")
+  end
+
+  defp setup_two_teams!(store) do
+    {:ok, _org} = Store.create_org(store, %{"slug" => "false-systems", "name" => "False Systems"})
+
+    {:ok, _team} =
+      Store.create_team(store, %{
+        "org_id" => "org_001",
+        "slug" => "platform",
+        "name" => "Platform"
+      })
+
+    {:ok, _other} =
+      Store.create_team(store, %{"org_id" => "org_001", "slug" => "infra", "name" => "Infra"})
+  end
+
+  defp run_payload(id, team_slug) do
+    %{
+      "version" => "1",
+      "run" => %{
+        "id" => id,
+        "org_slug" => "false-systems",
+        "team_slug" => team_slug,
+        "status" => "passed"
+      },
+      "nodes" => [],
+      "criteria_results" => [],
+      "review_results" => [],
+      "gates" => [],
+      "evidence_refs" => []
+    }
+  end
+
+  defp daemon_payload(id, team) do
+    %{
+      "daemon_id" => id,
+      "org" => "false-systems",
+      "team" => team,
+      "labels" => ["local"],
+      "capabilities" => ["local"],
+      "version" => "0.6.1"
+    }
+  end
+
+  defp gate_payload(id, session_id, team_slug) do
+    %{
+      "org_slug" => "false-systems",
+      "team_slug" => team_slug,
+      "daemon_session_id" => session_id,
+      "id" => id,
+      "run_id" => "run_#{team_slug}",
+      "work_item_id" => nil,
+      "status" => "waiting",
+      "decided_by" => nil,
+      "decided_at" => nil,
+      "reason" => nil
+    }
+  end
+
+  defp gate_decision_payload(team_slug) do
+    %{
+      "org_slug" => "false-systems",
+      "team_slug" => team_slug,
+      "status" => "approved",
+      "decided_by" => "member:reviewer",
+      "decided_at" => "2026-05-09T10:05:00Z",
+      "reason" => "Reviewed"
+    }
   end
 
   defp json(conn), do: Jason.decode!(conn.resp_body)

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -32,6 +32,7 @@ surface is still young. They are emitted in the JSON envelope returned by
 | `coordinator.body_read_failed` | Plug failed to read the coordinator request body. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:194` |
 | `coordinator.duplicate_org_slug` | An org create request used an org slug that already exists. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:206` |
 | `coordinator.duplicate_team_slug` | A team create request used a team slug that already exists in the org. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:209` |
+| `coordinator.forbidden` | A valid coordinator token attempted to access or mutate a resource outside its authorized team scope. | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
 | `coordinator.daemon_session_not_found` | A daemon session lookup or heartbeat referenced a session that does not exist. | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
 | `coordinator.internal_error` | Fallback coordinator API error for an unexpected structured reason. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:227` |
 | `coordinator.invalid_assignment_type` | A work claim request used an unsupported assignment type. | public-unstable | `core/lib/sykli/team_coordinator/router.ex:221` |

--- a/docs/self-hosted-coordinator.md
+++ b/docs/self-hosted-coordinator.md
@@ -4,9 +4,10 @@
 
 Design and implementation reference for the Sykli Coordinator service.
 The initial skeleton is implemented with an in-memory store,
-bearer-token auth, org/team/work item endpoints, and daemon
-join/heartbeat endpoints. Durable Postgres storage, run sync, gate sync,
-and deployment manifests remain future implementation slices.
+admin bootstrap token auth, signed team tokens, org/team/work item
+endpoints, run sync, gate sync, and daemon join/heartbeat endpoints.
+Durable Postgres storage and deployment manifests remain future
+implementation slices.
 
 ## Product sentence
 
@@ -94,6 +95,26 @@ Properties:
 - **No execution on the coordinator.** It does not run user pipelines.
 - **One process surface.** All state is in one Postgres database. No
   Kafka, Redis, or external broker is required to start.
+
+## Authorization model
+
+`SYKLI_COORDINATOR_TOKEN` is the admin bootstrap token. It has owner
+access to all coordinator endpoints and is the signing secret used by
+`sykli coordinator mint-token`.
+
+Team tokens are stateless signed bearer tokens carrying `{org, team,
+role}` claims. The current token format has no expiry claim; rotation is
+done by rotating the coordinator token/signing secret. Roles are:
+
+- `owner` — team-scoped read/write access, including gate decisions.
+- `approver` — team-scoped access and gate decisions.
+- `member` — team-scoped work/run/session/gate access, but not gate
+  decisions.
+
+List endpoints are scoped to the token's team. If a team token supplies
+a conflicting `org_id`, `team_id`, `org_slug`, or `team_slug`, the API
+returns `403 coordinator.forbidden` instead of widening the query.
+Single-resource endpoints also enforce the stored resource's team.
 
 ## Coordinator responsibilities (v0)
 

--- a/docs/team-mode-security.md
+++ b/docs/team-mode-security.md
@@ -252,6 +252,21 @@ defaults silently.
   credentials live on the coordinator side only and are mounted from
   Kubernetes Secrets.
 
+## Coordinator authorization
+
+- `SYKLI_COORDINATOR_TOKEN` is the admin bootstrap token. It can create
+  orgs and teams, mint team tokens, and access all team-scoped
+  resources.
+- `sykli coordinator mint-token --org <slug> --team <slug> --role
+  <role>` creates stateless HMAC-signed team tokens. Claims are limited
+  to `{org, team, role}`; the current format has no expiry claim, so
+  rotation means rotating the coordinator signing secret.
+- Team tokens are enforced by the coordinator router. A token for team X
+  cannot list, read, create, or mutate team Y work items, run summaries,
+  gates, or daemon sessions.
+- Gate decisions require `owner` or `approver`. A `member` token can see
+  its team's gate state but cannot approve or reject a gate.
+
 ## Audit log
 
 Mandatory. Append-only. Written for at least:

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -1743,6 +1743,21 @@
       "validated_by": "Injected bug: missing coordinator session still creates a local .sykli work item."
     },
     {
+      "id": "COORD-005",
+      "name": "team token cannot widen coordinator run queries",
+      "fixture": "empty_dir",
+      "command": "port=$((24000 + RANDOM % 10000)); SYKLI_COORDINATOR_TOKEN=secret sykli coordinator start --port \"$port\" >coord.log 2>&1 & pid=$!; trap 'kill $pid 2>/dev/null || true' EXIT; for i in {1..80}; do curl -fsS \"http://127.0.0.1:$port/health\" >/dev/null 2>&1 && break; sleep 0.1; done; curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' -d '{\"slug\":\"false-systems\",\"name\":\"False Systems\"}' \"http://127.0.0.1:$port/v1/orgs\" >org.json; org=$(jq -r '.data.org.id' org.json); curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' -d \"{\\\"org_id\\\":\\\"$org\\\",\\\"slug\\\":\\\"platform\\\",\\\"name\\\":\\\"Platform\\\"}\" \"http://127.0.0.1:$port/v1/teams\" >platform.json; curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' -d \"{\\\"org_id\\\":\\\"$org\\\",\\\"slug\\\":\\\"infra\\\",\\\"name\\\":\\\"Infra\\\"}\" \"http://127.0.0.1:$port/v1/teams\" >infra.json; infra=$(jq -r '.data.team.id' infra.json); team_token=$(sykli coordinator mint-token --token secret --org false-systems --team platform --role member); status=$(curl -sS -o forbidden.json -w '%{http_code}' -H \"Authorization: Bearer $team_token\" \"http://127.0.0.1:$port/v1/runs?team_id=$infra\"); test \"$status\" = 403; cat forbidden.json",
+      "shell": true,
+      "requires": "curl",
+      "expect_exit": 0,
+      "expect_json_jq": [
+        ".ok == false",
+        ".error.code == \"coordinator.forbidden\""
+      ],
+      "source": "docs/team-mode-security.md coordinator authorization model",
+      "validated_by": "Injected bug: router trusts client-supplied team_id filters and lets a team token query another team's run summaries."
+    },
+    {
       "id": "POS-team-run-sync-passing",
       "name": "joined daemon syncs passing run summary",
       "fixture": "single_task",


### PR DESCRIPTION
## Summary
- keep SYKLI_COORDINATOR_TOKEN as the admin/owner bootstrap token and add stateless HMAC-signed team tokens carrying org, team, and role claims
- add sykli coordinator mint-token --org <slug> --team <slug> --role <role> for owner/member/approver team tokens
- make Auth.authorize/2 return a principal and enforce tenant scope across coordinator lists, reads, writes, daemon sessions, work items, runs, and gates
- require owner/approver/admin for gate decisions and reject member decisions with coordinator.forbidden
- document the auth model, forbidden error code, and current no-expiry/rotation limitation

## Audit note
Verified the old S2 finding was real: Auth.authorize/2 accepted only one global bearer token and returned :ok, while router list filters trusted client-supplied team IDs. This PR closes that by resolving signed team-token principals to concrete org/team IDs and intersecting or rejecting client filters instead of widening access.

## Verification
- cd core && mix test
- cd core && mix credo
- cd core && mix escript.build
- test/blackbox/run.sh

Blackbox result: 168 passed, 0 expected-red, 0 failed.

## Follow-up
- Team tokens are stateless and currently have no expiry claim. Rotation is by changing the coordinator signing/admin token; explicit expiry/revocation can be added separately.