### PR TITLE
feat(daemon): heartbeat resilience + round-trip proof (Phase D, PR 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   liveness (`last heartbeat`, consecutive failures, token-revoked) in human
   output; `--json` carries the same fields inside `coordinator_session`.
   New error code: `daemon.stay_failed`.
+- **Heartbeat resilience (Monster Phase D, PR 3).** The loop now rejoins
+  automatically when the coordinator forgets its session
+  (`coordinator.daemon_session_not_found` — same daemon identity, fresh
+  `session_id`, immediate next tick) and sends a best-effort final
+  `offline` heartbeat on graceful shutdown. New black-box case
+  `COORD-006` proves the remote gate-approval round-trip end to end
+  against the built binary: coordinator decision → heartbeat delivery →
+  local gate store approved. This closes the 2026-05-22 audit's "live
+  layer is a stub" finding.
 
 ### Changed
 

--- a/core/lib/sykli/daemon/heartbeat.ex
+++ b/core/lib/sykli/daemon/heartbeat.ex
@@ -82,6 +82,11 @@ defmodule Sykli.Daemon.Heartbeat do
 
     with {:ok, session} <- session_result,
          t when is_binary(t) and t != "" <- token do
+      # Trap exits so terminate/2 can send a best-effort final offline
+      # heartbeat on supervisor shutdown (graceful disconnect, protocol §
+      # "Disconnect and reconnect").
+      Process.flag(:trap_exit, true)
+
       interval = interval_seconds(session)
 
       state = %__MODULE__{
@@ -138,12 +143,25 @@ defmodule Sykli.Daemon.Heartbeat do
         persist_liveness(state, %{"revoked" => true})
         {:stop, :normal, state}
 
+      {:error, {:coordinator_error, 404, %{"code" => "coordinator.daemon_session_not_found"}}} ->
+        rejoin(state)
+
       {:error, reason} ->
         handle_failure(state, reason)
     end
   end
 
   def handle_info(_message, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    if state.synced_once do
+      payload = Join.heartbeat_payload(state.session, %{"status" => "offline"})
+      post_heartbeat(state, payload)
+    end
+
+    :ok
+  end
 
   # ── Tick outcomes ───────────────────────────────────────────────────────
 
@@ -184,6 +202,56 @@ defmodule Sykli.Daemon.Heartbeat do
     state = %{state | failures: failures}
     schedule(state, delay_ms)
     {:noreply, state}
+  end
+
+  # The coordinator no longer knows our session (restart, cutoff exceeded).
+  # The protocol blesses an automatic fresh join: same daemon identity, new
+  # session_id, rejoin recorded by the coordinator's audit log.
+  defp rejoin(state) do
+    payload = %{
+      "daemon_id" => state.session["daemon_id"],
+      "org" => state.session["org"],
+      "team" => state.session["team"],
+      "labels" => state.session["labels"] || [],
+      "capabilities" => state.session["capabilities"] || [],
+      "version" => Application.spec(:sykli, :vsn) |> to_string(),
+      "accepts_remote_work" => state.session["accepts_remote_work"] == true
+    }
+
+    case post_join(state, payload) do
+      {:ok, data} ->
+        session =
+          state.session
+          |> Map.merge(
+            Map.take(data, ["session_id", "team_id", "heartbeat_interval_seconds", "policy"])
+          )
+          |> Map.delete("revoked")
+
+        Logger.info("heartbeat session expired; rejoined coordinator as #{session["session_id"]}")
+
+        state = %{state | session: session, interval: interval_seconds(session), failures: 0}
+        persist_liveness(state, %{"consecutive_failures" => 0})
+        schedule(state, 0)
+        {:noreply, state}
+
+      {:error, reason} ->
+        handle_failure(state, {:rejoin_failed, reason})
+    end
+  end
+
+  defp post_join(state, payload) do
+    case Keyword.get(state.opts, :join_fun) do
+      fun when is_function(fun, 2) ->
+        fun.(state.session, payload)
+
+      nil ->
+        Client.post_json(
+          state.session["coordinator"],
+          "/v1/daemon-sessions",
+          state.token,
+          payload
+        )
+    end
   end
 
   # Exponential backoff with jitter, capped at interval * 4 (protocol

--- a/core/test/sykli/daemon/heartbeat_test.exs
+++ b/core/test/sykli/daemon/heartbeat_test.exs
@@ -259,6 +259,83 @@ defmodule Sykli.Daemon.HeartbeatTest do
     assert_receive {:liveness, %{"consecutive_failures" => 1}}
   end
 
+  test "rejoins automatically when the coordinator forgot the session" do
+    test_pid = self()
+
+    {:ok, agent} =
+      Agent.start_link(fn ->
+        [
+          {:error,
+           {:coordinator_error, 404, %{"code" => "coordinator.daemon_session_not_found"}}},
+          :plain_ok
+        ]
+      end)
+
+    pid =
+      start_loop(
+        post_fun: fn session, payload ->
+          send(test_pid, {:posted, session["session_id"], payload})
+
+          case Agent.get_and_update(agent, fn [h | t] -> {h, t} end) do
+            :plain_ok -> ok_response()
+            other -> other
+          end
+        end,
+        join_fun: fn _session, payload ->
+          send(test_pid, {:rejoined, payload})
+          {:ok, %{"session_id" => "sess_new", "heartbeat_interval_seconds" => 20}}
+        end
+      )
+
+    assert_receive {:scheduled, 0}
+    send(pid, :heartbeat)
+    assert_receive {:posted, "sess_test", _payload}
+
+    assert_receive {:rejoined, join_payload}
+    assert join_payload["daemon_id"] == "test-daemon"
+    assert join_payload["accepts_remote_work"] == false
+
+    # rejoin schedules an immediate tick under the fresh session
+    assert_receive {:scheduled, 0}
+    send(pid, :heartbeat)
+    assert_receive {:posted, "sess_new", _payload}
+  end
+
+  test "sends a final offline heartbeat on shutdown after a successful sync" do
+    test_pid = self()
+
+    pid =
+      start_loop(
+        post_fun: fn _session, payload ->
+          send(test_pid, {:posted, payload})
+          ok_response()
+        end
+      )
+
+    assert_receive {:scheduled, 0}
+    send(pid, :heartbeat)
+    assert_receive {:posted, %{"status" => "available"}}
+
+    GenServer.stop(pid)
+    assert_receive {:posted, %{"status" => "offline"}}
+  end
+
+  test "does not send an offline heartbeat if it never synced" do
+    test_pid = self()
+
+    pid =
+      start_loop(
+        post_fun: fn _session, payload ->
+          send(test_pid, {:posted, payload})
+          ok_response()
+        end
+      )
+
+    assert_receive {:scheduled, 0}
+    GenServer.stop(pid)
+    refute_receive {:posted, _}, 50
+  end
+
   test "reports draining status once drain/1 is cast" do
     test_pid = self()
 

--- a/docs/daemon-join-protocol.md
+++ b/docs/daemon-join-protocol.md
@@ -2,15 +2,19 @@
 
 ## Status
 
-Implemented incrementally. PR #192 adds the first daemon join and
-heartbeat slice: coordinator daemon-session endpoints, the
-`sykli daemon join` client command, local session persistence, and
-`sykli daemon status --json` session visibility.
+Implemented. PR #192 added the join/heartbeat slice (coordinator
+daemon-session endpoints, `sykli daemon join`, local session persistence,
+`sykli daemon status --json`); later phases added work sync, run summary
+sync, and gate decision sync. The production heartbeat **loop**
+(`Sykli.Daemon.Heartbeat`) ships in the Monster Phase D series: hosted by
+`sykli daemon join --stay` (foreground, no BEAM distribution) and by the
+mesh daemon supervisor, it implements the cadence, backoff, revocation
+stop, decision application + acknowledgement, outbox drain on reconnect,
+automatic rejoin on session death, and the final offline heartbeat on
+graceful shutdown described below. The black-box case `COORD-006` proves
+the gate-decision round-trip end to end.
 
-Later phases still add work sync, run summary sync, gate decision sync,
-and event-stream delivery. Wire shapes below are the current contract for
-the implemented join/heartbeat slice unless a later section explicitly
-marks behavior as future work.
+Event-stream delivery (SSE) remains future work.
 
 ## Architecture sentence
 

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -1335,7 +1335,13 @@
       "command": "cd SYKLI_ROOT && tests/conformance/run.sh 01-basic >/dev/null",
       "shell": true,
       "expect_exit": 0,
-      "requires": ["go", "cargo", "node", "python3", "mix"],
+      "requires": [
+        "go",
+        "cargo",
+        "node",
+        "python3",
+        "mix"
+      ],
       "source": "CLAUDE.md §SDKs; sdk/*/README.md public surface parity",
       "validated_by": "Injected bug: change one SDK basic JSON key; conformance runner fails."
     },
@@ -1346,7 +1352,13 @@
       "command": "cd SYKLI_ROOT && tests/conformance/run.sh 02-capabilities >/dev/null",
       "shell": true,
       "expect_exit": 0,
-      "requires": ["go", "cargo", "node", "python3", "mix"],
+      "requires": [
+        "go",
+        "cargo",
+        "node",
+        "python3",
+        "mix"
+      ],
       "source": "CHANGELOG 0.5.0 Capability-based dependencies; SDK READMEs",
       "validated_by": "Injected bug: drop provides value in one SDK; conformance runner fails."
     },
@@ -1357,7 +1369,13 @@
       "command": "cd SYKLI_ROOT && tests/conformance/run.sh 04-gate >/dev/null",
       "shell": true,
       "expect_exit": 0,
-      "requires": ["go", "cargo", "node", "python3", "mix"],
+      "requires": [
+        "go",
+        "cargo",
+        "node",
+        "python3",
+        "mix"
+      ],
       "source": "CHANGELOG 0.5.0 Gate tasks; SDK READMEs",
       "validated_by": "Injected bug: omit gate timeout serialization; conformance runner fails."
     },
@@ -1368,7 +1386,13 @@
       "command": "cd SYKLI_ROOT && tests/conformance/run.sh 10-task-inputs >/dev/null",
       "shell": true,
       "expect_exit": 0,
-      "requires": ["go", "cargo", "node", "python3", "mix"],
+      "requires": [
+        "go",
+        "cargo",
+        "node",
+        "python3",
+        "mix"
+      ],
       "source": "README.md §Content-addressed caching; SDK READMEs",
       "validated_by": "Injected bug: serialize inputs under covers; conformance runner fails."
     },
@@ -1379,7 +1403,13 @@
       "command": "cd SYKLI_ROOT && tests/conformance/run.sh 20-edge-duplicate-after >/dev/null",
       "shell": true,
       "expect_exit": 0,
-      "requires": ["go", "cargo", "node", "python3", "mix"],
+      "requires": [
+        "go",
+        "cargo",
+        "node",
+        "python3",
+        "mix"
+      ],
       "source": "SDK READMEs; CLAUDE.md §SDKs",
       "validated_by": "Injected bug: one SDK keeps duplicate deps; conformance runner fails."
     },
@@ -1390,7 +1420,13 @@
       "command": "cd SYKLI_ROOT && tests/conformance/run.sh 18-edge-provides-empty >/dev/null",
       "shell": true,
       "expect_exit": 0,
-      "requires": ["go", "cargo", "node", "python3", "mix"],
+      "requires": [
+        "go",
+        "cargo",
+        "node",
+        "python3",
+        "mix"
+      ],
       "source": "CHANGELOG 0.5.0 TypeScript/Python provides empty string fix",
       "validated_by": "Injected bug: treat empty provides as undefined; conformance runner fails."
     },
@@ -1756,6 +1792,24 @@
       ],
       "source": "docs/team-mode-security.md coordinator authorization model",
       "validated_by": "Injected bug: router trusts client-supplied team_id filters and lets a team token query another team's run summaries."
+    },
+    {
+      "id": "COORD-006",
+      "name": "remote gate approval round-trips through the heartbeat loop",
+      "fixture": "empty_dir",
+      "command": "port=$((24000 + RANDOM % 10000)); SYKLI_COORDINATOR_TOKEN=secret sykli coordinator start --port \"$port\" >coord.log 2>&1 & cpid=$!; trap 'kill $cpid $spid 2>/dev/null || true' EXIT; for i in {1..80}; do curl -fsS \"http://127.0.0.1:$port/health\" >/dev/null 2>&1 && break; sleep 0.1; done; curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' -d '{\"slug\":\"false-systems\",\"name\":\"False Systems\"}' \"http://127.0.0.1:$port/v1/orgs\" >org.json; org=$(jq -r '.data.org.id' org.json); curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' -d \"{\\\"org_id\\\":\\\"$org\\\",\\\"slug\\\":\\\"platform\\\",\\\"name\\\":\\\"Platform\\\"}\" \"http://127.0.0.1:$port/v1/teams\" >team.json; mkdir -p .sykli/gates; printf '%s' '{\"id\":\"gate_rt\",\"version\":\"1\",\"work_item_id\":null,\"run_id\":\"run_rt\",\"node_id\":null,\"status\":\"waiting\",\"reason\":null,\"requested_by_type\":null,\"requested_by_id\":null,\"decided_by\":null,\"decided_at\":null,\"created_at\":\"2026-06-12T00:00:00Z\",\"updated_at\":\"2026-06-12T00:00:00Z\",\"evidence_refs\":[]}' > .sykli/gates/gate_rt.json; SYKLI_TEAM_TOKEN=secret sykli daemon join --coordinator \"http://127.0.0.1:$port\" --org false-systems --team platform --name rt-daemon --stay >stay.log 2>&1 & spid=$!; session=''; for i in {1..120}; do session=$(jq -r '.session_id // empty' .sykli/daemon/session.json 2>/dev/null); [ -n \"$session\" ] && break; sleep 0.25; done; [ -n \"$session\" ]; curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' -d \"{\\\"org_slug\\\":\\\"false-systems\\\",\\\"team_slug\\\":\\\"platform\\\",\\\"daemon_session_id\\\":\\\"$session\\\",\\\"id\\\":\\\"gate_rt\\\",\\\"run_id\\\":\\\"run_rt\\\",\\\"node_id\\\":null,\\\"work_item_id\\\":null,\\\"status\\\":\\\"waiting\\\",\\\"decided_by\\\":null,\\\"decided_at\\\":null,\\\"reason\\\":null}\" \"http://127.0.0.1:$port/v1/gates\" >gate.json; curl -fsS -H 'Authorization: Bearer secret' -H 'Content-Type: application/json' -d '{\"org_slug\":\"false-systems\",\"team_slug\":\"platform\",\"status\":\"approved\",\"decided_by\":\"member:reviewer\",\"decided_at\":\"2026-06-12T00:01:00Z\",\"reason\":\"Reviewed\"}' \"http://127.0.0.1:$port/v1/gates/gate_rt/decisions\" >decision.json; for i in {1..240}; do gstatus=$(jq -r '.status // empty' .sykli/gates/gate_rt.json 2>/dev/null); [ \"$gstatus\" = \"approved\" ] && break; sleep 0.25; done; kill $spid 2>/dev/null || true; sykli gate show gate_rt --json",
+      "shell": true,
+      "requires": "curl",
+      "expect_exit": 0,
+      "expect_json_jq": [
+        ".ok == true",
+        ".data.gate.id == \"gate_rt\"",
+        ".data.gate.status == \"approved\"",
+        ".data.gate.decided_by == \"member:reviewer\"",
+        ".data.gate.reason == \"Reviewed\""
+      ],
+      "source": "docs/daemon-join-protocol.md heartbeat decisions; Monster Phase D — the gate round-trip must be functional at runtime, not just at the endpoint level",
+      "validated_by": "Injected bug: heartbeat loop never runs, decisions are not applied to the local gate store, or acks never clear the coordinator queue."
     },
     {
       "id": "POS-team-run-sync-passing",


### PR DESCRIPTION
## What

Final slice of Monster Phase D:

- **Auto-rejoin** on `coordinator.daemon_session_not_found`: fresh join with the same daemon identity, new `session_id`, immediate next tick; failure falls back to backoff. (Protocol: "the daemon performs a fresh join".)
- **Graceful disconnect**: `terminate/2` sends a best-effort final `offline` heartbeat — only after at least one successful sync.
- **COORD-006** — the audit-closing black-box case: coordinator + org/team bootstrap → `daemon join --stay` in the background → gate published under the loop's own session → decision recorded via `POST /v1/gates/:id/decisions` → poll until the **local** gate store shows `approved` by `member:reviewer`. Passes in ~16s (one heartbeat interval).
- Protocol doc status section: join/heartbeat/loop marked implemented; SSE remains future work.

## Why this closes the audit finding

The 2026-05-22 audit: "Team Mode looks done but live layer is a stub — no daemon heartbeat loop exists, so the gate-approval round-trip is non-functional at runtime despite endpoints existing." After this PR the round-trip is exercised end-to-end against the built binary in CI on every change.

## Testing

- 3 new heartbeat unit tests (rejoin flow incl. fresh-session tick, offline-on-shutdown, no-offline-if-never-synced) — 12 total
- `mix test`: 1785, 0 failures · credo clean · `test/blackbox/run.sh --filter=COORD-006` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)