### PR TITLE
fix(executor): memoize task-level computation (#238)

### DIFF
--- a/core/lib/sykli/executor.ex
+++ b/core/lib/sykli/executor.ex
@@ -260,11 +260,16 @@ defmodule Sykli.Executor do
     # Start with all tasks at level 0
     task_names = Enum.map(tasks, & &1.name)
 
-    # Calculate level for each task
-    levels =
-      task_names
-      |> Enum.map(fn name -> {name, calc_level(name, graph, %{})} end)
-      |> Map.new()
+    # Calculate level for each task, threading a shared memo through every
+    # computation. The cache is carried forward so a dependency subtree shared by
+    # multiple tasks is computed once — previously the cache was passed but never
+    # populated, so each node re-descended its full subtree (O(exp) on deep
+    # diamond DAGs).
+    {levels, _cache} =
+      Enum.reduce(task_names, {%{}, %{}}, fn name, {levels, cache} ->
+        {level, cache} = calc_level(name, graph, cache)
+        {Map.put(levels, name, level), cache}
+      end)
 
     # Group by level, return list of lists
     tasks
@@ -273,24 +278,36 @@ defmodule Sykli.Executor do
     |> Enum.map(fn {_level, level_tasks} -> level_tasks end)
   end
 
-  # Recursive level calculation:
-  # level = max(level of all dependencies) + 1
-  # base case: no deps = level 0
+  # Recursive level calculation with memoization:
+  # level = max(level of all dependencies) + 1; base case: no deps = level 0.
+  # Returns `{level, updated_cache}` so each node's level is computed once and
+  # reused. (The graph is a validated DAG by the time this runs — cycles are
+  # rejected upstream — so the recursion terminates.)
   defp calc_level(name, graph, cache) do
-    if Map.has_key?(cache, name) do
-      cache[name]
-    else
-      task = Map.get(graph, name)
-      deps = if task, do: task.depends_on, else: []
+    case Map.fetch(cache, name) do
+      {:ok, level} ->
+        {level, cache}
 
-      if deps == [] do
-        0
-      else
-        deps
-        |> Enum.map(&calc_level(&1, graph, cache))
-        |> Enum.max()
-        |> Kernel.+(1)
-      end
+      :error ->
+        task = Map.get(graph, name)
+        deps = if task, do: task.depends_on || [], else: []
+
+        {level, cache} =
+          case deps do
+            [] ->
+              {0, cache}
+
+            deps ->
+              {max_dep, cache} =
+                Enum.reduce(deps, {-1, cache}, fn dep, {acc_max, cache} ->
+                  {dep_level, cache} = calc_level(dep, graph, cache)
+                  {max(acc_max, dep_level), cache}
+                end)
+
+              {max_dep + 1, cache}
+          end
+
+        {level, Map.put(cache, name, level)}
     end
   end
 

--- a/core/test/sykli/executor/retry_test.exs
+++ b/core/test/sykli/executor/retry_test.exs
@@ -75,6 +75,37 @@ defmodule Sykli.Executor.RetryTest do
       level_names = Enum.map(levels, fn l -> Enum.map(l, & &1.name) |> Enum.sort() end)
       assert level_names == [["a"], ["b", "c"], ["d"]]
     end
+
+    test "deep nested diamonds memoize shared subtrees with correct levels" do
+      # Chained diamonds: each merge node n_i fans out to a_i/b_i which both merge
+      # into n_i. Every n_i is a subtree shared by the pair above it — exactly the
+      # shape that made the (previously un-memoized) level calc exponential. The
+      # levels must still be exact: n_i sits at level 2*i, the a/b pair at 2*i-1.
+      tasks =
+        [%Task{name: "n0", command: "echo", depends_on: []}] ++
+          Enum.flat_map(1..8, fn i ->
+            prev = "n#{i - 1}"
+
+            [
+              %Task{name: "a#{i}", command: "echo", depends_on: [prev]},
+              %Task{name: "b#{i}", command: "echo", depends_on: [prev]},
+              %Task{name: "n#{i}", command: "echo", depends_on: ["a#{i}", "b#{i}"]}
+            ]
+          end)
+
+      graph = build_graph(tasks)
+      levels = Executor.group_by_level(tasks, graph)
+
+      level_of = fn name ->
+        Enum.find_index(levels, fn level -> Enum.any?(level, &(&1.name == name)) end)
+      end
+
+      assert length(levels) == 17
+      assert level_of.("n0") == 0
+      assert level_of.("a1") == 1
+      assert level_of.("n1") == 2
+      assert level_of.("n8") == 16
+    end
   end
 
   describe "TaskResult status contract" do


### PR DESCRIPTION
## What

`group_by_level/2` computed each task's DAG level via `calc_level/3`, which accepted a memo `cache` but **never populated it** — the recursive calls passed the same empty map and results were never stored back. Every node re-descended its full dependency subtree, making level computation **exponential on deep diamond DAGs** (shared subtrees recomputed once per path).

## Fix

Thread the memo through: `calc_level/3` returns `{level, updated_cache}` and `group_by_level/2` folds the cache across all tasks, so each node's level is computed exactly once. **Output levels are identical** — this is a performance fix, not a behavior change. The graph is a validated DAG when this runs (cycles rejected upstream), so the recursion still terminates.

## Tests

Adds a chained-nested-diamonds case to `retry_test.exs` — the shared-subtree shape that triggered the blowup — pinning exact levels through the merges. Existing `group_by_level/2` cases (linear/independent/diamond) unchanged and green. Full suite green (1798 passed); credo clean.

Found in the 2026-06-27 architecture deep-dive. Closes #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)