### PR TITLE
fix(github): mask secrets in Check Run output (#240)

### DIFF
--- a/core/lib/sykli/github/check_run_formatter.ex
+++ b/core/lib/sykli/github/check_run_formatter.ex
@@ -2,6 +2,8 @@ defmodule Sykli.GitHub.CheckRunFormatter do
   @moduledoc "Formats task results for GitHub check runs."
 
   alias Sykli.Executor.TaskResult
+  alias Sykli.Services.SecretMasker
+  alias Sykli.Services.SecretPatterns
 
   @max_lines 50
 
@@ -44,10 +46,17 @@ defmodule Sykli.GitHub.CheckRunFormatter do
   end
 
   defp output_block(%TaskResult{} = result) do
+    # GitHub Check Run summaries are a public egress surface. Mask the run's resolved
+    # secret values (per-task + env-derived) before truncation so a secret split across
+    # the @max_lines boundary is still redacted. Output is freeform text, so the
+    # value-based masking mechanism applies (mask_deep is for keyed maps).
+    secrets = SecretPatterns.all_values(result.secret_values)
+
     output =
       [result.output, error_output(result.error)]
       |> Enum.reject(&is_nil/1)
       |> Enum.join("\n")
+      |> SecretMasker.mask_string(secrets)
       |> last_lines(@max_lines)
 
     if output == "" do

--- a/core/test/sykli/github/check_run_formatter_test.exs
+++ b/core/test/sykli/github/check_run_formatter_test.exs
@@ -36,6 +36,60 @@ defmodule Sykli.GitHub.CheckRunFormatterTest do
     assert CheckRunFormatter.format(result).title == "deps: cached (cache hit)"
   end
 
+  test "masks resolved secret values in the output summary" do
+    secret = "super-secret-token-value"
+
+    result = %TaskResult{
+      name: "deploy",
+      status: :passed,
+      duration_ms: 5,
+      output: "connecting with #{secret} ...\ndone",
+      command: "deploy",
+      secret_values: [secret]
+    }
+
+    summary = CheckRunFormatter.format(result).summary
+
+    refute summary =~ secret
+    assert summary =~ "***MASKED***"
+    assert summary =~ "done"
+  end
+
+  test "masks secret values that appear in error output" do
+    secret = "another-secret-9999"
+
+    result = %TaskResult{
+      name: "publish",
+      status: :errored,
+      duration_ms: 7,
+      error: Sykli.Error.internal("auth failed using #{secret}"),
+      output: nil,
+      command: "publish",
+      secret_values: [secret]
+    }
+
+    summary = CheckRunFormatter.format(result).summary
+
+    refute summary =~ secret
+    assert summary =~ "Infrastructure failure"
+  end
+
+  test "leaves output untouched when there are no secrets" do
+    result = %TaskResult{
+      name: "build",
+      status: :failed,
+      duration_ms: 3,
+      output: "compile error on line 12",
+      command: "build",
+      secret_values: []
+    }
+
+    summary = CheckRunFormatter.format(result).summary
+
+    assert summary =~ "compile error on line 12"
+    refute summary =~ "***MASKED***"
+  end
+
   defp conclusion(status) do
     CheckRunFormatter.conclusion(%TaskResult{name: "task", status: status, duration_ms: 1})
   end


### PR DESCRIPTION
## What

GitHub Check Run summaries are a **public** egress surface, but `CheckRunFormatter` injected raw task `output`/`error` with no masking — unlike every other egress boundary (occurrence persistence, notifications, attestations, team run summaries). A task that printed a resolved secret to stdout would surface it in a public PR Checks tab.

## Fix

In `output_block/1`, mask the run's resolved secret values before truncation:
- `SecretPatterns.all_values(result.secret_values)` — per-task resolved values **plus** env-derived values.
- `SecretMasker.mask_string/2` — value-based masking (the applicable mechanism for freeform text; `mask_deep` is for keyed maps).
- Masking happens **before** `last_lines/2` so a secret split across the `@max_lines` boundary is still redacted.

`format/1` stays pure (input `TaskResult` already carries `secret_values`); no signature change.

## Tests

`check_run_formatter_test.exs`:
- secret value in `output` → masked
- secret value in `error.output` (`:errored`) → masked
- no-secret output → unchanged

All GitHub tests green (45 passed); credo clean.

## Context

Found in the 2026-06-27 architecture deep-dive. Closes #240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)