### PR TITLE
ci(release): derive release-notes path from the pushed tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,5 +108,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: release/*
-          body_path: docs/releases/v0.6.0.md
+          body_path: docs/releases/${{ github.ref_name }}.md
           make_latest: true


### PR DESCRIPTION
## What

`body_path` in the release workflow was hardcoded to `docs/releases/v0.6.0.md` — every release after 0.6.0 would ship with 0.6.0's notes. Now derived from `github.ref_name` (tag `vX.Y.Z` → `docs/releases/vX.Y.Z.md`).

Caught while cutting v0.7.0; that release's body will be corrected with `gh release edit` since its run already started from the old workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)