### PR TITLE
fix(team): use start_child for run-summary sync, not async_nolink (#246)

### DIFF
--- a/core/lib/sykli.ex
+++ b/core/lib/sykli.ex
@@ -536,7 +536,10 @@ defmodule Sykli do
         prequeued? =
           Sykli.Outbox.enqueue("runs", payload, path: path, secrets: secret_values) == :ok
 
-        Task.Supervisor.async_nolink(Sykli.TaskSupervisor, fn ->
+        # Fire-and-forget: start_child (not async_nolink) so no reply/`:DOWN`
+        # message accumulates in long-lived callers like the MCP server. The
+        # run summary is best-effort and deferred to the outbox on failure.
+        Task.Supervisor.start_child(Sykli.TaskSupervisor, fn ->
           publish_or_enqueue_run_summary(
             session,
             summary,

--- a/core/test/sykli/team_coordinator/run_summary_sync_test.exs
+++ b/core/test/sykli/team_coordinator/run_summary_sync_test.exs
@@ -1,0 +1,65 @@
+defmodule Sykli.TeamCoordinator.RunSummarySyncTest do
+  @moduledoc """
+  Guards that run-summary sync is genuinely fire-and-forget (#246).
+
+  `maybe_sync_run_summary/3` spawns the publish via `Task.Supervisor.start_child`,
+  NOT `async_nolink`. `async_nolink` would monitor from the caller, leaving a
+  `{ref, reply}` and a `{:DOWN, ...}` in the caller's mailbox — a leak for
+  long-lived callers like the MCP server. This test drives a real run with a
+  daemon session and asserts no such messages reach the caller.
+  """
+  use ExUnit.Case, async: false
+
+  alias Sykli.Daemon.SessionStore
+  alias Sykli.Occurrence
+
+  @moduletag :tmp_dir
+
+  setup do
+    # No team token → the sync takes the network-free defer path (outbox + PubSub).
+    prev = System.get_env("SYKLI_TEAM_TOKEN")
+    System.delete_env("SYKLI_TEAM_TOKEN")
+    on_exit(fn -> if prev, do: System.put_env("SYKLI_TEAM_TOKEN", prev) end)
+    :ok
+  end
+
+  test "run-summary sync leaves no Task reply/:DOWN in the caller mailbox", %{tmp_dir: tmp_dir} do
+    write_pipeline(tmp_dir, "true")
+
+    {:ok, _} =
+      SessionStore.write(
+        %{
+          "session_id" => "sess_test",
+          "coordinator_url" => "http://127.0.0.1:0",
+          "org" => "acme",
+          "team" => "platform",
+          "team_id" => "team_1",
+          "daemon_id" => "d1"
+        },
+        path: Path.join(tmp_dir, ".sykli")
+      )
+
+    Sykli.Occurrence.PubSub.subscribe(:all)
+
+    assert {:ok, _results} = Sykli.run(tmp_dir)
+
+    # The deferred-sync occurrence is broadcast from inside the spawned task, so
+    # receiving it proves the fire-and-forget publish actually ran.
+    assert_receive %Occurrence{type: "ci.team.run.sync_deferred"}, 2_000
+
+    # Give an async_nolink task (the regression) time to send its reply/:DOWN.
+    # With start_child there is no monitor, so nothing ever arrives.
+    Process.sleep(50)
+
+    # async_nolink monitors from the caller, so it would deliver a :DOWN here.
+    # start_child does not — the mailbox stays free of it.
+    refute_received {:DOWN, _ref, :process, _pid, _reason}
+  end
+
+  defp write_pipeline(tmp_dir, command) do
+    json =
+      Jason.encode!(%{"version" => "1", "tasks" => [%{"name" => "test", "command" => command}]})
+
+    File.write!(Path.join(tmp_dir, "sykli.exs"), "IO.puts(#{inspect(json)})")
+  end
+end


### PR DESCRIPTION
## What

`maybe_sync_run_summary/3` fired the run-summary publish via `Task.Supervisor.async_nolink` and never awaited it, so the task's reply (and `:DOWN`) messages accumulated in the caller's mailbox — a leak for long-lived callers like the MCP server. The Monster Phase E convention (CLAUDE.md) moved fire-and-forget paths to `Task.Supervisor.start_child` precisely for this; this one path was missed.

## Fix

Swap `async_nolink` → `start_child`. Behavior unchanged — the publish is best-effort and already defers to the outbox on failure.

Full suite green (1797 passed); team-coordinator suite green (57).

Found in the 2026-06-27 deep-dive. Closes #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)