### PR TITLE
feat(daemon): heartbeat loop GenServer (Monster Phase D, PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Daemon heartbeat loop (Monster Phase D, PR 1).** New
+  `Sykli.Daemon.Heartbeat` GenServer implements the runtime side of
+  `docs/daemon-join-protocol.md`: coordinator-owned cadence
+  (`next_heartbeat_seconds`), exponential backoff with jitter capped at
+  `heartbeat_interval_seconds * 4`, hard stop on 401/403
+  (`team.token.revoked` — the token is never retried), refusal of
+  assignments without `accepts_remote_work`, gate-decision application with
+  acknowledgement on the following tick, outbox drain on reconnect, and
+  liveness fields (`last_heartbeat_at`, `consecutive_failures`) persisted to
+  the session file. Not yet wired to a host process — `daemon join --stay`
+  and the daemon-supervisor child land in the next slice.
+
+### Changed
+
+- **Team Mode outbox drain extracted to `Sykli.TeamCoordinator.OutboxDrain`.**
+  The CLI post-run sync and the heartbeat loop now replay
+  `.sykli/outbox/{runs,gates}/` through one shared code path.
+
 ## [0.7.0] - 2026-06-11
 
 ### Added

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -2911,69 +2911,8 @@ defmodule Sykli.CLI do
     )
   end
 
-  defp drain_team_run_outbox do
-    with {:ok, session} <- Sykli.Daemon.SessionStore.read(),
-         token when is_binary(token) and token != "" <- System.get_env("SYKLI_TEAM_TOKEN") do
-      result =
-        Sykli.Outbox.drain("runs", fn payload ->
-          Sykli.TeamCoordinator.RunClient.publish_raw(session, token, payload)
-        end)
-
-      count_synced =
-        case result do
-          {:ok, count} -> count
-          {:error, count, _reason} -> count
-        end
-
-      if count_synced > 0 do
-        remaining = daemon_outbox_runs_count()
-
-        Sykli.Occurrence.PubSub.team_outbox_drained("team-outbox", %{
-          "count_synced" => count_synced,
-          "count_remaining" => remaining
-        })
-      end
-
-      :ok
-    else
-      _ -> :ok
-    end
-  end
-
   defp drain_team_outboxes do
-    drain_team_run_outbox()
-    drain_team_gate_outbox()
-  end
-
-  defp drain_team_gate_outbox do
-    with {:ok, session} <- Sykli.Daemon.SessionStore.read(),
-         token when is_binary(token) and token != "" <- System.get_env("SYKLI_TEAM_TOKEN") do
-      result =
-        Sykli.Outbox.drain("gates", fn payload ->
-          if payload["daemon_session_id"] == session["session_id"] do
-            Sykli.TeamCoordinator.GateClient.publish_raw(session, token, payload)
-          else
-            {:error, :team_gate_invalid_payload}
-          end
-        end)
-
-      count_synced =
-        case result do
-          {:ok, count} -> count
-          {:error, count, _reason} -> count
-        end
-
-      if count_synced > 0 do
-        Sykli.Occurrence.PubSub.team_outbox_drained("team-outbox", %{
-          "kind" => "gates",
-          "count_synced" => count_synced
-        })
-      end
-
-      :ok
-    else
-      _ -> :ok
-    end
+    Sykli.TeamCoordinator.OutboxDrain.drain_all()
   end
 
   defp daemon_outbox_runs_count do

--- a/core/lib/sykli/daemon/heartbeat.ex
+++ b/core/lib/sykli/daemon/heartbeat.ex
@@ -1,0 +1,270 @@
+defmodule Sykli.Daemon.Heartbeat do
+  @moduledoc """
+  The Team Mode heartbeat loop (docs/daemon-join-protocol.md).
+
+  Periodically POSTs the daemon heartbeat to the joined coordinator, applies
+  returned gate decisions through `Sykli.Daemon.Join.apply_heartbeat_response/2`,
+  acknowledges them on the following tick, and drains the Team Mode outbox on
+  reconnect.
+
+  Protocol behavior implemented here:
+
+    * the coordinator owns the cadence — `next_heartbeat_seconds` from each
+      response schedules the next tick (fallback: the session's
+      `heartbeat_interval_seconds`);
+    * network/5xx failures back off exponentially with jitter, capped at
+      `heartbeat_interval_seconds * 4`;
+    * 401/403 stops the loop and surfaces `team.token.revoked` — the token is
+      never retried;
+    * assignments received while `accepts_remote_work` is false are refused
+      and logged (`team.policy.refused_remote_work`);
+    * the first successful heartbeat after a failure (or after startup)
+      drains `.sykli/outbox/`.
+
+  Local-first is binding: without a persisted session and a team token the
+  loop refuses to start (`:ignore`), and a coordination failure never blocks
+  local execution — it only delays this process's next tick.
+
+  The process is intended to run under `restart: :transient` so a protocol
+  stop (token revoked, session refused) is not resurrected into a retry storm.
+  """
+
+  use GenServer, restart: :transient
+
+  alias Sykli.Coordinator.Client
+  alias Sykli.Daemon.Join
+  alias Sykli.Daemon.SessionStore
+
+  require Logger
+
+  @default_interval_seconds 15
+  @backoff_cap_multiplier 4
+
+  defstruct session: nil,
+            token: nil,
+            interval: @default_interval_seconds,
+            failures: 0,
+            pending_acks: [],
+            status: "available",
+            synced_once: false,
+            opts: []
+
+  # ── Public API ──────────────────────────────────────────────────────────
+
+  def start_link(opts \\ []) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc "Current loop state for status surfaces. Returns a map."
+  def info(server \\ __MODULE__) do
+    GenServer.call(server, :info)
+  end
+
+  @doc "Mark the daemon as draining; the next heartbeat reports it."
+  def drain(server \\ __MODULE__) do
+    GenServer.cast(server, :drain)
+  end
+
+  # ── GenServer ───────────────────────────────────────────────────────────
+
+  @impl true
+  def init(opts) do
+    session_result =
+      case Keyword.fetch(opts, :session) do
+        {:ok, session} when is_map(session) -> {:ok, session}
+        _ -> session_store(opts).read(session_store_opts(opts))
+      end
+
+    token = Keyword.get(opts, :token) || System.get_env("SYKLI_TEAM_TOKEN")
+
+    with {:ok, session} <- session_result,
+         t when is_binary(t) and t != "" <- token do
+      interval = interval_seconds(session)
+
+      state = %__MODULE__{
+        session: session,
+        token: t,
+        interval: interval,
+        opts: opts
+      }
+
+      schedule(state, Keyword.get(opts, :initial_delay_ms, 0))
+      {:ok, state}
+    else
+      _ ->
+        Logger.debug("heartbeat loop not started: no coordinator session or team token")
+        :ignore
+    end
+  end
+
+  @impl true
+  def handle_call(:info, _from, state) do
+    {:reply,
+     %{
+       session_id: state.session["session_id"],
+       coordinator: state.session["coordinator"],
+       interval_seconds: state.interval,
+       consecutive_failures: state.failures,
+       status: state.status
+     }, state}
+  end
+
+  @impl true
+  def handle_cast(:drain, state) do
+    {:noreply, %{state | status: "draining"}}
+  end
+
+  @impl true
+  def handle_info(:heartbeat, state) do
+    payload =
+      Join.heartbeat_payload(state.session, %{
+        "status" => state.status,
+        "acknowledged_decision_ids" => state.pending_acks
+      })
+
+    case post_heartbeat(state, payload) do
+      {:ok, data} ->
+        handle_success(state, data)
+
+      {:error, {:coordinator_error, status, _error}} when status in [401, 403] ->
+        Logger.error(
+          "team.token.revoked: coordinator rejected the team token; " <>
+            "stopping heartbeat loop. Rotate the token and rejoin."
+        )
+
+        persist_liveness(state, %{"revoked" => true})
+        {:stop, :normal, state}
+
+      {:error, reason} ->
+        handle_failure(state, reason)
+    end
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  # ── Tick outcomes ───────────────────────────────────────────────────────
+
+  defp handle_success(state, data) do
+    if state.failures > 0 or not state.synced_once do
+      outbox_drain(state.opts).()
+    end
+
+    refuse_unconsented_assignments(state, data)
+
+    apply_opts =
+      Keyword.merge(
+        [session_id: state.session["session_id"]],
+        Keyword.get(state.opts, :gate_opts, [])
+      )
+
+    {:ok, acks} = Join.apply_heartbeat_response(data, apply_opts)
+
+    next_seconds = positive_integer(data["next_heartbeat_seconds"], state.interval)
+
+    persist_liveness(state, %{"consecutive_failures" => 0})
+
+    state = %{state | failures: 0, pending_acks: acks, synced_once: true}
+    schedule(state, next_seconds * 1000)
+    {:noreply, state}
+  end
+
+  defp handle_failure(state, reason) do
+    failures = state.failures + 1
+    delay_ms = backoff_ms(state.interval, failures, state.opts)
+
+    Logger.warning(
+      "heartbeat failed (attempt #{failures}); retrying in #{delay_ms}ms: #{inspect(reason)}"
+    )
+
+    persist_liveness(state, %{"consecutive_failures" => failures})
+
+    state = %{state | failures: failures}
+    schedule(state, delay_ms)
+    {:noreply, state}
+  end
+
+  # Exponential backoff with jitter, capped at interval * 4 (protocol
+  # mandate). The jittered delay lands in [cap/2, cap] of the computed step.
+  defp backoff_ms(interval_seconds, failures, opts) do
+    cap_ms = interval_seconds * @backoff_cap_multiplier * 1000
+    step_ms = min(interval_seconds * 1000 * Integer.pow(2, failures), cap_ms)
+    half = div(step_ms, 2)
+    half + jitter_fun(opts).(max(half, 1))
+  end
+
+  defp refuse_unconsented_assignments(state, data) do
+    assignments = Map.get(data, "assignments", [])
+
+    if assignments != [] and state.session["accepts_remote_work"] != true do
+      Logger.warning(
+        "team.policy.refused_remote_work: coordinator sent #{length(assignments)} " <>
+          "assignment(s) but this daemon did not opt into remote work; refusing"
+      )
+    end
+
+    :ok
+  end
+
+  # ── Liveness persistence ────────────────────────────────────────────────
+
+  # Best-effort: liveness fields on the session file power
+  # `sykli daemon status`; a write failure must never affect the loop.
+  defp persist_liveness(state, fields) do
+    updated =
+      state.session
+      |> Map.merge(fields)
+      |> Map.put("last_heartbeat_at", now_fun(state.opts).())
+
+    case session_store(state.opts).write(updated, session_store_opts(state.opts)) do
+      {:ok, _} -> :ok
+      _other -> :ok
+    end
+  end
+
+  # ── Wiring (injectable for tests) ───────────────────────────────────────
+
+  defp post_heartbeat(state, payload) do
+    case Keyword.get(state.opts, :post_fun) do
+      fun when is_function(fun, 2) ->
+        fun.(state.session, payload)
+
+      nil ->
+        Client.post_json(
+          state.session["coordinator"],
+          "/v1/daemon-sessions/#{state.session["session_id"]}/heartbeat",
+          state.token,
+          payload
+        )
+    end
+  end
+
+  defp schedule(state, delay_ms) do
+    schedule_fun =
+      Keyword.get(state.opts, :schedule_fun, fn ms ->
+        Process.send_after(self(), :heartbeat, ms)
+      end)
+
+    schedule_fun.(delay_ms)
+  end
+
+  defp outbox_drain(opts),
+    do: Keyword.get(opts, :outbox_drain, fn -> Sykli.TeamCoordinator.OutboxDrain.drain_all() end)
+
+  defp jitter_fun(opts), do: Keyword.get(opts, :jitter_fun, &:rand.uniform/1)
+
+  defp now_fun(opts),
+    do: Keyword.get(opts, :now_fun, fn -> DateTime.to_iso8601(DateTime.utc_now()) end)
+
+  defp session_store(opts), do: Keyword.get(opts, :session_store, SessionStore)
+  defp session_store_opts(opts), do: Keyword.take(opts, [:path])
+
+  defp interval_seconds(session) do
+    positive_integer(session["heartbeat_interval_seconds"], @default_interval_seconds)
+  end
+
+  defp positive_integer(value, _fallback) when is_integer(value) and value > 0, do: value
+  defp positive_integer(_value, fallback), do: fallback
+end

--- a/core/lib/sykli/team_coordinator/outbox_drain.ex
+++ b/core/lib/sykli/team_coordinator/outbox_drain.ex
@@ -1,0 +1,94 @@
+defmodule Sykli.TeamCoordinator.OutboxDrain do
+  @moduledoc """
+  Shared drain path for deferred Team Mode sync payloads.
+
+  Used by the CLI post-run sync and the daemon heartbeat loop. Reads the
+  local daemon session and the team token from the environment and quietly
+  no-ops when either is absent — no session means no network (local-first).
+
+  Extracted from the CLI so both callers replay `.sykli/outbox/` through
+  one code path.
+  """
+
+  alias Sykli.Daemon.SessionStore
+  alias Sykli.Occurrence.PubSub
+
+  @doc """
+  Drain both Team Mode outboxes (runs, then gates). Always returns `:ok`.
+  """
+  def drain_all(opts \\ []) do
+    drain_runs(opts)
+    drain_gates(opts)
+    :ok
+  end
+
+  def drain_runs(opts \\ []) do
+    with_session_and_token(opts, fn session, token ->
+      result =
+        Sykli.Outbox.drain("runs", fn payload ->
+          Sykli.TeamCoordinator.RunClient.publish_raw(session, token, payload)
+        end)
+
+      count_synced = synced_count(result)
+
+      if count_synced > 0 do
+        remaining =
+          case Sykli.Outbox.pending_count("runs") do
+            {:ok, count} -> count
+            {:error, _reason} -> 0
+          end
+
+        PubSub.team_outbox_drained("team-outbox", %{
+          "count_synced" => count_synced,
+          "count_remaining" => remaining
+        })
+      end
+
+      :ok
+    end)
+  end
+
+  def drain_gates(opts \\ []) do
+    with_session_and_token(opts, fn session, token ->
+      result =
+        Sykli.Outbox.drain("gates", fn payload ->
+          if payload["daemon_session_id"] == session["session_id"] do
+            Sykli.TeamCoordinator.GateClient.publish_raw(session, token, payload)
+          else
+            {:error, :team_gate_invalid_payload}
+          end
+        end)
+
+      count_synced = synced_count(result)
+
+      if count_synced > 0 do
+        PubSub.team_outbox_drained("team-outbox", %{
+          "kind" => "gates",
+          "count_synced" => count_synced
+        })
+      end
+
+      :ok
+    end)
+  end
+
+  defp with_session_and_token(opts, fun) do
+    session_result =
+      case Keyword.fetch(opts, :session) do
+        {:ok, session} when is_map(session) -> {:ok, session}
+        _ -> SessionStore.read()
+      end
+
+    token = Keyword.get(opts, :token) || System.get_env("SYKLI_TEAM_TOKEN")
+
+    with {:ok, session} <- session_result,
+         t when is_binary(t) and t != "" <- token do
+      fun.(session, t)
+    else
+      _ -> :ok
+    end
+  end
+
+  defp synced_count({:ok, count}), do: count
+  defp synced_count({:error, count, _reason}), do: count
+end

--- a/core/test/sykli/daemon/heartbeat_test.exs
+++ b/core/test/sykli/daemon/heartbeat_test.exs
@@ -1,0 +1,279 @@
+defmodule Sykli.Daemon.HeartbeatTest do
+  use ExUnit.Case, async: false
+
+  alias Sykli.Daemon.Heartbeat
+
+  # The loop persists liveness through a session-store double so tests never
+  # touch the real `.sykli/daemon/session.json`.
+  defmodule NullStore do
+    def read(_opts), do: {:error, :enoent}
+    def write(session, _opts), do: {:ok, session}
+  end
+
+  # The loop calls write/2 from its own process, so the test pid travels via
+  # persistent_term (async: false keeps this race-free across tests).
+  defmodule RecordingStore do
+    def read(_opts), do: {:error, :enoent}
+
+    def write(session, _opts) do
+      send(:persistent_term.get({__MODULE__, :test_pid}), {:liveness, session})
+      {:ok, session}
+    end
+
+    def record_to(pid), do: :persistent_term.put({__MODULE__, :test_pid}, pid)
+  end
+
+  defp session(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "coordinator" => "https://coordinator.test",
+        "session_id" => "sess_test",
+        "daemon_id" => "test-daemon",
+        "heartbeat_interval_seconds" => 15,
+        "labels" => ["macos"],
+        "capabilities" => ["local"],
+        "accepts_remote_work" => false
+      },
+      overrides
+    )
+  end
+
+  defp start_loop(opts) do
+    test_pid = self()
+
+    defaults = [
+      name: nil,
+      token: "tok_test",
+      session: session(),
+      session_store: NullStore,
+      outbox_drain: fn -> send(test_pid, :outbox_drained) end,
+      jitter_fun: fn _max -> 0 end,
+      now_fun: fn -> "2026-06-12T00:00:00Z" end,
+      schedule_fun: fn ms ->
+        send(test_pid, {:scheduled, ms})
+        make_ref()
+      end
+    ]
+
+    opts = Keyword.merge(defaults, opts)
+    start_supervised!({Heartbeat, opts}, restart: :temporary)
+  end
+
+  defp ok_response(extra \\ %{}) do
+    {:ok,
+     Map.merge(
+       %{"next_heartbeat_seconds" => 15, "decisions" => [], "assignments" => []},
+       extra
+     )}
+  end
+
+  test "refuses to start without a session" do
+    assert :ignore =
+             Heartbeat.start_link(
+               name: nil,
+               token: "tok_test",
+               session_store: NullStore
+             )
+  end
+
+  test "refuses to start without a token" do
+    previous = System.get_env("SYKLI_TEAM_TOKEN")
+    System.delete_env("SYKLI_TEAM_TOKEN")
+    on_exit(fn -> if previous, do: System.put_env("SYKLI_TEAM_TOKEN", previous) end)
+
+    assert :ignore =
+             Heartbeat.start_link(
+               name: nil,
+               token: nil,
+               session: session(),
+               session_store: NullStore
+             )
+  end
+
+  test "schedules the first tick immediately and follows next_heartbeat_seconds" do
+    test_pid = self()
+
+    pid =
+      start_loop(
+        post_fun: fn _session, payload ->
+          send(test_pid, {:posted, payload})
+          ok_response(%{"next_heartbeat_seconds" => 7})
+        end
+      )
+
+    assert_receive {:scheduled, 0}
+    send(pid, :heartbeat)
+
+    assert_receive {:posted, payload}
+    assert payload["session_id"] == "sess_test"
+    assert payload["status"] == "available"
+    assert payload["acknowledged_decision_ids"] == []
+
+    assert_receive {:scheduled, 7_000}
+  end
+
+  test "drains the outbox on the first successful heartbeat and after failures" do
+    test_pid = self()
+    {:ok, agent} = Agent.start_link(fn -> [:fail, :ok, :ok, :fail, :ok] end)
+
+    pid =
+      start_loop(
+        post_fun: fn _session, _payload ->
+          case Agent.get_and_update(agent, fn [h | t] -> {h, t} end) do
+            :ok -> ok_response()
+            :fail -> {:error, {:coordinator_unavailable, :econnrefused}}
+          end
+        end,
+        outbox_drain: fn -> send(test_pid, :outbox_drained) end
+      )
+
+    assert_receive {:scheduled, 0}
+
+    # fail → success: drains (recovery is also the first success)
+    send(pid, :heartbeat)
+    refute_receive :outbox_drained, 50
+    send(pid, :heartbeat)
+    assert_receive :outbox_drained
+
+    # steady-state success: no drain
+    send(pid, :heartbeat)
+    refute_receive :outbox_drained, 50
+
+    # fail → success: drains again
+    send(pid, :heartbeat)
+    send(pid, :heartbeat)
+    assert_receive :outbox_drained
+  end
+
+  test "acknowledges applied gate decisions on the following tick" do
+    test_pid = self()
+    tmp = Path.join(System.tmp_dir!(), "hb-gates-#{System.unique_integer([:positive])}")
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    {:ok, gate} = Sykli.GateDecision.new(id: "gate_1")
+    :ok = Sykli.Gate.Store.save(gate, path: tmp)
+
+    # apply_remote_decision keys the local gate by the decision's "id".
+    decision = %{
+      "id" => "gate_1",
+      "status" => "approved",
+      "decided_by" => "member:yair",
+      "reason" => "test"
+    }
+
+    {:ok, agent} = Agent.start_link(fn -> [{:ok_with, [decision]}, :plain_ok] end)
+
+    pid =
+      start_loop(
+        post_fun: fn _session, payload ->
+          send(test_pid, {:posted, payload})
+
+          case Agent.get_and_update(agent, fn [h | t] -> {h, t} end) do
+            {:ok_with, decisions} -> ok_response(%{"decisions" => decisions})
+            :plain_ok -> ok_response()
+          end
+        end,
+        gate_opts: [path: tmp]
+      )
+
+    assert_receive {:scheduled, 0}
+    send(pid, :heartbeat)
+    assert_receive {:posted, %{"acknowledged_decision_ids" => []}}
+
+    send(pid, :heartbeat)
+    assert_receive {:posted, %{"acknowledged_decision_ids" => acked}}
+    assert acked == ["gate_1"]
+  end
+
+  test "backs off exponentially with a cap of interval * 4" do
+    {:ok, agent} = Agent.start_link(fn -> 0 end)
+
+    pid =
+      start_loop(
+        post_fun: fn _session, _payload ->
+          Agent.update(agent, &(&1 + 1))
+          {:error, {:coordinator_unavailable, :econnrefused}}
+        end,
+        jitter_fun: fn _max -> 0 end
+      )
+
+    assert_receive {:scheduled, 0}
+
+    # interval 15s, cap 60s. step = min(15 * 2^n, 60); delay = step/2 + 0
+    send(pid, :heartbeat)
+    assert_receive {:scheduled, 15_000}
+
+    send(pid, :heartbeat)
+    assert_receive {:scheduled, 30_000}
+
+    send(pid, :heartbeat)
+    assert_receive {:scheduled, 30_000}
+
+    send(pid, :heartbeat)
+    assert_receive {:scheduled, 30_000}
+  end
+
+  test "stops on 401 and never retries the token" do
+    RecordingStore.record_to(self())
+
+    pid =
+      start_loop(
+        post_fun: fn _session, _payload ->
+          {:error, {:coordinator_error, 401, %{"message" => "revoked"}}}
+        end,
+        session_store: RecordingStore
+      )
+
+    ref = Process.monitor(pid)
+    assert_receive {:scheduled, 0}
+    send(pid, :heartbeat)
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+    assert_receive {:liveness, %{"revoked" => true}}
+    refute_receive {:scheduled, _}, 50
+  end
+
+  test "persists liveness fields on success and failure" do
+    RecordingStore.record_to(self())
+    {:ok, agent} = Agent.start_link(fn -> [:ok, :fail] end)
+
+    pid =
+      start_loop(
+        post_fun: fn _session, _payload ->
+          case Agent.get_and_update(agent, fn [h | t] -> {h, t} end) do
+            :ok -> ok_response()
+            :fail -> {:error, {:coordinator_unavailable, :timeout}}
+          end
+        end,
+        session_store: RecordingStore
+      )
+
+    assert_receive {:scheduled, 0}
+
+    send(pid, :heartbeat)
+
+    assert_receive {:liveness,
+                    %{"consecutive_failures" => 0, "last_heartbeat_at" => "2026-06-12T00:00:00Z"}}
+
+    send(pid, :heartbeat)
+    assert_receive {:liveness, %{"consecutive_failures" => 1}}
+  end
+
+  test "reports draining status once drain/1 is cast" do
+    test_pid = self()
+
+    pid =
+      start_loop(
+        post_fun: fn _session, payload ->
+          send(test_pid, {:posted, payload})
+          ok_response()
+        end
+      )
+
+    assert_receive {:scheduled, 0}
+    Heartbeat.drain(pid)
+    send(pid, :heartbeat)
+
+    assert_receive {:posted, %{"status" => "draining"}}
+  end
+end


### PR DESCRIPTION
## What

First slice of Monster Phase D — the audit's "Team Mode looks done but live layer is a stub" finding. `Join.heartbeat_payload/2` and `Join.apply_heartbeat_response/2` were tested pure functions with zero production callers; this PR adds the process that drives them.

**`Sykli.Daemon.Heartbeat`** (GenServer, `restart: :transient`):
- Coordinator-owned cadence: schedules from `next_heartbeat_seconds`, falls back to the session's `heartbeat_interval_seconds`
- Exponential backoff with jitter, capped at `interval × 4` (protocol mandate)
- 401/403 → log `team.token.revoked`, persist `revoked: true`, stop — token never retried
- Gate decisions applied idempotently; ack IDs ride the next heartbeat
- Outbox drained on first success after startup or any failure window
- Assignments refused (`team.policy.refused_remote_work`) when the daemon didn't opt into remote work
- Liveness (`last_heartbeat_at`, `consecutive_failures`) written to the session file for `daemon status`
- Local-first: no session/token → `:ignore`, never starts

**`Sykli.TeamCoordinator.OutboxDrain`**: the runs/gates drains extracted verbatim from `cli.ex` so the CLI and the loop share one replay path.

All collaborators are injectable (`post_fun`, `schedule_fun`, `jitter_fun`, `now_fun`, `session_store`) — the 9 unit tests tick the loop manually and assert backoff arithmetic without sleeping.

## What this PR does NOT do

No host wiring yet. PR 2 adds `sykli daemon join --stay` (foreground loop, no BEAM distribution) and the daemon-supervisor child. PR 3 adds graceful drain on SIGTERM, auto-rejoin on session death, and the black-box round-trip case.

## Testing

- `mix test`: 1779 tests, 0 failures (9 new)
- `mix credo`, `mix format`, `mix escript.build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)