### PR TITLE
feat(daemon): sykli daemon leave — clean session teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   liveness (`last heartbeat`, consecutive failures, token-revoked) in human
   output; `--json` carries the same fields inside `coordinator_session`.
   New error code: `daemon.stay_failed`.
+- **`sykli daemon leave`.** The inverse of `daemon join`: sends a
+  best-effort final `offline` heartbeat (when a team token is available)
+  and removes the local session file. Idempotent — leaving without a
+  session reports `left: false` and exits 0; a down coordinator never
+  blocks the local teardown. New error codes:
+  `daemon.invalid_leave_command`, `daemon.leave_failed`.
 - **Heartbeat resilience (Monster Phase D, PR 3).** The loop now rejoins
   automatically when the coordinator forgets its session
   (`coordinator.daemon_session_not_found` — same daemon identity, fresh

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -2683,6 +2683,12 @@ defmodule Sykli.CLI do
     |> halt()
   end
 
+  defp handle_daemon(["leave" | args]) do
+    args
+    |> Sykli.Daemon.Leave.run()
+    |> halt()
+  end
+
   defp handle_daemon(["stop"]) do
     IO.puts("#{IO.ANSI.cyan()}Stopping SYKLI daemon...#{IO.ANSI.reset()}")
 
@@ -2804,6 +2810,8 @@ defmodule Sykli.CLI do
       stop               Stop the daemon
       status             Show daemon status
       join               Join a self-hosted coordinator
+      join --stay        Join and keep the heartbeat loop in the foreground
+      leave              Leave the coordinator (final offline heartbeat + session removal)
 
     Examples:
       sykli daemon start                  Start full daemon (default)

--- a/core/lib/sykli/daemon/leave.ex
+++ b/core/lib/sykli/daemon/leave.ex
@@ -1,0 +1,201 @@
+defmodule Sykli.Daemon.Leave do
+  @moduledoc """
+  CLI flow for leaving a self-hosted Team Mode coordinator.
+
+  The inverse of `Sykli.Daemon.Join`: sends a best-effort final heartbeat
+  with `status: "offline"` (when a team token is available) and removes the
+  persisted session file. Leaving is idempotent — without a session it
+  reports `left: false` and exits 0; coordination must never block local
+  workflows, including its own teardown.
+  """
+
+  alias Sykli.CLI.JsonResponse
+  alias Sykli.Coordinator.Client
+  alias Sykli.Daemon.Join
+  alias Sykli.Daemon.SessionStore
+  alias Sykli.Error
+  alias Sykli.Error.Formatter
+
+  def run(args, runtime_opts \\ []) do
+    case parse(args) do
+      {:ok, :help} ->
+        print_help()
+        0
+
+      {:ok, opts} ->
+        leave(opts, runtime_opts)
+
+      {:error, reason, opts} ->
+        output_error(reason, Keyword.get(opts, :json, false))
+    end
+  end
+
+  def leave(opts, runtime_opts \\ []) do
+    json? = Keyword.get(opts, :json, false)
+    store = Keyword.get(runtime_opts, :session_store, SessionStore)
+    store_opts = Keyword.take(opts, [:path])
+
+    case store.read(store_opts) do
+      {:ok, session} ->
+        notified = notify_offline(session, opts, runtime_opts)
+
+        case store.delete(store_opts) do
+          :ok ->
+            output_left(session, notified, json?)
+
+          {:error, reason} ->
+            output_error({:session_delete_failed, reason}, json?)
+        end
+
+      {:error, _reason} ->
+        output_not_joined(json?)
+    end
+  end
+
+  # Best-effort: the coordinator marks the session offline on its own after
+  # the liveness cutoff, so a failed (or token-less) notification must not
+  # block the local teardown.
+  defp notify_offline(session, opts, runtime_opts) do
+    token =
+      Keyword.get(opts, :token) ||
+        System.get_env("SYKLI_TEAM_TOKEN")
+
+    with t when is_binary(t) and t != "" <- token,
+         payload = Join.heartbeat_payload(session, %{"status" => "offline"}),
+         {:ok, _data} <- post_heartbeat(session, t, payload, runtime_opts) do
+      true
+    else
+      _ -> false
+    end
+  end
+
+  defp post_heartbeat(session, token, payload, runtime_opts) do
+    client = Keyword.get(runtime_opts, :client, Client)
+
+    client.post_json(
+      session["coordinator"],
+      "/v1/daemon-sessions/#{session["session_id"]}/heartbeat",
+      token,
+      payload
+    )
+  end
+
+  defp output_left(session, notified, true) do
+    IO.puts(
+      JsonResponse.ok(%{
+        left: true,
+        session_id: session["session_id"],
+        coordinator: session["coordinator"],
+        coordinator_notified: notified
+      })
+    )
+
+    0
+  end
+
+  defp output_left(session, notified, false) do
+    IO.puts("Left coordinator #{session["coordinator"]}")
+
+    unless notified do
+      IO.puts(
+        "Could not send the final offline heartbeat; the coordinator will " <>
+          "mark the session offline after its liveness cutoff."
+      )
+    end
+
+    0
+  end
+
+  defp output_not_joined(true) do
+    IO.puts(JsonResponse.ok(%{left: false, reason: "not_joined"}))
+    0
+  end
+
+  defp output_not_joined(false) do
+    IO.puts("No coordinator session to leave.")
+    0
+  end
+
+  defp parse(args) do
+    case Enum.reduce_while(args, {[], []}, &collect_flag/2) do
+      {:error, reason, opts} -> {:error, reason, opts}
+      {opts, ["leave"]} -> route(opts)
+      {opts, []} -> route(opts)
+      {_opts, positionals} -> {:error, {:invalid_daemon_leave_command, positionals}, []}
+    end
+  end
+
+  defp route(opts) do
+    if Keyword.get(opts, :help, false), do: {:ok, :help}, else: {:ok, opts}
+  end
+
+  defp collect_flag("--json", {opts, pos}), do: {:cont, {[{:json, true} | opts], pos}}
+  defp collect_flag("--help", {opts, pos}), do: {:cont, {[{:help, true} | opts], pos}}
+  defp collect_flag("-h", {opts, pos}), do: {:cont, {[{:help, true} | opts], pos}}
+
+  defp collect_flag("--token", {opts, pos}), do: {:cont, {[{:token_next, true} | opts], pos}}
+
+  defp collect_flag(<<"--token=", value::binary>>, {opts, pos}),
+    do: {:cont, {[{:token, value} | opts], pos}}
+
+  defp collect_flag(<<"--", _::binary>> = flag, {opts, _pos}),
+    do: {:halt, {:error, {:unknown_daemon_leave_flag, flag}, opts}}
+
+  defp collect_flag(value, {opts, pos}) do
+    if Keyword.get(opts, :token_next, false) do
+      {:cont, {[{:token, value} | Keyword.delete(opts, :token_next)], pos}}
+    else
+      {:cont, {opts, pos ++ [value]}}
+    end
+  end
+
+  defp output_error(reason, json?) do
+    error = leave_error(reason)
+
+    if json? do
+      IO.puts(JsonResponse.error(error))
+    else
+      IO.puts(:stderr, Formatter.format(error))
+    end
+
+    1
+  end
+
+  defp leave_error({:unknown_daemon_leave_flag, flag}),
+    do: validation("daemon.invalid_leave_command", "unknown daemon leave flag: #{flag}")
+
+  defp leave_error({:invalid_daemon_leave_command, positionals}),
+    do:
+      validation(
+        "daemon.invalid_leave_command",
+        "invalid daemon leave command: #{Enum.join(positionals, " ")}"
+      )
+
+  defp leave_error({:session_delete_failed, reason}),
+    do:
+      runtime(
+        "daemon.leave_failed",
+        "could not remove the local session file: #{inspect(reason)}"
+      )
+
+  defp validation(code, message),
+    do: %Error{code: code, type: :validation, message: message, step: :validate, hints: []}
+
+  defp runtime(code, message),
+    do: %Error{code: code, type: :runtime, message: message, step: :setup, hints: []}
+
+  defp print_help do
+    IO.puts("""
+    Usage: sykli daemon leave [options]
+
+    Leave the joined Team Mode coordinator: send a best-effort final
+    offline heartbeat and remove the local session. Idempotent — leaving
+    without a session succeeds with left: false.
+
+    Options:
+      --json           Output JSON
+      --token TOKEN    Team token for the offline notification;
+                       SYKLI_TEAM_TOKEN is also supported
+    """)
+  end
+end

--- a/core/lib/sykli/daemon/session_store.ex
+++ b/core/lib/sykli/daemon/session_store.ex
@@ -44,6 +44,18 @@ defmodule Sykli.Daemon.SessionStore do
 
   defp validate(_data), do: {:error, :daemon_session_invalid}
 
+  @doc """
+  Remove the persisted session. Removing an absent session is `:ok` —
+  leave is idempotent.
+  """
+  def delete(opts \\ []) do
+    case File.rm(path(opts)) do
+      :ok -> :ok
+      {:error, :enoent} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp restrict_permissions(path) do
     case :file.change_mode(String.to_charlist(path), 0o600) do
       :ok -> :ok

--- a/core/test/sykli/daemon/leave_test.exs
+++ b/core/test/sykli/daemon/leave_test.exs
@@ -1,0 +1,128 @@
+defmodule Sykli.Daemon.LeaveTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias Sykli.Daemon.Leave
+  alias Sykli.Daemon.SessionStore
+
+  defmodule OfflineClient do
+    def post_json(url, path, token, payload) do
+      send(:persistent_term.get({__MODULE__, :pid}), {:offline_posted, url, path, token, payload})
+      {:ok, %{"next_heartbeat_seconds" => 15, "decisions" => [], "assignments" => []}}
+    end
+  end
+
+  defmodule DownClient do
+    def post_json(_url, _path, _token, _payload),
+      do: {:error, {:coordinator_unavailable, :econnrefused}}
+  end
+
+  setup do
+    :persistent_term.put({__MODULE__.OfflineClient, :pid}, self())
+
+    tmp = Path.join(System.tmp_dir!(), "sykli-leave-#{System.unique_integer([:positive])}")
+    on_exit(fn -> File.rm_rf(tmp) end)
+    %{tmp: tmp}
+  end
+
+  defp write_session(tmp) do
+    {:ok, _} =
+      SessionStore.write(
+        %{
+          "coordinator" => "https://sykli.internal",
+          "org" => "false-systems",
+          "team" => "platform",
+          "daemon_id" => "yair-mbp",
+          "session_id" => "sess_001",
+          "labels" => ["macos"],
+          "capabilities" => ["local"]
+        },
+        path: tmp
+      )
+  end
+
+  test "leave notifies offline, removes the session, and reports json", %{tmp: tmp} do
+    write_session(tmp)
+
+    output =
+      capture_io(fn ->
+        assert Leave.leave([json: true, path: tmp, token: "tok"], client: OfflineClient) == 0
+      end)
+
+    assert_received {:offline_posted, "https://sykli.internal",
+                     "/v1/daemon-sessions/sess_001/heartbeat", "tok", payload}
+
+    assert payload["status"] == "offline"
+    assert payload["session_id"] == "sess_001"
+
+    decoded = Jason.decode!(output)
+    assert decoded["data"]["left"] == true
+    assert decoded["data"]["coordinator_notified"] == true
+    assert {:error, :daemon_session_not_found} = SessionStore.read(path: tmp)
+  end
+
+  test "leave still removes the session when the coordinator is down", %{tmp: tmp} do
+    write_session(tmp)
+
+    output =
+      capture_io(fn ->
+        assert Leave.leave([json: true, path: tmp, token: "tok"], client: DownClient) == 0
+      end)
+
+    decoded = Jason.decode!(output)
+    assert decoded["data"]["left"] == true
+    assert decoded["data"]["coordinator_notified"] == false
+    assert {:error, :daemon_session_not_found} = SessionStore.read(path: tmp)
+  end
+
+  test "leave without a token skips the notification but removes the session", %{tmp: tmp} do
+    previous = System.get_env("SYKLI_TEAM_TOKEN")
+    System.delete_env("SYKLI_TEAM_TOKEN")
+    on_exit(fn -> if previous, do: System.put_env("SYKLI_TEAM_TOKEN", previous) end)
+
+    write_session(tmp)
+
+    output =
+      capture_io(fn ->
+        assert Leave.leave([json: true, path: tmp], client: OfflineClient) == 0
+      end)
+
+    refute_received {:offline_posted, _, _, _, _}
+    assert Jason.decode!(output)["data"]["coordinator_notified"] == false
+    assert {:error, :daemon_session_not_found} = SessionStore.read(path: tmp)
+  end
+
+  test "leave without a session is an idempotent success", %{tmp: tmp} do
+    output =
+      capture_io(fn ->
+        assert Leave.leave([json: true, path: tmp], client: OfflineClient) == 0
+      end)
+
+    decoded = Jason.decode!(output)
+    assert decoded["data"]["left"] == false
+    assert decoded["data"]["reason"] == "not_joined"
+  end
+
+  test "human output reports the leave" do
+    tmp = Path.join(System.tmp_dir!(), "sykli-leave-h-#{System.unique_integer([:positive])}")
+    on_exit(fn -> File.rm_rf(tmp) end)
+    write_session(tmp)
+
+    output =
+      capture_io(fn ->
+        assert Leave.leave([path: tmp, token: "tok"], client: OfflineClient) == 0
+      end)
+
+    assert output =~ "Left coordinator https://sykli.internal"
+  end
+
+  test "unknown flag is rejected" do
+    output =
+      capture_io(:stderr, fn ->
+        assert Leave.run(["--nope"]) == 1
+      end)
+
+    assert output =~ "daemon.invalid_leave_command"
+  end
+end

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -74,6 +74,8 @@ daemon status/session JSON surfaces.
 | `daemon.join_missing_team` | `sykli daemon join` was called without `--team`. | public-unstable | `core/lib/sykli/daemon/join.ex` |
 | `daemon.join_missing_token` | `sykli daemon join` was called without `--token` or `SYKLI_TEAM_TOKEN`. | public-unstable | `core/lib/sykli/daemon/join.ex` |
 | `daemon.stay_failed` | `sykli daemon join --stay` could not start the foreground heartbeat loop. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `daemon.invalid_leave_command` | `sykli daemon leave` received an unsupported flag or command form. | public-unstable | `core/lib/sykli/daemon/leave.ex` |
+| `daemon.leave_failed` | `sykli daemon leave` could not remove the local session file. | public-unstable | `core/lib/sykli/daemon/leave.ex` |
 
 ### team.run
 


### PR DESCRIPTION
## What

0.7.1 scope item: the session lifecycle gets its back door.

- `sykli daemon leave [--json] [--token T]` — best-effort final `offline` heartbeat + session-file removal
- Idempotent: no session → `{left: false, reason: "not_joined"}`, exit 0
- Coordinator down → session still removed, `coordinator_notified: false` (the coordinator expires the session via its liveness cutoff regardless)
- `SessionStore.delete/1` (absent file is `:ok`)
- Daemon help text updated (also documents `join --stay`); error codes cataloged

## Testing

6 new tests: notify+remove happy path (asserts the offline payload on the wire), coordinator-down teardown, token-less skip, idempotent no-session, human output, unknown-flag rejection. `mix test`: 1791/0 · credo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)