### PR TITLE
fix(team): drain team outboxes from the workdir, not cwd (#203)

### DIFF
--- a/core/lib/sykli/daemon/heartbeat.ex
+++ b/core/lib/sykli/daemon/heartbeat.ex
@@ -167,7 +167,7 @@ defmodule Sykli.Daemon.Heartbeat do
 
   defp handle_success(state, data) do
     if state.failures > 0 or not state.synced_once do
-      outbox_drain(state.opts).()
+      outbox_drain(state).()
     end
 
     refuse_unconsented_assignments(state, data)
@@ -318,8 +318,24 @@ defmodule Sykli.Daemon.Heartbeat do
     schedule_fun.(delay_ms)
   end
 
-  defp outbox_drain(opts),
-    do: Keyword.get(opts, :outbox_drain, fn -> Sykli.TeamCoordinator.OutboxDrain.drain_all() end)
+  defp outbox_drain(%__MODULE__{} = state) do
+    Keyword.get(state.opts, :outbox_drain, fn ->
+      Sykli.TeamCoordinator.OutboxDrain.drain_all(drain_opts(state))
+    end)
+  end
+
+  # Drain with the loop's LIVE session (not a cwd re-read, which could miss a
+  # daemon configured at a non-cwd path or pick up a stale session after rejoin)
+  # and the daemon's workdir. The heartbeat's :path opt is the `.sykli` dir
+  # (SessionStore convention), so the outbox workdir is its parent (#203).
+  defp drain_opts(state) do
+    base = [session: state.session, token: state.token]
+
+    case Keyword.get(state.opts, :path) do
+      nil -> base
+      sykli_dir -> Keyword.put(base, :path, Path.dirname(sykli_dir))
+    end
+  end
 
   defp jitter_fun(opts), do: Keyword.get(opts, :jitter_fun, &:rand.uniform/1)
 

--- a/core/lib/sykli/team_coordinator/outbox_drain.ex
+++ b/core/lib/sykli/team_coordinator/outbox_drain.ex
@@ -25,15 +25,19 @@ defmodule Sykli.TeamCoordinator.OutboxDrain do
   def drain_runs(opts \\ []) do
     with_session_and_token(opts, fn session, token ->
       result =
-        Sykli.Outbox.drain("runs", fn payload ->
-          Sykli.TeamCoordinator.RunClient.publish_raw(session, token, payload)
-        end)
+        Sykli.Outbox.drain(
+          "runs",
+          fn payload ->
+            Sykli.TeamCoordinator.RunClient.publish_raw(session, token, payload)
+          end,
+          outbox_opts(opts)
+        )
 
       count_synced = synced_count(result)
 
       if count_synced > 0 do
         remaining =
-          case Sykli.Outbox.pending_count("runs") do
+          case Sykli.Outbox.pending_count("runs", outbox_opts(opts)) do
             {:ok, count} -> count
             {:error, _reason} -> 0
           end
@@ -51,13 +55,17 @@ defmodule Sykli.TeamCoordinator.OutboxDrain do
   def drain_gates(opts \\ []) do
     with_session_and_token(opts, fn session, token ->
       result =
-        Sykli.Outbox.drain("gates", fn payload ->
-          if payload["daemon_session_id"] == session["session_id"] do
-            Sykli.TeamCoordinator.GateClient.publish_raw(session, token, payload)
-          else
-            {:error, :team_gate_invalid_payload}
-          end
-        end)
+        Sykli.Outbox.drain(
+          "gates",
+          fn payload ->
+            if payload["daemon_session_id"] == session["session_id"] do
+              Sykli.TeamCoordinator.GateClient.publish_raw(session, token, payload)
+            else
+              {:error, :team_gate_invalid_payload}
+            end
+          end,
+          outbox_opts(opts)
+        )
 
       count_synced = synced_count(result)
 
@@ -76,7 +84,7 @@ defmodule Sykli.TeamCoordinator.OutboxDrain do
     session_result =
       case Keyword.fetch(opts, :session) do
         {:ok, session} when is_map(session) -> {:ok, session}
-        _ -> SessionStore.read()
+        _ -> SessionStore.read(session_opts(opts))
       end
 
     token = Keyword.get(opts, :token) || System.get_env("SYKLI_TEAM_TOKEN")
@@ -91,4 +99,22 @@ defmodule Sykli.TeamCoordinator.OutboxDrain do
 
   defp synced_count({:ok, count}), do: count
   defp synced_count({:error, count, _reason}), do: count
+
+  # `:path` here is the workdir (matching the executor's `Outbox.enqueue(..., path: workdir)`
+  # and `Outbox`'s own convention). Threading it makes the drain read the same
+  # `.sykli/outbox/` the enqueue wrote, instead of defaulting to cwd (#203).
+  defp outbox_opts(opts) do
+    case Keyword.get(opts, :path) do
+      nil -> []
+      path -> [path: path]
+    end
+  end
+
+  # SessionStore takes the `.sykli` directory, which lives under the workdir.
+  defp session_opts(opts) do
+    case Keyword.get(opts, :path) do
+      nil -> []
+      path -> [path: Path.join(path, ".sykli")]
+    end
+  end
 end

--- a/core/test/sykli/team_coordinator/outbox_drain_test.exs
+++ b/core/test/sykli/team_coordinator/outbox_drain_test.exs
@@ -1,0 +1,43 @@
+defmodule Sykli.TeamCoordinator.OutboxDrainTest do
+  @moduledoc """
+  Guards that the team outbox drain reads the workdir it was given, not cwd (#203).
+
+  The executor enqueues deferred syncs with `Outbox.enqueue(..., path: workdir)`.
+  Before the fix the drain dropped its opts and defaulted to cwd, so a run whose
+  workdir differs from the daemon's cwd silently never drained.
+  """
+  use ExUnit.Case, async: true
+
+  alias Sykli.Outbox
+  alias Sykli.TeamCoordinator.OutboxDrain
+
+  @moduletag :tmp_dir
+
+  # A payload whose daemon_session_id won't match the draining session is a
+  # permanent invalid payload, so the drain drops it WITHOUT any network call —
+  # letting us prove the drain found the file purely by which outbox it read.
+  defp enqueue_unmatched_gate(workdir) do
+    payload = %{"id" => "gate_001", "daemon_session_id" => "other-session"}
+    assert :ok = Outbox.enqueue("gates", payload, path: workdir)
+  end
+
+  test "drain_gates with :path reads that workdir's outbox", %{tmp_dir: tmp_dir} do
+    enqueue_unmatched_gate(tmp_dir)
+    assert {:ok, 1} = Outbox.pending_count("gates", path: tmp_dir)
+
+    OutboxDrain.drain_gates(session: %{"session_id" => "my-session"}, token: "t", path: tmp_dir)
+
+    # Found and dropped (permanent invalid) — proves the drain read tmp_dir, not cwd.
+    assert {:ok, 0} = Outbox.pending_count("gates", path: tmp_dir)
+  end
+
+  test "drain_gates without :path leaves a different workdir's outbox untouched",
+       %{tmp_dir: tmp_dir} do
+    enqueue_unmatched_gate(tmp_dir)
+
+    # No :path → operates on cwd, so tmp_dir's outbox is not its concern.
+    OutboxDrain.drain_gates(session: %{"session_id" => "my-session"}, token: "t")
+
+    assert {:ok, 1} = Outbox.pending_count("gates", path: tmp_dir)
+  end
+end


### PR DESCRIPTION
## What

The executor enqueues deferred run/gate syncs with `Outbox.enqueue(..., path: workdir)`, but `OutboxDrain` **dropped its opts**: `Outbox.drain`/`pending_count` and the `SessionStore.read` fallback all defaulted to **cwd**. A run whose workdir differs from the drainer's cwd silently never drained — its deferred publishes stranded in `<workdir>/.sykli/outbox/`. (Confirmed by review with exact file:line on #203.)

## Fix

- **`OutboxDrain`** now threads `:path` (the workdir, matching `Outbox`/executor enqueue convention) into `Outbox.drain` and `pending_count`, and derives the session dir as `Path.join(path, ".sykli")` for the `SessionStore.read` fallback.
- **Heartbeat** drains with its **live** `state.session` and the daemon's workdir instead of letting the drain re-read from cwd — fixes both the cwd mismatch and a *stale session after rejoin*. (The heartbeat's `:path` opt is the `.sykli` dir, so the outbox workdir is its parent.)
- CLI daemon-status drainers keep the cwd default on purpose — they're status commands with no run-workdir context, consistent with a cwd-based daemon.

## Tests

`outbox_drain_test.exs`: drain reads the **given workdir's** outbox (enqueue→drop-on-permanent-invalid proves the file was found), and leaves a different workdir's outbox untouched when no path is given. The heartbeat override seam still works (22 heartbeat tests green). Full suite green (1805); credo clean.

Found in PR #201 review; verified live in the 2026-06-27 triage. Closes #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)