### PR TITLE
feat(daemon): heartbeat hosts — join --stay + supervisor child (Phase D, PR 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   assignments without `accepts_remote_work`, gate-decision application with
   acknowledgement on the following tick, outbox drain on reconnect, and
   liveness fields (`last_heartbeat_at`, `consecutive_failures`) persisted to
-  the session file. Not yet wired to a host process — `daemon join --stay`
-  and the daemon-supervisor child land in the next slice.
+  the session file.
+- **Heartbeat hosts (Monster Phase D, PR 2).** `sykli daemon join --stay`
+  runs the heartbeat loop in the foreground with no BEAM distribution — the
+  minimal Team Mode daemon. The mesh daemon (`sykli daemon start`) now also
+  hosts the loop as a supervised child for every role; it self-ignores when
+  no coordinator session is joined. `sykli daemon status` shows heartbeat
+  liveness (`last heartbeat`, consecutive failures, token-revoked) in human
+  output; `--json` carries the same fields inside `coordinator_session`.
+  New error code: `daemon.stay_failed`.
 
 ### Changed
 

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -2851,6 +2851,7 @@ defmodule Sykli.CLI do
         end
 
         IO.puts("  Outbox:   #{daemon_outbox_runs_count()} run(s) pending")
+        print_session_heartbeat_line()
 
       {:stopped, info} ->
         IO.puts("")
@@ -2869,6 +2870,37 @@ defmodule Sykli.CLI do
         end
 
         IO.puts("  Outbox:   #{daemon_outbox_runs_count()} run(s) pending")
+        print_session_heartbeat_line()
+    end
+  end
+
+  defp print_session_heartbeat_line do
+    case Sykli.Daemon.SessionStore.read() do
+      {:ok, session} ->
+        failures = session["consecutive_failures"] || 0
+
+        cond do
+          session["revoked"] == true ->
+            IO.puts("  Team:     token revoked — rotate the token and rejoin")
+
+          is_binary(session["last_heartbeat_at"]) and failures > 0 ->
+            IO.puts(
+              "  Team:     last heartbeat #{session["last_heartbeat_at"]} " <>
+                "(#{failures} consecutive failure(s))"
+            )
+
+          is_binary(session["last_heartbeat_at"]) ->
+            IO.puts("  Team:     last heartbeat #{session["last_heartbeat_at"]}")
+
+          true ->
+            IO.puts(
+              "  Team:     joined #{session["coordinator"]} " <>
+                "#{IO.ANSI.faint()}(no heartbeat yet — run sykli daemon join --stay or sykli daemon start)#{IO.ANSI.reset()}"
+            )
+        end
+
+      {:error, _reason} ->
+        :ok
     end
   end
 

--- a/core/lib/sykli/daemon.ex
+++ b/core/lib/sykli/daemon.ex
@@ -538,10 +538,13 @@ defmodule Sykli.Daemon do
   end
 
   defp daemon_children(role, workdir) do
-    # Occurrence store is always needed (context for AI)
+    # Occurrence store is always needed (context for AI). The Team Mode
+    # heartbeat loop self-ignores when no coordinator session is joined, so
+    # it is safe to list for every role.
     base = [
       {Sykli.Occurrence.Store, workdir: workdir},
-      Sykli.Cluster
+      Sykli.Cluster,
+      {Sykli.Daemon.Heartbeat, path: Path.join(workdir, ".sykli")}
     ]
 
     case role do

--- a/core/lib/sykli/daemon/join.ex
+++ b/core/lib/sykli/daemon/join.ex
@@ -41,8 +41,48 @@ defmodule Sykli.Daemon.Join do
            ]),
          {:ok, persisted} <- persist_session(opts, payload, data, runtime_opts) do
       output_success(persisted, json?)
+
+      if Keyword.get(opts, :stay, false) do
+        stay(persisted, opts, runtime_opts)
+      else
+        0
+      end
     else
       {:error, reason} -> output_error(reason, json?)
+    end
+  end
+
+  # Foreground heartbeat host: runs the loop in the current process's
+  # supervision-free world and blocks until it stops (token revoked, session
+  # refused, or operator interrupt). The minimal Team Mode daemon — no BEAM
+  # distribution, no mesh.
+  defp stay(session, opts, runtime_opts) do
+    heartbeat = Keyword.get(runtime_opts, :heartbeat, Sykli.Daemon.Heartbeat)
+
+    start_opts =
+      [
+        name: nil,
+        session: session,
+        token: Keyword.get(opts, :token) || System.get_env("SYKLI_TEAM_TOKEN")
+      ] ++ Keyword.take(opts, [:path])
+
+    case heartbeat.start_link(start_opts) do
+      {:ok, pid} ->
+        unless Keyword.get(opts, :json, false) do
+          IO.puts("Heartbeat loop running. Ctrl-C to stop.")
+        end
+
+        ref = Process.monitor(pid)
+
+        receive do
+          {:DOWN, ^ref, :process, ^pid, _reason} -> 0
+        end
+
+      :ignore ->
+        output_error(:daemon_stay_failed, Keyword.get(opts, :json, false))
+
+      {:error, reason} ->
+        output_error({:daemon_stay_failed, reason}, Keyword.get(opts, :json, false))
     end
   end
 
@@ -201,6 +241,9 @@ defmodule Sykli.Daemon.Join do
   defp parse_flags(["--accept-remote-work" | rest], opts, pos),
     do: parse_flags(rest, [{:accepts_remote_work, true} | opts], pos)
 
+  defp parse_flags(["--stay" | rest], opts, pos),
+    do: parse_flags(rest, [{:stay, true} | opts], pos)
+
   defp parse_flags(["--coordinator", value | rest], opts, pos),
     do: parse_flags(rest, [{:coordinator, value} | opts], pos)
 
@@ -341,6 +384,16 @@ defmodule Sykli.Daemon.Join do
   defp join_error({:invalid_daemon_join_command, command}),
     do: validation("daemon.invalid_join_command", "invalid daemon join command: #{command}")
 
+  defp join_error(:daemon_stay_failed),
+    do:
+      runtime(
+        "daemon.stay_failed",
+        "heartbeat loop refused to start: missing session or team token"
+      )
+
+  defp join_error({:daemon_stay_failed, reason}),
+    do: runtime("daemon.stay_failed", "heartbeat loop failed to start: #{inspect(reason)}")
+
   defp join_error({:coordinator_unavailable, reason}),
     do: runtime("daemon.coordinator_unavailable", "coordinator unavailable: #{inspect(reason)}")
 
@@ -387,8 +440,11 @@ defmodule Sykli.Daemon.Join do
       --capabilities LIST       Comma-separated capabilities, default: local
       --name NAME               Stable daemon id, default: hostname
       --accept-remote-work      Explicitly advertise remote-work acceptance
+      --stay                    Keep running: heartbeat loop in the foreground
 
-    Remote work is disabled by default.
+    Remote work is disabled by default. Without --stay, join registers the
+    session and exits; gate decisions are then picked up only while a daemon
+    or a --stay loop is running.
     """)
   end
 end

--- a/core/test/sykli/daemon/join_test.exs
+++ b/core/test/sykli/daemon/join_test.exs
@@ -188,6 +188,92 @@ defmodule Sykli.Daemon.JoinTest do
     end
   end
 
+  test "join --stay runs the heartbeat host and returns when it stops" do
+    tmp = Path.join(System.tmp_dir!(), "sykli-stay-test-#{System.unique_integer([:positive])}")
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    output =
+      capture_io(fn ->
+        assert Join.join(
+                 [
+                   coordinator: "https://sykli.internal",
+                   org: "false-systems",
+                   team: "platform",
+                   token: "super-secret",
+                   name: "yair-mbp",
+                   stay: true,
+                   path: tmp
+                 ],
+                 client: __MODULE__.FakeClient,
+                 heartbeat: __MODULE__.InstantHeartbeat,
+                 now: @now,
+                 version: "0.6.1"
+               ) == 0
+      end)
+
+    assert output =~ "Heartbeat loop running"
+    assert_received {:stay_started, opts}
+    assert opts[:session]["session_id"] == "sess_001"
+    assert opts[:token] == "super-secret"
+    assert opts[:path] == tmp
+  end
+
+  test "join --stay surfaces a refused heartbeat start" do
+    tmp =
+      Path.join(System.tmp_dir!(), "sykli-stay-ignore-#{System.unique_integer([:positive])}")
+
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    output =
+      capture_io(:stderr, fn ->
+        assert Join.join(
+                 [
+                   coordinator: "https://sykli.internal",
+                   org: "false-systems",
+                   team: "platform",
+                   token: "super-secret",
+                   name: "yair-mbp",
+                   stay: true,
+                   path: tmp
+                 ],
+                 client: __MODULE__.FakeClient,
+                 heartbeat: __MODULE__.IgnoringHeartbeat,
+                 now: @now,
+                 version: "0.6.1"
+               ) == 1
+      end)
+
+    assert output =~ "daemon.stay_failed"
+  end
+
+  test "accepts the --stay flag in command parsing" do
+    output =
+      capture_io(:stderr, fn ->
+        assert Join.run(["join", "--stay"]) == 1
+      end)
+
+    assert output =~ "daemon.join_missing_coordinator"
+    refute output =~ "invalid_join_command"
+  end
+
+  defmodule InstantHeartbeat do
+    def start_link(opts) do
+      send(self_test_pid(), {:stay_started, opts})
+      {:ok, spawn(fn -> :ok end)}
+    end
+
+    defp self_test_pid, do: :persistent_term.get({__MODULE__, :pid})
+  end
+
+  defmodule IgnoringHeartbeat do
+    def start_link(_opts), do: :ignore
+  end
+
+  setup do
+    :persistent_term.put({__MODULE__.InstantHeartbeat, :pid}, self())
+    :ok
+  end
+
   defmodule FakeClient do
     def post_json(_url, "/v1/daemon-sessions", "super-secret", payload) do
       if Map.has_key?(payload, "token") do

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -73,6 +73,7 @@ daemon status/session JSON surfaces.
 | `daemon.join_missing_org` | `sykli daemon join` was called without `--org`. | public-unstable | `core/lib/sykli/daemon/join.ex` |
 | `daemon.join_missing_team` | `sykli daemon join` was called without `--team`. | public-unstable | `core/lib/sykli/daemon/join.ex` |
 | `daemon.join_missing_token` | `sykli daemon join` was called without `--token` or `SYKLI_TEAM_TOKEN`. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.stay_failed` | `sykli daemon join --stay` could not start the foreground heartbeat loop. | public-unstable | `core/lib/sykli/daemon/join.ex` |
 
 ### team.run
 


### PR DESCRIPTION
## What

Second slice of Monster Phase D — the heartbeat loop from #226 gets its host processes:

- **`sykli daemon join --stay`** — joins, then runs the loop in the foreground. No BEAM distribution, no epmd, no mesh: the minimal Team Mode daemon for laptops and CI runners. Returns when the loop stops (e.g. token revoked).
- **Supervisor child** — `sykli daemon start` (any role) now hosts the loop under `Sykli.Daemon.Supervisor`. `restart: :transient` + `:ignore` without a session keep local-only mode untouched.
- **`sykli daemon status`** — human output gains a `Team:` line (last heartbeat / consecutive failures / token-revoked hint with rejoin guidance); `--json` inherits the liveness fields through `coordinator_session` automatically.
- `daemon.stay_failed` cataloged in `docs/error-codes.md` (public-unstable).

With this merged, the gate round-trip is functional end-to-end for anyone running `--stay` or a daemon: reviewer approves via team CLI → coordinator queues decision → heartbeat delivers → local gate store applies → executor unblocks.

## Remaining (PR 3)

Graceful drain on SIGTERM, auto-rejoin on session death, black-box round-trip case, protocol-doc status refresh.

## Testing

- 3 new join tests (`--stay` happy path with injected heartbeat host, refused start, flag parsing); heartbeat tests from PR 1 unchanged
- `mix test`: 1782 tests, 0 failures · credo clean · escript builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)