### PR TITLE
docs: reconcile conformance + coordinator drift (#243, #249)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ eval/harness/run.sh --case 001 --dry-run    # preview without running
 
 - `core/test/` — Elixir unit/integration tests run by `mix test`.
 - `test/blackbox/` — shell-driven black-box suite against the built `sykli` binary (dataset in `dataset.json`).
-- `tests/conformance/cases/` — positive cross-SDK conformance cases. SDKs must emit byte-identical JSON for these.
+- `tests/conformance/cases/` — positive cross-SDK conformance cases. SDKs must emit semantically-identical JSON for these (the runner normalizes key order and whitespace before comparing; `Sykli.ContractHash` likewise canonicalizes before hashing).
 - `tests/conformance/schema-invalid/` — negative schema-rejection fixtures. The schema validator asserts each one **fails** validation; missing-rejection is itself a failure.
 - `tests/conformance/fixtures/<sdk>/` — per-SDK pipeline files for each case in `cases/`.
 - `eval/oracle/` + `eval/harness/` — ground-truth cases and the AI-agent eval loop.

--- a/core/lib/sykli/cli/coordinator.ex
+++ b/core/lib/sykli/cli/coordinator.ex
@@ -333,7 +333,8 @@ defmodule Sykli.CLI.Coordinator do
       --bind ADDRESS  Listen address (default: #{@default_bind}; use 0.0.0.0 only intentionally)
 
     The coordinator skeleton stores state in memory. It exposes health,
-    org/team, and work item endpoints only; it does not execute work.
+    org/team, work-item, run, gate (including gate decisions), and
+    daemon-session/heartbeat endpoints; it never executes work.
     """)
   end
 end

--- a/docs/daemon-join-protocol.md
+++ b/docs/daemon-join-protocol.md
@@ -292,17 +292,15 @@ The daemon emits the following events as POSTs to the relevant API:
 
 - `work.created` — `POST /v1/work-items`
 - `work.claimed` — `POST /v1/work-items/:id/claim`
-- `run.started` — `POST /v1/runs`
-- `run.node.updated` — `POST /v1/runs/:id/nodes`
-- `success_criteria.failed` — recorded under `POST /v1/runs/:id/nodes`
-  with the criterion result body
-- `review.completed` — recorded under `POST /v1/runs/:id/nodes` with
-  the review result body
+- `run.completed` — `POST /v1/runs` — the implemented run sync posts one
+  **complete, metadata-only** run summary per run. Node state, success-criteria
+  results, review results, and evidence refs all travel inside that single POST
+  body; there are no separate `/v1/runs/:id/nodes`, `PATCH /v1/runs/:id`, or
+  `/v1/evidence-refs` endpoints today (incremental run-node streaming and an
+  evidence-ref endpoint are possible later slices).
 - `gate.requested` — `POST /v1/gates`
 - `gate.decided` — `POST /v1/gates/:id/decisions` (approve or reject;
   originates from a CLI/MCP call against the coordinator, not the daemon)
-- `run.completed` — `PATCH /v1/runs/:id`
-- `evidence.ref.created` — `POST /v1/evidence-refs`
 
 Every event must carry the originating `daemon_id`, `run_id` (when
 applicable), and `contract_hash` (for runs). Each event must be

--- a/docs/daemon-join-protocol.md
+++ b/docs/daemon-join-protocol.md
@@ -299,9 +299,8 @@ The daemon emits the following events as POSTs to the relevant API:
 - `review.completed` — recorded under `POST /v1/runs/:id/nodes` with
   the review result body
 - `gate.requested` — `POST /v1/gates`
-- `gate.approved` — `POST /v1/gates/:id/approve` (originates from a
-  CLI/MCP call against the coordinator, not the daemon)
-- `gate.rejected` — `POST /v1/gates/:id/reject`
+- `gate.decided` — `POST /v1/gates/:id/decisions` (approve or reject;
+  originates from a CLI/MCP call against the coordinator, not the daemon)
 - `run.completed` — `PATCH /v1/runs/:id`
 - `evidence.ref.created` — `POST /v1/evidence-refs`
 

--- a/docs/self-hosted-coordinator.md
+++ b/docs/self-hosted-coordinator.md
@@ -524,8 +524,8 @@ Gates:
 ```text
 GET   /v1/gates                      # list waiting/decided
 POST  /v1/gates                      # daemon registers a waiting gate
-POST  /v1/gates/:id/approve          # approver decision
-POST  /v1/gates/:id/reject           # approver decision
+GET   /v1/gates/:id                  # show
+POST  /v1/gates/:id/decisions        # approver decision (approve or reject)
 ```
 
 Evidence:
@@ -578,6 +578,17 @@ POST /v1/work-items
 GET  /v1/work-items/:id
 POST /v1/work-items/:id/claim
 POST /v1/work-items/:id/notes
+POST /v1/runs
+GET  /v1/runs
+GET  /v1/runs/:id
+POST /v1/gates
+GET  /v1/gates
+GET  /v1/gates/:id
+POST /v1/gates/:id/decisions
+POST /v1/daemon-sessions
+GET  /v1/daemon-sessions
+GET  /v1/daemon-sessions/:id
+POST /v1/daemon-sessions/:id/heartbeat
 ```
 
 All `/v1/*` endpoints require `Authorization: Bearer <token>`.

--- a/docs/self-hosted-coordinator.md
+++ b/docs/self-hosted-coordinator.md
@@ -507,16 +507,18 @@ GET   /v1/work-items                 # list, filter by team/status/assignee
 POST  /v1/work-items                 # create
 GET   /v1/work-items/:id             # show
 POST  /v1/work-items/:id/claim       # actor claims
-POST  /v1/work-items/:id/assign      # owner/approver assigns
+POST  /v1/work-items/:id/assign      # owner/approver assigns (planned; not in current skeleton)
 POST  /v1/work-items/:id/notes       # append note
 ```
 
-Runs:
+Runs (the implemented sync posts one complete, metadata-only summary per run;
+node/criteria/review/evidence refs travel inside the `POST /v1/runs` body —
+there is no incremental run-node or run-patch endpoint today):
 
 ```text
-POST  /v1/runs                       # daemon reports a new run
-PATCH /v1/runs/:id                   # update status / finished_at / summary
-POST  /v1/runs/:id/nodes             # append/update run node state
+POST  /v1/runs                       # daemon reports a complete run summary
+GET   /v1/runs                       # list
+GET   /v1/runs/:id                   # show
 ```
 
 Gates:
@@ -528,7 +530,8 @@ GET   /v1/gates/:id                  # show
 POST  /v1/gates/:id/decisions        # approver decision (approve or reject)
 ```
 
-Evidence:
+Evidence (planned; **not in the current skeleton** — evidence refs travel
+inside the `POST /v1/runs` summary body today):
 
 ```text
 POST  /v1/evidence-refs              # daemon registers a reference

--- a/tests/conformance/run.sh
+++ b/tests/conformance/run.sh
@@ -119,7 +119,8 @@ else
 fi
 echo ""
 
-# Normalize JSON for comparison: sort keys, compact, normalize provides without value
+# Normalize JSON for comparison: sort keys and compact (whitespace-insensitive).
+# Comparison is semantic, not byte-for-byte: SDKs may differ in key order/whitespace.
 normalize_json() {
   python3 -c "
 import json, sys


### PR DESCRIPTION
Two documentation-drift findings from the 2026-06-27 deep-dive. **Docs/comments/help only — no logic change.**

## #243 — "byte-identical" overstated
The conformance runner compares **normalized** JSON (sorted keys, stripped whitespace via `json.dumps(sort_keys=True, separators=(',',':'))`), so SDKs need only be *semantically* identical. Softened the CLAUDE.md claim and fixed the stale `run.sh` comment (`normalize provides without value` described logic that no longer exists). Left the genuinely-byte-identical references (Fake-runtime replay determinism, same-input-same-output) untouched.

## #249 — coordinator docs/CLI help drift
- CLI `coordinator` help claimed "health, org/team, and work item endpoints **only**" — the router also serves runs, gates (incl. decisions), and daemon-session/heartbeat. Reworded.
- The "current skeleton implements" list in `self-hosted-coordinator.md` undersold the surface — added the runs / gates / gate-decisions / daemon-session endpoints that are actually wired.
- Gate decisions use `POST /v1/gates/:id/decisions`, not the documented `/approve` + `/reject` — reconciled in `self-hosted-coordinator.md` and `daemon-join-protocol.md`.

Closes #243, closes #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)