### PR TITLE
fix(coordinator): gate-decision lifecycle — retention, recovery, error split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local gate store approved. This closes the 2026-05-22 audit's "live
   layer is a stub" finding.
 
+### Fixed
+
+- **Coordinator gate-decision lifecycle (closes #202, #205).** Sessions
+  silent past the protocol's resume cutoff (default 300s, configurable via
+  the store's `session_expiry_seconds`) are pruned together with their
+  decision-delivery queues on join and heartbeat. Delivery state now lives
+  on the gate record (`acknowledged_at`, `daemon_id`), making queues a
+  disposable cache: a daemon rejoining after its old session was pruned
+  receives decided-but-unacknowledged gates re-enqueued from the gate
+  records; acknowledged decisions are never redelivered. Separately, a
+  coordinator session record with corrupt/missing team metadata now
+  reports `gate.invalid_session` (500) instead of masquerading as
+  `gate.team_mismatch` (403). All `gate.*` coordinator codes are now
+  cataloged in `docs/error-codes.md`.
+
 ### Changed
 
 - **`sykli --help` tagline aligned with the project positioning.** The

--- a/core/lib/sykli/team_coordinator/router.ex
+++ b/core/lib/sykli/team_coordinator/router.ex
@@ -437,6 +437,7 @@ defmodule Sykli.TeamCoordinator.Router do
   defp status_for(:team_gate_invalid_decision), do: 400
   defp status_for(:team_gate_unknown_session), do: 403
   defp status_for(:team_gate_team_mismatch), do: 403
+  defp status_for(:team_gate_invalid_session), do: 500
   defp status_for({:team_gate_terminal, _status}), do: 409
   defp status_for({:missing_field, _field}), do: 400
   defp status_for({:invalid_field, _field}), do: 400
@@ -558,6 +559,9 @@ defmodule Sykli.TeamCoordinator.Router do
 
   defp coordinator_error(:team_gate_team_mismatch),
     do: error("gate.team_mismatch", "session does not belong to claimed team")
+
+  defp coordinator_error(:team_gate_invalid_session),
+    do: error("gate.invalid_session", "daemon session record is missing team metadata")
 
   defp coordinator_error({:team_gate_terminal, status}),
     do: error("gate.terminal", "gate is already terminal: #{status}")

--- a/core/lib/sykli/team_coordinator/store.ex
+++ b/core/lib/sykli/team_coordinator/store.ex
@@ -72,6 +72,9 @@ defmodule Sykli.TeamCoordinator.Store do
      %{
        now: Keyword.get(opts, :now, &DateTime.utc_now/0),
        id: Keyword.get(opts, :id, &Sykli.ULID.generate/0),
+       # Sessions silent past this many seconds are dead per the protocol's
+       # resume cutoff; the sweep removes them and their delivery queues.
+       session_expiry_seconds: Keyword.get(opts, :session_expiry_seconds, 300),
        orgs: %{},
        orgs_by_slug: %{},
        teams: %{},
@@ -295,9 +298,11 @@ defmodule Sykli.TeamCoordinator.Store do
 
       state =
         state
+        |> prune_stale_sessions()
         |> supersede_existing_daemon(identity, session_id, now)
         |> put_in([:daemon_sessions, session_id], session)
         |> put_in([:daemon_sessions_by_identity, identity], session_id)
+        |> reenqueue_undelivered_decisions(identity, session_id)
         |> audit("daemon.joined", "daemon_session", session_id, org_id, team_id)
 
       {:reply, {:ok, session_response(session), session}, state}
@@ -323,6 +328,8 @@ defmodule Sykli.TeamCoordinator.Store do
   end
 
   def handle_call({:heartbeat_daemon_session, id, attrs}, _from, state) do
+    state = prune_stale_sessions(state)
+
     with {:ok, session} <- fetch_daemon_session(state, id),
          :ok <- validate_session_id_match(id, Map.get(attrs, "session_id")),
          {:ok, status} <- required_heartbeat_status(attrs),
@@ -344,7 +351,7 @@ defmodule Sykli.TeamCoordinator.Store do
 
       state =
         state
-        |> acknowledge_gate_decisions(id, acknowledged_ids)
+        |> acknowledge_gate_decisions(id, acknowledged_ids, now)
         |> put_in([:daemon_sessions, id], updated)
         |> audit("daemon.heartbeat", "daemon_session", id, session["org_id"], session["team_id"])
 
@@ -645,6 +652,7 @@ defmodule Sykli.TeamCoordinator.Store do
        |> Map.put("org_id", org_id)
        |> Map.put("team_id", team_id)
        |> Map.put("daemon_session_id", daemon_session_id)
+       |> Map.put("daemon_id", session["daemon_id"])
        |> Map.put("created_at", now)
        |> Map.put("updated_at", now)}
     end
@@ -658,8 +666,15 @@ defmodule Sykli.TeamCoordinator.Store do
     end
   end
 
-  defp validate_session_team(%{"team_id" => team_id}, team_id), do: :ok
-  defp validate_session_team(_session, _team_id), do: {:error, :team_gate_team_mismatch}
+  defp validate_session_team(%{"team_id" => team_id}, team_id) when is_binary(team_id), do: :ok
+
+  defp validate_session_team(%{"team_id" => session_team}, _team_id)
+       when is_binary(session_team) and session_team != "",
+       do: {:error, :team_gate_team_mismatch}
+
+  # A session record without usable team metadata is coordinator-side data
+  # corruption, not an authorization failure — report it as such (#202).
+  defp validate_session_team(_session, _team_id), do: {:error, :team_gate_invalid_session}
 
   defp validate_waiting_gate("waiting"), do: :ok
   defp validate_waiting_gate(_status), do: {:error, :team_gate_invalid_payload}
@@ -721,12 +736,26 @@ defmodule Sykli.TeamCoordinator.Store do
     |> Kernel.++([payload])
   end
 
-  defp acknowledge_gate_decisions(state, _session_id, []), do: state
+  defp acknowledge_gate_decisions(state, _session_id, [], _now), do: state
 
-  defp acknowledge_gate_decisions(state, session_id, ids) do
-    update_in(state, [:pending_gate_decisions, session_id], fn
+  defp acknowledge_gate_decisions(state, session_id, ids, now) do
+    state
+    |> update_in([:pending_gate_decisions, session_id], fn
       nil -> []
       decisions -> Enum.reject(decisions, &(&1["id"] in ids))
+    end)
+    |> stamp_acknowledged_gates(ids, now)
+  end
+
+  # Delivery state lives on the gate record, not only in the per-session
+  # queue — queues are a disposable delivery cache (#205); an unacknowledged
+  # decision can always be re-enqueued from the gate on rejoin.
+  defp stamp_acknowledged_gates(state, ids, now) do
+    Enum.reduce(ids, state, fn id, acc ->
+      case acc.gates[id] do
+        nil -> acc
+        gate -> put_in(acc, [:gates, id], Map.put(gate, "acknowledged_at", now))
+      end
     end)
   end
 
@@ -867,6 +896,72 @@ defmodule Sykli.TeamCoordinator.Store do
           end)
 
         %{state | pending_gate_decisions: Map.put(pending, new_session_id, merged)}
+    end
+  end
+
+  # Recovery path for #205: a rejoin after the previous session (and its
+  # queue) was pruned must still receive decided-but-unacknowledged gates.
+  # The gate record is the source of truth; the queue is rebuilt from it
+  # and the gate is retargeted to the new session. replace_decision/2
+  # dedups against anything the supersede fast path already moved.
+  defp reenqueue_undelivered_decisions(state, {org_id, team_id, daemon_id}, new_session_id) do
+    state.gates
+    |> Map.values()
+    |> Enum.filter(fn gate ->
+      gate["org_id"] == org_id and gate["team_id"] == team_id and
+        gate["daemon_id"] == daemon_id and gate["status"] != "waiting" and
+        is_nil(gate["acknowledged_at"])
+    end)
+    |> Enum.reduce(state, fn gate, acc ->
+      retargeted = Map.put(gate, "daemon_session_id", new_session_id)
+
+      acc
+      |> put_in([:gates, gate["id"]], retargeted)
+      |> enqueue_gate_decision(retargeted)
+    end)
+  end
+
+  # Retention sweep for #205: sessions whose last heartbeat is older than
+  # the expiry are dead per the protocol's resume cutoff — remove the
+  # session, its delivery queue, and its identity mapping. Runs
+  # opportunistically on join and heartbeat (the in-memory skeleton has no
+  # timers). Unacknowledged decisions survive on the gate records and are
+  # re-enqueued if the daemon ever rejoins.
+  defp prune_stale_sessions(state) do
+    case DateTime.from_iso8601(now(state)) do
+      {:ok, now_dt, _offset} ->
+        cutoff = DateTime.add(now_dt, -state.session_expiry_seconds, :second)
+
+        stale_ids =
+          state.daemon_sessions
+          |> Enum.filter(fn {_id, session} -> session_stale?(session, cutoff) end)
+          |> Enum.map(fn {id, _session} -> id end)
+          |> MapSet.new()
+
+        if MapSet.size(stale_ids) == 0 do
+          state
+        else
+          %{
+            state
+            | daemon_sessions: Map.drop(state.daemon_sessions, MapSet.to_list(stale_ids)),
+              pending_gate_decisions:
+                Map.drop(state.pending_gate_decisions, MapSet.to_list(stale_ids)),
+              daemon_sessions_by_identity:
+                state.daemon_sessions_by_identity
+                |> Enum.reject(fn {_identity, id} -> MapSet.member?(stale_ids, id) end)
+                |> Map.new()
+          }
+        end
+
+      _other ->
+        state
+    end
+  end
+
+  defp session_stale?(session, cutoff) do
+    case DateTime.from_iso8601(session["last_seen_at"] || "") do
+      {:ok, last_seen, _offset} -> DateTime.compare(last_seen, cutoff) == :lt
+      _other -> false
     end
   end
 

--- a/core/test/sykli/team_coordinator/store_test.exs
+++ b/core/test/sykli/team_coordinator/store_test.exs
@@ -254,4 +254,198 @@ defmodule Sykli.TeamCoordinator.StoreTest do
       end)
     end
   end
+
+  describe "gate decision lifecycle (#202, #205)" do
+    test "prunes sessions and their queues past the expiry" do
+      {now_fun, advance} = ticking_now("2026-06-13T10:00:00Z")
+
+      {:ok, store} =
+        Store.start_link(now: now_fun, id: counter_ids(), session_expiry_seconds: 300)
+
+      bootstrap(store)
+
+      stale = join(store, "old-laptop")
+      gate = publish_gate(store, stale, "gate_stale")
+      decide(store, gate["id"])
+
+      advance.(301)
+      _fresh = join(store, "other-daemon")
+
+      assert {:ok, sessions} = Store.list_daemon_sessions(store, %{})
+      refute Enum.any?(sessions, &(&1["session_id"] == stale["session_id"]))
+
+      assert {:error, {:daemon_session_not_found, _}} =
+               Store.heartbeat_daemon_session(store, stale["session_id"], %{
+                 "session_id" => stale["session_id"],
+                 "status" => "available"
+               })
+    end
+
+    test "rejoin after prune re-enqueues unacknowledged decisions from gate records" do
+      {now_fun, advance} = ticking_now("2026-06-13T10:00:00Z")
+
+      {:ok, store} =
+        Store.start_link(now: now_fun, id: counter_ids(), session_expiry_seconds: 300)
+
+      bootstrap(store)
+
+      first = join(store, "yair-mbp")
+      gate = publish_gate(store, first, "gate_rt")
+      decide(store, gate["id"])
+
+      # daemon goes dark past the cutoff; the queue dies with the session
+      advance.(301)
+      rejoined = join(store, "yair-mbp")
+
+      assert {:ok, heartbeat, _session} =
+               Store.heartbeat_daemon_session(store, rejoined["session_id"], %{
+                 "session_id" => rejoined["session_id"],
+                 "status" => "available"
+               })
+
+      assert [%{"id" => "gate_rt", "status" => "approved"}] = heartbeat["decisions"]
+    end
+
+    test "acknowledged decisions are not redelivered after rejoin" do
+      {now_fun, advance} = ticking_now("2026-06-13T10:00:00Z")
+
+      {:ok, store} =
+        Store.start_link(now: now_fun, id: counter_ids(), session_expiry_seconds: 300)
+
+      bootstrap(store)
+
+      first = join(store, "yair-mbp")
+      gate = publish_gate(store, first, "gate_done")
+      decide(store, gate["id"])
+
+      assert {:ok, %{"decisions" => [_delivered]}, _} =
+               Store.heartbeat_daemon_session(store, first["session_id"], %{
+                 "session_id" => first["session_id"],
+                 "status" => "available"
+               })
+
+      assert {:ok, %{"decisions" => []}, _} =
+               Store.heartbeat_daemon_session(store, first["session_id"], %{
+                 "session_id" => first["session_id"],
+                 "status" => "available",
+                 "acknowledged_decision_ids" => ["gate_done"]
+               })
+
+      advance.(301)
+      rejoined = join(store, "yair-mbp")
+
+      assert {:ok, %{"decisions" => []}, _} =
+               Store.heartbeat_daemon_session(store, rejoined["session_id"], %{
+                 "session_id" => rejoined["session_id"],
+                 "status" => "available"
+               })
+    end
+
+    test "corrupted session team metadata reports invalid_session, not team_mismatch" do
+      {now_fun, _advance} = ticking_now("2026-06-13T10:00:00Z")
+      {:ok, store} = Store.start_link(now: now_fun, id: counter_ids())
+      bootstrap(store)
+      session = join(store, "yair-mbp")
+
+      :sys.replace_state(store, fn state ->
+        update_in(state, [:daemon_sessions, session["session_id"]], &Map.delete(&1, "team_id"))
+      end)
+
+      assert {:error, :team_gate_invalid_session} =
+               Store.upsert_gate(store, gate_payload(session, "gate_corrupt"))
+    end
+
+    test "claiming a mismatched team still reports team_mismatch" do
+      {now_fun, _advance} = ticking_now("2026-06-13T10:00:00Z")
+      {:ok, store} = Store.start_link(now: now_fun, id: counter_ids())
+      bootstrap(store)
+
+      {:ok, _team2} =
+        Store.create_team(store, %{
+          "org_slug" => "false-systems",
+          "slug" => "infra",
+          "name" => "Infra"
+        })
+
+      session = join(store, "yair-mbp")
+      payload = Map.put(gate_payload(session, "gate_x"), "team_slug", "infra")
+
+      assert {:error, :team_gate_team_mismatch} = Store.upsert_gate(store, payload)
+    end
+  end
+
+  defp ticking_now(start_iso) do
+    {:ok, start, _offset} = DateTime.from_iso8601(start_iso)
+    {:ok, agent} = Agent.start_link(fn -> start end)
+
+    now_fun = fn -> Agent.get(agent, & &1) end
+    advance = fn seconds -> Agent.update(agent, &DateTime.add(&1, seconds, :second)) end
+    {now_fun, advance}
+  end
+
+  defp counter_ids do
+    {:ok, agent} = Agent.start_link(fn -> 0 end)
+    fn -> "id_#{Agent.get_and_update(agent, &{&1 + 1, &1 + 1})}" end
+  end
+
+  defp bootstrap(store) do
+    {:ok, _org} = Store.create_org(store, %{"slug" => "false-systems", "name" => "FS"})
+
+    {:ok, _team} =
+      Store.create_team(store, %{
+        "org_slug" => "false-systems",
+        "slug" => "platform",
+        "name" => "Platform"
+      })
+
+    :ok
+  end
+
+  defp join(store, daemon_id) do
+    {:ok, _response, session} =
+      Store.create_daemon_session(store, %{
+        "org" => "false-systems",
+        "team" => "platform",
+        "daemon_id" => daemon_id,
+        "labels" => [],
+        "capabilities" => ["local"],
+        "version" => "0.7.0",
+        "accepts_remote_work" => false
+      })
+
+    session
+  end
+
+  defp gate_payload(session, gate_id) do
+    %{
+      "org_slug" => "false-systems",
+      "team_slug" => "platform",
+      "daemon_session_id" => session["session_id"],
+      "id" => gate_id,
+      "run_id" => "run_#{gate_id}",
+      "node_id" => nil,
+      "work_item_id" => nil,
+      "status" => "waiting",
+      "decided_by" => nil,
+      "decided_at" => nil,
+      "reason" => nil
+    }
+  end
+
+  defp publish_gate(store, session, gate_id) do
+    {:ok, gate, :inserted} = Store.upsert_gate(store, gate_payload(session, gate_id))
+    gate
+  end
+
+  defp decide(store, gate_id) do
+    {:ok, _gate} =
+      Store.record_gate_decision(store, gate_id, %{
+        "org_slug" => "false-systems",
+        "team_slug" => "platform",
+        "status" => "approved",
+        "decided_by" => "member:reviewer",
+        "decided_at" => "2026-06-13T10:01:00Z",
+        "reason" => "Reviewed"
+      })
+  end
 end

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -74,6 +74,12 @@ daemon status/session JSON surfaces.
 | `daemon.join_missing_team` | `sykli daemon join` was called without `--team`. | public-unstable | `core/lib/sykli/daemon/join.ex` |
 | `daemon.join_missing_token` | `sykli daemon join` was called without `--token` or `SYKLI_TEAM_TOKEN`. | public-unstable | `core/lib/sykli/daemon/join.ex` |
 | `daemon.stay_failed` | `sykli daemon join --stay` could not start the foreground heartbeat loop. | public-unstable | `core/lib/sykli/daemon/join.ex` |
+| `gate.invalid_payload` | Coordinator gate publish payload failed validation. | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
+| `gate.invalid_decision` | Coordinator gate decision payload failed validation. | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
+| `gate.invalid_session` | Coordinator daemon-session record is missing team metadata (server-side data corruption, not an authz failure). | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
+| `gate.unknown_session` | Gate publish referenced a daemon session the coordinator does not know. | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
+| `gate.team_mismatch` | Gate publish or decision claimed a team the daemon session does not belong to. | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
+| `gate.terminal` | Gate decision attempted on a gate already in a terminal status. | public-unstable | `core/lib/sykli/team_coordinator/router.ex` |
 | `daemon.invalid_leave_command` | `sykli daemon leave` received an unsupported flag or command form. | public-unstable | `core/lib/sykli/daemon/leave.ex` |
 | `daemon.leave_failed` | `sykli daemon leave` could not remove the local session file. | public-unstable | `core/lib/sykli/daemon/leave.ex` |
 


### PR DESCRIPTION
## What

Closes #202 and #205.

**#205 — orphaned decision queues.** The design insight: stop treating the per-session queue as the source of truth. Delivery state now lives on the gate record (`daemon_id` stamped at publish, `acknowledged_at` stamped on heartbeat ack), which makes queues a disposable delivery cache:

- **Retention:** sessions silent past `session_expiry_seconds` (default 300s = the protocol's resume cutoff; injectable for tests) are pruned with their queues + identity mappings, opportunistically on join/heartbeat — no timers in the in-memory skeleton.
- **Recovery:** a daemon rejoining after its old session was pruned gets decided-but-unacknowledged gates **re-enqueued from the gate records** and retargeted to the new session. This matters since #228: the heartbeat loop auto-rejoins on `session_not_found`, which previously could silently lose a decision queued for the dead session.
- The existing supersede fast path (queue move on same-identity rejoin) is kept; `replace_decision/2` dedups between the two paths.

**#202 — error conflation.** Corrupt session metadata (missing `team_id`) now reports `gate.invalid_session` (500 — server-side data problem) instead of `gate.team_mismatch` (403 — authz). Genuine mismatches unchanged.

**Bonus:** all six `gate.*` coordinator codes are now in `docs/error-codes.md` — none were cataloged.

## Testing

5 new store tests with an injected ticking clock: prune past expiry, **rejoin-after-prune recovers the undelivered decision**, acked-never-redelivered, corrupt-session → `invalid_session`, real mismatch → `team_mismatch`. Full suite 1796/0, credo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)