### PR TITLE
perf(graph): make topo_sort linear in (V + E) (#242)

### DIFF
--- a/core/lib/sykli/graph.ex
+++ b/core/lib/sykli/graph.ex
@@ -724,46 +724,61 @@ defmodule Sykli.Graph do
       |> Enum.filter(fn {_name, deg} -> deg == 0 end)
       |> Enum.map(fn {name, _} -> name end)
 
-    do_topo_sort(queue, in_degree, graph, [])
+    # Precompute reverse adjacency (name -> dependents) once, so each node's
+    # dependents are an O(1) lookup instead of rescanning the whole graph on
+    # every dequeue. Combined with a real FIFO queue (no O(n) `++` append),
+    # this makes the sort linear in (V + E) rather than ~O(V^2 * E). See #242.
+    dependents_map = build_dependents_map(graph)
+
+    do_topo_sort(:queue.from_list(queue), in_degree, dependents_map, graph, [])
   end
 
-  defp do_topo_sort([], in_degree, graph, result) do
-    remaining = Enum.filter(in_degree, fn {_, deg} -> deg > 0 end)
+  # name => list of tasks that declare `name` in their `depends_on` (graph order).
+  defp build_dependents_map(graph) do
+    base = Map.new(Map.keys(graph), fn name -> {name, []} end)
 
-    if remaining == [] do
-      {:ok, Enum.reverse(result)}
-    else
-      # Find the actual cycle path using DFS
-      cycle_path = detect_cycle(graph)
-      {:error, {:cycle_detected, cycle_path}}
-    end
-  end
-
-  defp do_topo_sort([current | rest], in_degree, graph, result) do
-    task = Map.get(graph, current)
-
-    # Find tasks that depend on current
-    dependents =
-      graph
-      |> Enum.filter(fn {_name, t} -> current in (t.depends_on || []) end)
-      |> Enum.map(fn {name, _} -> name end)
-
-    # Decrease in-degree for dependents
-    {new_in_degree, new_queue} =
-      Enum.reduce(dependents, {in_degree, rest}, fn dep, {deg_acc, queue_acc} ->
-        new_deg = Map.update!(deg_acc, dep, &(&1 - 1))
-
-        if new_deg[dep] == 0 do
-          {new_deg, queue_acc ++ [dep]}
-        else
-          {new_deg, queue_acc}
-        end
+    graph
+    |> Enum.reduce(base, fn {name, task}, acc ->
+      Enum.reduce(task.depends_on || [], acc, fn dep, acc2 ->
+        Map.update(acc2, dep, [name], &[name | &1])
       end)
+    end)
+    |> Map.new(fn {name, deps} -> {name, Enum.reverse(deps)} end)
+  end
 
-    new_in_degree = Map.put(new_in_degree, current, -1)
+  defp do_topo_sort(queue, in_degree, dependents_map, graph, result) do
+    case :queue.out(queue) do
+      {:empty, _queue} ->
+        remaining = Enum.filter(in_degree, fn {_, deg} -> deg > 0 end)
 
-    result = if task, do: [task | result], else: result
-    do_topo_sort(new_queue, new_in_degree, graph, result)
+        if remaining == [] do
+          {:ok, Enum.reverse(result)}
+        else
+          # Find the actual cycle path using DFS
+          cycle_path = detect_cycle(graph)
+          {:error, {:cycle_detected, cycle_path}}
+        end
+
+      {{:value, current}, rest} ->
+        task = Map.get(graph, current)
+        dependents = Map.get(dependents_map, current, [])
+
+        # Decrease in-degree for dependents; enqueue any that reach zero.
+        {new_in_degree, new_queue} =
+          Enum.reduce(dependents, {in_degree, rest}, fn dep, {deg_acc, queue_acc} ->
+            new_deg = Map.update!(deg_acc, dep, &(&1 - 1))
+
+            if new_deg[dep] == 0 do
+              {new_deg, :queue.in(dep, queue_acc)}
+            else
+              {new_deg, queue_acc}
+            end
+          end)
+
+        new_in_degree = Map.put(new_in_degree, current, -1)
+        result = if task, do: [task | result], else: result
+        do_topo_sort(new_queue, new_in_degree, dependents_map, graph, result)
+    end
   end
 
   @doc """

--- a/core/test/core_test.exs
+++ b/core/test/core_test.exs
@@ -138,6 +138,32 @@ defmodule SykliTest do
     assert length(order) == 2
   end
 
+  test "topo sort returns a valid order for a large dense layered graph (#242)" do
+    # Layered DAG: every node in a layer depends on every node in the previous
+    # layer (dense fan-in/out). Exercises the reverse-adjacency + FIFO path at a
+    # scale where the old per-dequeue full-graph rescan would be quadratic.
+    layers = 30
+    width = 20
+
+    tasks =
+      for l <- 0..(layers - 1), w <- 0..(width - 1) do
+        deps = if l == 0, do: [], else: for(pw <- 0..(width - 1), do: "l#{l - 1}_n#{pw}")
+        %Sykli.Graph.Task{name: "l#{l}_n#{w}", command: "true", depends_on: deps}
+      end
+
+    graph = Map.new(tasks, fn t -> {t.name, t} end)
+
+    assert {:ok, order} = Sykli.Graph.topo_sort(graph)
+    assert length(order) == layers * width
+
+    # Validity: every task appears strictly after all of its dependencies.
+    positions = order |> Enum.with_index() |> Map.new(fn {t, i} -> {t.name, i} end)
+
+    for t <- order, dep <- t.depends_on do
+      assert positions[dep] < positions[t.name], "#{dep} must precede #{t.name}"
+    end
+  end
+
   # ----- MATRIX EXPANSION TESTS -----
 
   test "expand_matrix with no matrix returns unchanged" do

--- a/core/test/core_test.exs
+++ b/core/test/core_test.exs
@@ -138,6 +138,25 @@ defmodule SykliTest do
     assert length(order) == 2
   end
 
+  test "topo sort preserves exact Kahn FIFO output order (#242)" do
+    # Locks the "identical output order" guarantee of the linear rewrite. For a
+    # diamond a -> {b, c} -> d with <=32 nodes (key-sorted map iteration), Kahn's
+    # algorithm yields exactly [a, b, c, d]: a is the only root; processing it
+    # enqueues its dependents b, c in graph order; d is enqueued only once both
+    # b and c are drained.
+    json =
+      ~s({"version":"1","tasks":[) <>
+        ~s({"name":"a","command":"a"},) <>
+        ~s({"name":"b","command":"b","depends_on":["a"]},) <>
+        ~s({"name":"c","command":"c","depends_on":["a"]},) <>
+        ~s({"name":"d","command":"d","depends_on":["b","c"]}]})
+
+    {:ok, graph} = Sykli.Graph.parse(json)
+    {:ok, order} = Sykli.Graph.topo_sort(graph)
+
+    assert Enum.map(order, & &1.name) == ["a", "b", "c", "d"]
+  end
+
   test "topo sort returns a valid order for a large dense layered graph (#242)" do
     # Layered DAG: every node in a layer depends on every node in the previous
     # layer (dense fan-in/out). Exercises the reverse-adjacency + FIFO path at a


### PR DESCRIPTION
## What

`Graph.topo_sort/1` was **~O(V² · E)**: `do_topo_sort` recomputed each node's dependents by scanning the **entire graph** on every dequeue, and appended to the work queue with `queue ++ [dep]` (O(n) per append). On large/dense DAGs this dominated run setup.

## Fix

- Precompute the reverse adjacency (`name -> dependents`) **once** via `build_dependents_map/1` (O(V + E)) — each dequeue is now an O(1) lookup.
- Replace the list + `++` queue with an Erlang `:queue` FIFO (O(1) enqueue/dequeue).

Same Kahn's-algorithm semantics: identical output order and identical cycle detection — purely a complexity fix. (Tests only assert topological *validity* + cycle detection, not exact sequence.)

## Tests

Adds a dense 30×20 layered-DAG test (every node depends on every node in the prior layer) asserting a **valid topological order** — every task appears strictly after all its dependencies. Existing topo/cycle tests unchanged. Full suite green (1806); credo clean.

Found in the 2026-06-27 deep-dive. Closes #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)