### PR TITLE
ci(release): tokenless registry publishing from the release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,3 +110,100 @@ jobs:
           files: release/*
           body_path: docs/releases/${{ github.ref_name }}.md
           make_latest: true
+
+  # ── Registry publishing ──────────────────────────────────────────────
+  # Tokenless where the registry supports OIDC trusted publishing.
+  # One-time registry-side setup is documented in RELEASE.md §"Automated
+  # registry publishing". These jobs run after the GitHub release exists,
+  # so a registry failure never blocks the binary release.
+
+  publish-go:
+    name: Publish Go SDK (module tag)
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Push module-aware tag
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          tag="sdk/go/v${version}"
+          if git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "tag $tag already exists"
+          else
+            git tag "$tag" "$GITHUB_SHA"
+            git push origin "$tag"
+          fi
+
+  publish-pypi:
+    name: Publish Python SDK (PyPI trusted publishing)
+    needs: release
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build distributions
+        working-directory: sdk/python
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: sdk/python/dist
+
+  publish-crates:
+    name: Publish Rust SDK (crates.io trusted publishing)
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: cargo publish
+        working-directory: sdk/rust
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish
+
+  # npm trusted publishing can only be configured on a package that already
+  # exists, and the sykli package has not had its first publish yet. After
+  # the first manual `npm publish` from sdk/typescript: configure the
+  # trusted publisher on npmjs.com (package Settings → Trusted publisher:
+  # GitHub Actions, repository false-systems/sykli, workflow release.yml),
+  # then uncomment this job. Requires npm >= 11.5 on the runner (OIDC).
+  #
+  # publish-npm:
+  #   name: Publish TypeScript SDK (npm trusted publishing)
+  #   needs: release
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '22'
+  #         registry-url: 'https://registry.npmjs.org'
+  #     - name: Publish to npm
+  #       working-directory: sdk/typescript
+  #       run: |
+  #         npm install -g npm@latest
+  #         npm publish

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -48,9 +48,55 @@ Checked files:
 The Go SDK has no embedded package version. It publishes via the module-aware
 tag `sdk/go/v<version>`.
 
-## Publish Credentials
+## Automated registry publishing (tag-triggered)
 
-Actual publishing requires all credentials to be present before the first
+Pushing a `v<version>` tag triggers `.github/workflows/release.yml`, which —
+after building binaries and creating the GitHub release — publishes:
+
+- **Go** — pushes the module-aware `sdk/go/v<version>` tag (skips if it
+  already exists). No credentials; uses the workflow's `GITHUB_TOKEN`.
+- **PyPI** — builds `sdk/python` and publishes via **trusted publishing**
+  (OIDC). No token anywhere.
+- **crates.io** — publishes `sdk/rust` via **trusted publishing** (OIDC).
+  No token anywhere.
+- **npm** — not yet automated; see below.
+- **Hex** — not automated (hex.pm has no OIDC trusted publishing); publish
+  with `scripts/publish-elixir.sh <version>` and `HEX_API_KEY`.
+
+### One-time registry setup (required before the first automated publish)
+
+**PyPI** (works even though `sykli` has never been published — "pending
+publisher"): pypi.org → Your account → Publishing → *Add a new pending
+publisher* with exactly:
+
+| Field | Value |
+|---|---|
+| PyPI project name | `sykli` |
+| Owner | `false-systems` |
+| Repository name | `sykli` |
+| Workflow name | `release.yml` |
+| Environment name | `pypi` |
+
+**crates.io** (the `sykli` crate exists, so configure on the crate):
+crates.io → `sykli` → Settings → Trusted Publishing → *Add* with repository
+owner `false-systems`, repository `sykli`, workflow filename `release.yml`,
+environment left empty.
+
+**npm**: trusted publishing can only be configured on an existing package.
+After the first manual `npm publish` from `sdk/typescript`, configure the
+trusted publisher on npmjs.com (package Settings → Trusted publisher:
+GitHub Actions, repository `false-systems/sykli`, workflow `release.yml`)
+and uncomment the `publish-npm` job in `release.yml`.
+
+The publish jobs run after the GitHub release is created, so a registry
+failure never blocks the binary release — fix the registry side and re-run
+the failed job from the Actions UI.
+
+## Publish Credentials (manual script path)
+
+`make publish` / `scripts/publish-all.sh` remain available as the manual
+path (and the only path for Hex, plus npm until its first publish). Actual
+publishing requires all credentials to be present before the first
 registry call:
 
 - `CARGO_REGISTRY_TOKEN` for crates.io


### PR DESCRIPTION
## What

0.7.1 scope item: registries publish themselves on tag push — no tokens in anyone's shell ever again.

| Registry | Mechanism | State |
|---|---|---|
| Go | module tag pushed by workflow (`GITHUB_TOKEN`) | automated |
| PyPI | OIDC trusted publishing (pending publisher — works for first publish) | automated after one-time setup |
| crates.io | OIDC trusted publishing | automated after one-time setup |
| npm | commented job — npm requires the package to exist before a trusted publisher can be configured | manual first publish, then uncomment |
| Hex | no OIDC at hex.pm | stays on `scripts/publish-elixir.sh` |

Publish jobs `needs: release`, so a registry failure never blocks the binary release; failed jobs re-run from the Actions UI.

## ⚠️ Before tagging v0.7.1

Two one-time registry-side steps (exact field values in RELEASE.md §"Automated registry publishing"):
1. PyPI → account → Publishing → add pending publisher (`sykli` / `false-systems/sykli` / `release.yml` / environment `pypi`)
2. crates.io → `sykli` crate → Settings → Trusted Publishing → add (`false-systems/sykli` / `release.yml`)

## Testing

YAML validated; jobs are tag-triggered so the real exercise is the v0.7.1 tag. Go job is idempotent against pre-existing tags (verified logic against the 0.7.0 manual tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)