### PR TITLE
Harden MCP agent contract

### DIFF
--- a/core/lib/sykli/error.ex
+++ b/core/lib/sykli/error.ex
@@ -868,6 +868,66 @@ defmodule Sykli.Error do
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
+  # MCP TOOL ERRORS
+  # ─────────────────────────────────────────────────────────────────────────────
+  #
+  # Failures that originate inside the MCP tool dispatch itself (not the engine).
+  # Codes are public-unstable while the MCP surface stabilizes. Hints are written
+  # for an *agent* reader: each one should name a concrete next tool call.
+
+  @doc """
+  mcp.unknown_tool: An MCP `tools/call` named a tool that does not exist.
+  """
+  def mcp_unknown_tool(name) do
+    %__MODULE__{
+      code: "mcp.unknown_tool",
+      type: :validation,
+      message: "unknown MCP tool: #{name}",
+      step: :run,
+      hints: ["call tools/list to discover the available tool names"]
+    }
+  end
+
+  @doc """
+  mcp.no_occurrence: A tool needs occurrence data but none has been recorded yet.
+  """
+  def mcp_no_occurrence do
+    %__MODULE__{
+      code: "mcp.no_occurrence",
+      type: :execution,
+      message: "no occurrence data found for this project",
+      step: :run,
+      hints: ["call run_pipeline first to produce a run, then retry this tool"]
+    }
+  end
+
+  @doc """
+  mcp.missing_argument: A required tool argument was absent or empty.
+  """
+  def mcp_missing_argument(argument, tool) do
+    %__MODULE__{
+      code: "mcp.missing_argument",
+      type: :validation,
+      message: "missing required argument '#{argument}' for tool '#{tool}'",
+      step: :run,
+      hints: ["check the tool's inputSchema in tools/list and supply '#{argument}'"]
+    }
+  end
+
+  @doc """
+  mcp.tool_crashed: A tool raised an unexpected exception during dispatch.
+  """
+  def mcp_tool_crashed(message) do
+    %__MODULE__{
+      code: "mcp.tool_crashed",
+      type: :internal,
+      message: "MCP tool crashed: #{message}",
+      step: :run,
+      hints: ["report this issue at https://github.com/false-systems/sykli/issues"]
+    }
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
   # INTERNAL ERRORS
   # ─────────────────────────────────────────────────────────────────────────────
 

--- a/core/lib/sykli/mcp/protocol.ex
+++ b/core/lib/sykli/mcp/protocol.ex
@@ -8,6 +8,7 @@ defmodule Sykli.MCP.Protocol do
   and dispatches tool calls to `Sykli.MCP.Tools`.
   """
 
+  alias Sykli.CLI.JsonResponse
   alias Sykli.MCP.Tools
 
   @server_name "sykli"
@@ -54,15 +55,13 @@ defmodule Sykli.MCP.Protocol do
 
     case Tools.call(name, arguments) do
       {:ok, result} ->
-        json = Jason.encode!(result)
-
         ok_response(id, %{
-          "content" => [%{"type" => "text", "text" => json}]
+          "content" => [%{"type" => "text", "text" => JsonResponse.ok(result)}]
         })
 
-      {:error, message} ->
+      {:error, %Sykli.Error{} = error} ->
         ok_response(id, %{
-          "content" => [%{"type" => "text", "text" => message}],
+          "content" => [%{"type" => "text", "text" => JsonResponse.error(error)}],
           "isError" => true
         })
     end

--- a/core/lib/sykli/mcp/tools.ex
+++ b/core/lib/sykli/mcp/tools.ex
@@ -2,13 +2,19 @@ defmodule Sykli.MCP.Tools do
   @moduledoc """
   MCP tool definitions and implementations.
 
-  Five tools that expose sykli's core capabilities to AI assistants:
+  Seven tools that expose sykli's execution-graph capabilities to AI agents:
 
-  - `run_pipeline` — execute the pipeline
-  - `explain_pipeline` — describe pipeline structure
+  - `run_pipeline` — execute the graph
+  - `explain_pipeline` — describe graph structure
   - `get_failure` — get last failure with error context
   - `suggest_tests` — which tasks to run for changed files
   - `get_history` — recent runs with patterns
+  - `retry_task` — re-run specific tasks by name
+  - `run_fix` — structured analysis of the last failure
+
+  Every tool returns its result through the shared `Sykli.CLI.JsonResponse`
+  envelope (see `Sykli.MCP.Protocol`), and every failure is a coded
+  `%Sykli.Error{}` so agents branch on `error.code` instead of parsing prose.
   """
 
   alias Sykli.{Detector, Graph, Explain, RunHistory, Delta, Context}
@@ -22,7 +28,7 @@ defmodule Sykli.MCP.Tools do
       %{
         "name" => "run_pipeline",
         "description" =>
-          "Execute the sykli CI pipeline. Returns task statuses, durations, and errors.",
+          "Execute the sykli execution graph. Returns per-task status, duration, cache flags, typed failure semantics, and errors. CI is one use case; nodes may be build, test, review, or reasoning tasks.",
         "inputSchema" => %{
           "type" => "object",
           "properties" => %{
@@ -33,10 +39,12 @@ defmodule Sykli.MCP.Tools do
             "tasks" => %{
               "type" => "array",
               "items" => %{"type" => "string"},
+              "minItems" => 1,
               "description" => "Only run these specific tasks (default: all)"
             },
             "timeout" => %{
               "type" => "integer",
+              "minimum" => 1,
               "description" => "Per-task timeout in milliseconds (default: 300000)"
             }
           }
@@ -45,7 +53,7 @@ defmodule Sykli.MCP.Tools do
       %{
         "name" => "explain_pipeline",
         "description" =>
-          "Describe the pipeline structure: tasks, dependencies, execution levels, critical path, and semantic metadata. Zero-cost read-only operation.",
+          "Describe the execution graph structure: tasks, dependencies, execution levels, critical path, and semantic metadata. Zero-cost read-only operation.",
         "inputSchema" => %{
           "type" => "object",
           "properties" => %{
@@ -77,7 +85,7 @@ defmodule Sykli.MCP.Tools do
       %{
         "name" => "suggest_tests",
         "description" =>
-          "Suggest which tasks to run based on changed files. Uses semantic coverage and dependency analysis to find affected and skippable tasks.",
+          "Suggest which tasks to run based on changed files. Uses semantic coverage and dependency analysis to find affected and skippable tasks. Returns a ready-to-call `run_tasks` list for run_pipeline.",
         "inputSchema" => %{
           "type" => "object",
           "properties" => %{
@@ -107,6 +115,7 @@ defmodule Sykli.MCP.Tools do
             },
             "limit" => %{
               "type" => "integer",
+              "minimum" => 1,
               "description" => "Number of runs to return (default: 10)"
             }
           }
@@ -126,6 +135,7 @@ defmodule Sykli.MCP.Tools do
             "tasks" => %{
               "type" => "array",
               "items" => %{"type" => "string"},
+              "minItems" => 1,
               "description" => "Task names to retry"
             }
           },
@@ -156,14 +166,17 @@ defmodule Sykli.MCP.Tools do
   @doc """
   Dispatches a tool call by name.
 
-  Returns `{:ok, result_map}` or `{:error, message}`.
+  Returns `{:ok, result_map}` on success or `{:error, %Sykli.Error{}}` on
+  failure. The protocol layer renders both through the shared
+  `Sykli.CLI.JsonResponse` envelope so agents parse one shape across the CLI
+  and MCP surfaces.
   """
-  @spec call(String.t(), map()) :: {:ok, map()} | {:error, String.t()}
+  @spec call(String.t(), map()) :: {:ok, map()} | {:error, Sykli.Error.t()}
   def call(name, arguments) do
     do_call(name, arguments)
   rescue
     e ->
-      {:error, "Tool crashed: #{Exception.message(e)}"}
+      {:error, Sykli.Error.mcp_tool_crashed(Exception.message(e))}
   end
 
   # --- Tool implementations ---
@@ -188,7 +201,7 @@ defmodule Sykli.MCP.Tools do
          }}
 
       {:error, reason} ->
-        {:error, "Pipeline failed: #{inspect(reason)}"}
+        {:error, Sykli.Error.wrap(reason)}
     end
   end
 
@@ -211,7 +224,7 @@ defmodule Sykli.MCP.Tools do
       {:ok, explanation}
     else
       {:error, reason} ->
-        {:error, format_error(reason)}
+        {:error, mcp_error(reason)}
     end
   end
 
@@ -231,7 +244,7 @@ defmodule Sykli.MCP.Tools do
 
     case occurrence do
       nil ->
-        {:error, "No occurrence data found. Run 'sykli' first."}
+        {:error, Sykli.Error.mcp_no_occurrence()}
 
       data ->
         {:ok, data}
@@ -261,7 +274,14 @@ defmodule Sykli.MCP.Tools do
         end
 
       if changed_files == [] do
-        {:ok, %{changed_files: [], affected: [], skipped: [], message: "No changes detected"}}
+        {:ok,
+         %{
+           changed_files: [],
+           affected: [],
+           skipped: [],
+           run_tasks: [],
+           message: "No changes detected"
+         }}
       else
         # Semantic coverage analysis
         suggested = Context.tasks_for_changes(expanded, changed_files)
@@ -278,6 +298,10 @@ defmodule Sykli.MCP.Tools do
         suggested_set = MapSet.new(suggested)
         affected_set = MapSet.new(affected_names)
         run_set = MapSet.union(suggested_set, affected_set)
+
+        # Deduped, graph-ordered list an agent can pass straight to
+        # run_pipeline.tasks without reconstructing it from `affected`.
+        run_tasks = Enum.filter(all_task_names, &MapSet.member?(run_set, &1))
 
         skipped =
           all_task_names
@@ -298,12 +322,13 @@ defmodule Sykli.MCP.Tools do
          %{
            changed_files: changed_files,
            affected: affected,
-           skipped: skipped
+           skipped: skipped,
+           run_tasks: run_tasks
          }}
       end
     else
       {:error, reason} ->
-        {:error, format_error(reason)}
+        {:error, mcp_error(reason)}
     end
   end
 
@@ -376,7 +401,7 @@ defmodule Sykli.MCP.Tools do
     task_names = args["tasks"] || []
 
     if task_names == [] do
-      {:error, "No task names provided"}
+      {:error, Sykli.Error.mcp_missing_argument("tasks", "retry_task")}
     else
       name_set = MapSet.new(task_names)
       filter_fn = fn task -> MapSet.member?(name_set, task.name) end
@@ -400,7 +425,7 @@ defmodule Sykli.MCP.Tools do
            }}
 
         {:error, reason} ->
-          {:error, "Retry failed: #{inspect(reason)}"}
+          {:error, Sykli.Error.wrap(reason)}
       end
     end
   end
@@ -416,7 +441,7 @@ defmodule Sykli.MCP.Tools do
         {:ok, analysis}
 
       {:error, :no_occurrence} ->
-        {:error, "No occurrence data found. Run 'sykli' first."}
+        {:error, Sykli.Error.mcp_no_occurrence()}
 
       {:error, :no_failures} ->
         {:ok, %{status: "no_failures", message: "No failed tasks in the last run."}}
@@ -424,7 +449,7 @@ defmodule Sykli.MCP.Tools do
   end
 
   defp do_call(name, _args) do
-    {:error, "Unknown tool: #{name}"}
+    {:error, Sykli.Error.mcp_unknown_tool(name)}
   end
 
   # --- Helpers ---
@@ -538,18 +563,30 @@ defmodule Sykli.MCP.Tools do
     end
   end
 
-  defp format_error(:no_sdk_file), do: "No sykli SDK file found (sykli.go, sykli.rs, etc.)"
-  defp format_error({:go_failed, msg}), do: "Go SDK failed: #{msg}"
-  defp format_error({:rust_failed, msg}), do: "Rust SDK failed: #{msg}"
-  defp format_error({:elixir_failed, msg}), do: "Elixir SDK failed: #{msg}"
-  defp format_error({:typescript_failed, msg}), do: "TypeScript SDK failed: #{msg}"
-  defp format_error({:python_failed, msg}), do: "Python SDK failed: #{msg}"
-  defp format_error({:missing_tool, tool, hint}), do: "Missing #{tool}: #{hint}"
-  defp format_error({:task_type_on_review, _} = reason), do: Sykli.Graph.format_error(reason)
+  # Converts a parse/detect/SDK failure reason into a coded `%Sykli.Error{}`.
+  # Graph contract violations keep their rich `Graph.format_error/1` message but
+  # gain a stable code so agents branch without parsing prose; everything else
+  # routes through the engine-wide `Sykli.Error.wrap/1`.
+  defp mcp_error({:task_type_on_review, _} = reason), do: graph_contract_error(reason)
 
-  defp format_error({:task_type_requires_v3_or_newer, _, _, _} = reason),
-    do: Sykli.Graph.format_error(reason)
+  defp mcp_error({:task_type_requires_v3_or_newer, _, _, _} = reason),
+    do: graph_contract_error(reason)
 
-  defp format_error({:unknown_task_type, _, _} = reason), do: Sykli.Graph.format_error(reason)
-  defp format_error(reason), do: inspect(reason)
+  defp mcp_error({:unknown_task_type, _, _} = reason), do: graph_contract_error(reason)
+  defp mcp_error(reason), do: Sykli.Error.wrap(reason)
+
+  defp graph_contract_error(reason) do
+    message =
+      reason
+      |> Sykli.Graph.format_error()
+      |> String.replace_prefix("Error: ", "")
+
+    %Sykli.Error{
+      code: "graph.invalid_contract",
+      type: :validation,
+      step: :parse,
+      message: message,
+      hints: ["fix the contract violation in your SDK pipeline and re-emit"]
+    }
+  end
 end

--- a/core/test/sykli/mcp/protocol_test.exs
+++ b/core/test/sykli/mcp/protocol_test.exs
@@ -93,12 +93,15 @@ defmodule Sykli.MCP.ProtocolTest do
       assert is_list(content)
       assert length(content) == 1
       assert hd(content)["type"] == "text"
-      # Should be valid JSON
+      # Should be the shared JsonResponse envelope wrapping the tool result
       parsed = Jason.decode!(hd(content)["text"])
-      assert parsed["runs"] == []
+      assert parsed["ok"] == true
+      assert parsed["version"] == "1"
+      assert parsed["error"] == nil
+      assert parsed["data"]["runs"] == []
     end
 
-    test "returns isError for unknown tool" do
+    test "returns isError with a coded error envelope for unknown tool" do
       request = %{
         "jsonrpc" => "2.0",
         "id" => 4,
@@ -109,8 +112,11 @@ defmodule Sykli.MCP.ProtocolTest do
       response = Protocol.handle(request)
 
       assert response["result"]["isError"] == true
-      text = hd(response["result"]["content"])["text"]
-      assert text =~ "Unknown tool"
+      parsed = Jason.decode!(hd(response["result"]["content"])["text"])
+      assert parsed["ok"] == false
+      assert parsed["data"] == nil
+      assert parsed["error"]["code"] == "mcp.unknown_tool"
+      assert is_list(parsed["error"]["hints"])
     end
   end
 

--- a/core/test/sykli/mcp/tools_test.exs
+++ b/core/test/sykli/mcp/tools_test.exs
@@ -1,6 +1,7 @@
 defmodule Sykli.MCP.ToolsTest do
   use ExUnit.Case, async: true
 
+  alias Sykli.Error
   alias Sykli.MCP.Tools
 
   describe "list/0" do
@@ -27,14 +28,16 @@ defmodule Sykli.MCP.ToolsTest do
   end
 
   describe "call/2" do
-    test "unknown tool returns error" do
-      assert {:error, "Unknown tool: bogus"} = Tools.call("bogus", %{})
+    test "unknown tool returns a coded error" do
+      assert {:error, %Error{code: "mcp.unknown_tool"} = err} = Tools.call("bogus", %{})
+      assert err.hints != []
     end
 
-    test "explain_pipeline with nonexistent path returns error" do
+    test "explain_pipeline with nonexistent path returns a coded error" do
       path = "/tmp/sykli-mcp-test-#{:rand.uniform(999_999)}"
-      assert {:error, message} = Tools.call("explain_pipeline", %{"path" => path})
-      assert is_binary(message)
+      assert {:error, %Error{} = err} = Tools.call("explain_pipeline", %{"path" => path})
+      assert is_binary(err.code)
+      assert is_binary(err.message)
     end
 
     test "get_history with empty dir returns empty runs" do
@@ -48,35 +51,40 @@ defmodule Sykli.MCP.ToolsTest do
       assert result.patterns == %{}
     end
 
-    test "get_failure with no data returns error" do
+    test "get_failure with no data returns mcp.no_occurrence" do
       path = System.tmp_dir!() |> Path.join("sykli-mcp-test-#{:rand.uniform(999_999)}")
       File.mkdir_p!(path)
 
       on_exit(fn -> File.rm_rf!(path) end)
 
-      assert {:error, message} = Tools.call("get_failure", %{"path" => path})
-      assert message =~ "No occurrence data"
+      assert {:error, %Error{code: "mcp.no_occurrence"}} =
+               Tools.call("get_failure", %{"path" => path})
     end
 
-    test "tool crash is caught and returns error" do
+    test "missing required tasks argument returns mcp.missing_argument" do
+      assert {:error, %Error{code: "mcp.missing_argument"}} =
+               Tools.call("retry_task", %{"tasks" => []})
+    end
+
+    test "tool crash is caught and returns a coded error" do
       # suggest_tests with a nonexistent path should return an error, not crash
       path = "/tmp/sykli-mcp-test-#{:rand.uniform(999_999)}"
       result = Tools.call("suggest_tests", %{"path" => path})
-      assert {:error, _message} = result
+      assert {:error, %Error{}} = result
     end
 
-    test "retry_task with nonexistent path returns error" do
+    test "retry_task with nonexistent path returns a coded error" do
       path = "/tmp/sykli-mcp-test-#{:rand.uniform(999_999)}"
       result = Tools.call("retry_task", %{"path" => path, "tasks" => ["some_task"]})
-      assert {:error, message} = result
-      assert is_binary(message)
+      assert {:error, %Error{} = err} = result
+      assert is_binary(err.message)
     end
 
-    test "run_fix with nonexistent path returns error" do
+    test "run_fix with nonexistent path returns a coded error" do
       path = "/tmp/sykli-mcp-test-#{:rand.uniform(999_999)}"
       result = Tools.call("run_fix", %{"path" => path})
-      assert {:error, message} = result
-      assert is_binary(message)
+      assert {:error, %Error{} = err} = result
+      assert is_binary(err.message)
     end
 
     test "run_pipeline exposes agent-readable failure facts" do

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -174,6 +174,21 @@ daemon-side deferred publish path.
 | `source_not_found` / `source_not_regular` / `symlink_not_allowed` | Internal artifact-copy reasons returned by local target storage; callers should format or wrap them before exposing a public boundary. | internal | `core/lib/sykli/target/local.ex`, `core/lib/sykli/target/storage.ex` |
 | `unknown` | JSON envelope fallback when an error-like value is not a `Sykli.Error`. | internal | `core/lib/sykli/cli/json_response.ex:51`, `core/lib/sykli/cli.ex:317` |
 
+### mcp
+
+MCP tool-dispatch codes are public-unstable while the agent tool surface
+stabilizes. They originate inside `Sykli.MCP.Tools`, not the engine, and are
+rendered through the shared `Sykli.CLI.JsonResponse` envelope (with
+`isError: true`) so agents branch on `error.code` instead of parsing prose.
+
+| Code | Description | Tier | Emitted from |
+|------|-------------|------|--------------|
+| `mcp.unknown_tool` | An MCP `tools/call` named a tool that does not exist. | public-unstable | `core/lib/sykli/error.ex` |
+| `mcp.no_occurrence` | A tool needs occurrence data but no run has been recorded for the project yet. | public-unstable | `core/lib/sykli/error.ex` |
+| `mcp.missing_argument` | A required tool argument was absent or empty. | public-unstable | `core/lib/sykli/error.ex` |
+| `mcp.tool_crashed` | A tool raised an unexpected exception during dispatch. | public-unstable | `core/lib/sykli/error.ex` |
+| `graph.invalid_contract` | A graph contract violation surfaced while parsing the pipeline for a read-only MCP tool (e.g. `task_type` on a review node). | public-unstable | `core/lib/sykli/mcp/tools.ex` |
+
 ### runtime
 
 | Code | Description | Tier | Emitted from |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -6,21 +6,20 @@ Protocol notes:
 
 - Transport: stdio with `Content-Length` framed JSON-RPC 2.0 messages.
 - Lifecycle: `initialize`, `initialized`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`.
-- Tool result shape: `tools/call` returns MCP `content` with one `text` item. Successful tool maps are JSON-encoded into that text field; errors are plain text with `isError: true`.
-- JSON envelope: tools do **not** currently return the `Sykli.CLI.JsonResponse` envelope.
+- Tool result shape: `tools/call` returns MCP `content` with one `text` item. The text is always a JSON string using the shared `Sykli.CLI.JsonResponse` envelope (`{ok, version, data, error}`); successful tool maps are under `data`, and failures set `isError: true` with a coded `error`.
 - Typed result metadata: `run_pipeline`, `retry_task`, and `get_failure` task records may carry `failure_semantics`, `agent_hints`, `contract_slice`, `success_criteria_results`, and `evidence_results`. See `docs/failure-semantics.md`, `docs/agent-readable-failure-output.md`, and `docs/result-contract-slices.md`.
 
 ## Current Tools
 
 | Tool | Description | Parameter schema | Return shape | Composability |
 |------|-------------|------------------|--------------|---------------|
-| `run_pipeline` | Execute the current pipeline and return task statuses, durations, cache flags, and errors. | `path` string optional, description quality: acceptable. `tasks` array of strings optional, description quality: acceptable. `timeout` integer optional, description quality: acceptable but unit is milliseconds and not constrained. | Structured map encoded as JSON text. Success shape has `status: "passed"` and `tasks`; failure-with-results shape has `status: "failed"` and `tasks`; infrastructure errors return plain rendered text. No JSON envelope. | Natural start of a chain into `get_failure`, `run_fix`, and `get_history`. Weak link: errors are not stable structured codes. |
-| `explain_pipeline` | Describe pipeline structure, dependencies, execution levels, critical path, and semantic metadata without running tasks. | `path` string optional, description quality: acceptable. | Structured explanation map encoded as JSON text; errors are plain text. No JSON envelope. | Chains well before `run_pipeline` and `suggest_tests`. Also useful after SDK edits. |
-| `get_failure` | Return the latest or selected failure occurrence with error context. | `path` string optional, description quality: acceptable. `run_id` string optional, description quality: acceptable but format is unconstrained. | Returns raw occurrence data as JSON text when found. Missing data returns plain text error. No JSON envelope. | Chains from `run_pipeline` failure into `run_fix`. It is a dead end for agents when no occurrence exists because the error is prose only. |
-| `suggest_tests` | Suggest affected tasks for changed files using semantic coverage and dependency analysis. | `path` string optional, description quality: acceptable. `changed_files` array of strings optional, description quality: good. | Structured map encoded as JSON text with `changed_files`, `affected`, `skipped`, or a no-change `message`. No JSON envelope. | Chains naturally into `run_pipeline` by passing affected task names, but the return shape does not include a ready-to-call task list field. |
-| `get_history` | Return recent run history and computed patterns. | `path` string optional, description quality: acceptable. `limit` integer optional, description quality: acceptable but no min/max. | Structured map encoded as JSON text with `runs` and `patterns`. No JSON envelope. | Useful after `run_pipeline` or `get_failure` to assess flakiness. Does not expose query filters, so agents must post-process. |
-| `retry_task` | Re-run specific tasks by name. | `path` string optional, description quality: acceptable. `tasks` array of strings required, description quality: good but no `minItems`. | Structured map encoded as JSON text for task results; missing tasks returns plain text error. No JSON envelope. | Chains from `get_failure`, `suggest_tests`, or `explain_pipeline`. It partly duplicates `run_pipeline` with `tasks`, which may confuse agents. |
-| `run_fix` | Analyze the last failure and return structured fix analysis. | `path` string optional, description quality: acceptable. `task` string optional, description quality: acceptable. | Structured fix-analysis map encoded as JSON text, or plain text errors for no occurrence. No JSON envelope. | Natural terminal step after `get_failure`. It should be one of the most important agent tools, but its error surface is prose-only. |
+| `run_pipeline` | Execute the current graph and return task statuses, durations, cache flags, and errors. | `path` string optional, description quality: acceptable. `tasks` array of strings optional, description quality: acceptable and constrained with `minItems: 1`. `timeout` integer optional, milliseconds, constrained with `minimum: 1`. | Shared JSON envelope. `data.status` is `"passed"` or `"failed"` with `data.tasks`; infrastructure failures return coded `error` objects. | Natural start of a chain into `get_failure`, `run_fix`, and `get_history`. |
+| `explain_pipeline` | Describe graph structure, dependencies, execution levels, critical path, and semantic metadata without running tasks. | `path` string optional, description quality: acceptable. | Shared JSON envelope. Success data is the `Sykli.Explain.pipeline/2` map; failures return coded `error` objects. | Chains well before `run_pipeline` and `suggest_tests`. Also useful after SDK edits. |
+| `get_failure` | Return the latest or selected failure occurrence with error context. | `path` string optional, description quality: acceptable. `run_id` string optional, description quality: acceptable but format is unconstrained. | Shared JSON envelope. Success data is raw occurrence data. Missing data returns `mcp.no_occurrence`. | Chains from `run_pipeline` failure into `run_fix`; missing occurrence is machine-branchable. |
+| `suggest_tests` | Suggest affected tasks for changed files using semantic coverage and dependency analysis. | `path` string optional, description quality: acceptable. `changed_files` array of strings optional, description quality: good. | Shared JSON envelope with `changed_files`, `affected`, `skipped`, and `run_tasks`; no-change output includes an empty `run_tasks` and a message. | Chains naturally into `run_pipeline` by passing `data.run_tasks` to `run_pipeline.tasks`. |
+| `get_history` | Return recent run history and computed patterns. | `path` string optional, description quality: acceptable. `limit` integer optional, description quality: acceptable and constrained with `minimum: 1`. | Shared JSON envelope. Success data contains `runs` and `patterns`. | Useful after `run_pipeline` or `get_failure` to assess flakiness. Does not expose query filters, so agents must post-process. |
+| `retry_task` | Re-run specific tasks by name. | `path` string optional, description quality: acceptable. `tasks` array of strings required, description quality: good and constrained with `minItems: 1`. | Shared JSON envelope. Success data contains retry results; missing tasks returns `mcp.missing_argument`. | Chains from `get_failure`, `suggest_tests`, or `explain_pipeline`. It partly duplicates `run_pipeline` with `tasks`, which may confuse agents. |
+| `run_fix` | Analyze the last failure and return structured fix analysis. | `path` string optional, description quality: acceptable. `task` string optional, description quality: acceptable. | Shared JSON envelope. Success data is structured fix analysis; missing occurrence returns `mcp.no_occurrence`. | Natural terminal step after `get_failure`; its missing-data path is machine-branchable. |
 
 ## Tool Details
 
@@ -31,8 +30,8 @@ Parameters:
 | Name | Type | Required | Description quality | Notes |
 |------|------|----------|---------------------|-------|
 | `path` | string | no | acceptable | Defaults to current directory. Could specify path containment expectations. |
-| `tasks` | array<string> | no | acceptable | Filters by task name. No schema-level `minItems`. |
-| `timeout` | integer | no | acceptable | Milliseconds. No minimum or maximum. |
+| `tasks` | array<string> | no | acceptable | Filters by task name. Schema declares `minItems: 1`. |
+| `timeout` | integer | no | acceptable | Milliseconds. Schema declares `minimum: 1`; no maximum. |
 
 Return:
 
@@ -87,7 +86,7 @@ Parameters:
 |------|------|----------|---------------------|-------|
 | `path` | string | no | acceptable | Defaults to current directory. |
 
-Return: `Sykli.Explain.pipeline/2` map encoded as JSON text.
+Return: shared JSON envelope with `Sykli.Explain.pipeline/2` map under `data`.
 
 ### `get_failure`
 
@@ -98,7 +97,8 @@ Parameters:
 | `path` | string | no | acceptable | Used only for cold `.sykli/occurrence.json` fallback. |
 | `run_id` | string | no | acceptable | No pattern hint for valid run IDs. |
 
-Return: raw occurrence JSON map encoded as text, or prose error.
+Return: shared JSON envelope with raw occurrence JSON map under `data`, or
+`mcp.no_occurrence` under `error`.
 
 The returned occurrence contains typed result-metadata fields in each
 `data.tasks[]` record; see `docs/false-protocol-schema.md` for the on-disk
@@ -119,6 +119,7 @@ Return:
 ```json
 {
   "changed_files": ["lib/app.ex"],
+  "run_tasks": ["test"],
   "affected": [
     {
       "name": "test",
@@ -138,7 +139,7 @@ Parameters:
 | Name | Type | Required | Description quality | Notes |
 |------|------|----------|---------------------|-------|
 | `path` | string | no | acceptable | Defaults to current directory. |
-| `limit` | integer | no | acceptable | Defaults to 10. No upper bound in schema. |
+| `limit` | integer | no | acceptable | Defaults to 10. Schema declares `minimum: 1`; no upper bound. |
 
 Return:
 
@@ -172,9 +173,10 @@ Parameters:
 | Name | Type | Required | Description quality | Notes |
 |------|------|----------|---------------------|-------|
 | `path` | string | no | acceptable | Defaults to current directory. |
-| `tasks` | array<string> | yes | good | Required, but schema does not enforce non-empty arrays. |
+| `tasks` | array<string> | yes | good | Required. Schema declares `minItems: 1`; runtime also rejects empty arrays with `mcp.missing_argument`. |
 
-Return: structured retry result map encoded as JSON text, or prose error.
+Return: shared JSON envelope with structured retry result map under `data`, or
+coded failure under `error`.
 
 `retry_task` uses the same per-task return shape as `run_pipeline`, so the same
 typed result-metadata fields apply.
@@ -188,7 +190,8 @@ Parameters:
 | `path` | string | no | acceptable | Defaults to current directory. |
 | `task` | string | no | acceptable | Restricts analysis to a named failed task. |
 
-Return: `Sykli.Fix.analyze/2` map encoded as JSON text, or prose error.
+Return: shared JSON envelope with `Sykli.Fix.analyze/2` map under `data`, or
+coded failure under `error`.
 
 `run_fix` returns the fix-analysis map produced by `Sykli.Fix.analyze/2`. It
 does not surface `failure_semantics`, `agent_hints`, `contract_slice`,
@@ -197,22 +200,31 @@ that want those typed facts should call `get_failure`.
 
 ## Gaps And Recommendations
 
-1. **Return envelopes are inconsistent with the CLI agent contract.** MCP tools should return the `Sykli.CLI.JsonResponse` shape, or the MCP-specific reason for not doing so should be documented. Today success values are JSON text and errors are prose text.
+> **Resolved by MCP agent-contract hardening:** items 1, 2, 5, 7, 8,
+> and 9 below. `tools/call` now renders every result through the shared
+> `Sykli.CLI.JsonResponse` envelope; failures are coded `%Sykli.Error{}`
+> (`mcp.*` + `graph.invalid_contract`, see `docs/error-codes.md`) returned with
+> `isError: true`; schemas carry `minimum`/`minItems`; `suggest_tests` returns a
+> ready-to-call `run_tasks` list; tool descriptions use execution-graph language;
+> and the module doc lists all seven tools. The remaining items (3, 4, 6, 10)
+> are deferred.
 
-2. **Error codes are missing from MCP failures.** Tool failures like "No occurrence data found" and "Unknown tool" should expose stable `Sykli.Error` codes so agents can branch without parsing prose.
+1. ~~**Return envelopes are inconsistent with the CLI agent contract.**~~ Resolved — all tool results flow through `Sykli.CLI.JsonResponse`.
+
+2. ~~**Error codes are missing from MCP failures.**~~ Resolved — failures are coded `%Sykli.Error{}` (`mcp.unknown_tool`, `mcp.no_occurrence`, `mcp.missing_argument`, `mcp.tool_crashed`, `graph.invalid_contract`).
 
 3. **The tool list lacks `explain`, `query`, and richer history discovery parity.** `explain_pipeline` covers pipeline structure only; there is no direct MCP counterpart for `sykli query` grammar discovery or `sykli report`.
 
 4. **Review primitives have no MCP surface yet.** Once review nodes ship, agents will need a read-only graph inspection tool and a controlled invocation tool for review primitive execution. Do not add it before the graph model lands.
 
-5. **Schemas should tighten loose integers and arrays.** Add `minimum` for `timeout` and `limit`, `minItems` for required `tasks`, and enum-like constraints where a future parameter has known modes.
+5. ~~**Schemas should tighten loose integers and arrays.**~~ Resolved — `minimum` on `timeout`/`limit`, `minItems` on `tasks`.
 
 6. **`retry_task` duplicates `run_pipeline` filtering.** Consider either documenting `retry_task` as a convenience wrapper or folding it into a more general `run_pipeline` schema with a clear `mode`.
 
-7. **`suggest_tests` should return a ready-to-call task list.** Add a `run_tasks` array so agents can pass it directly to `run_pipeline.tasks` without reconstructing from `affected`.
+7. ~~**`suggest_tests` should return a ready-to-call task list.**~~ Resolved — `suggest_tests` now returns a graph-ordered, deduped `run_tasks` array.
 
-8. **Tool descriptions still say "CI pipeline".** ADR-022 reframes sykli as execution graphs as code. MCP descriptions should use graph language so agents do not treat non-CI nodes as unsupported.
+8. ~~**Tool descriptions still say "CI pipeline".**~~ Resolved — descriptions use execution-graph language.
 
-9. **Module documentation says five tools, but seven are exposed.** Keep implementation docs aligned with `tools/list` so audits do not diverge from the actual protocol surface.
+9. ~~**Module documentation says five tools, but seven are exposed.**~~ Resolved.
 
 10. **Token efficiency is uneven.** `get_failure` returns the full occurrence by default. Add a terse default with an explicit verbose flag or field selector so agents do not pay for large logs unless they ask.


### PR DESCRIPTION
## Summary
- Normalize MCP tools/call responses behind the shared {ok, version, data, error} envelope
- Translate MCP failures into coded Sykli.Errors for agent branching
- Add suggest_tests.run_tasks, tighten MCP schemas, and update protocol/tools/docs coverage

## Validation
- cd core && mix test test/sykli/mcp/protocol_test.exs test/sykli/mcp/tools_test.exs
- cd core && mix format
- cd core && mix test