### PR TITLE
fix(release): wire NPM_TOKEN into npm publish

### DIFF
--- a/scripts/publish-ts.sh
+++ b/scripts/publish-ts.sh
@@ -26,4 +26,13 @@ if [[ -z "${NPM_TOKEN:-}" ]]; then
 fi
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../sdk/typescript"
-npm publish
+
+# Feed the token to npm via a throwaway userconfig. The ${NPM_TOKEN}
+# placeholder is expanded by npm at run time, so the token itself is
+# never written to disk.
+npmrc="$(mktemp)"
+trap 'rm -f "$npmrc"' EXIT
+# shellcheck disable=SC2016
+echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > "$npmrc"
+
+NPM_CONFIG_USERCONFIG="$npmrc" npm publish


### PR DESCRIPTION
## What

`publish-ts.sh` gated on `NPM_TOKEN` being set but never gave it to `npm publish` — the step only worked if you happened to be `npm login`'d. Now the token flows through a temp `NPM_CONFIG_USERCONFIG` with an `${NPM_TOKEN}` placeholder npm expands at run time (token never touches disk).

Found while driving the first full five-registry 0.7.0 publish.

## Testing

`bash -n` + `--dry-run` pass; real publish exercised by the 0.7.0 release flow once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)