### PR TITLE
fix(eval): assert blocked status in oracle case 031, not command absence

### DIFF
--- a/eval/oracle/fixtures/blocked_downstream.exs
+++ b/eval/oracle/fixtures/blocked_downstream.exs
@@ -1,1 +1,1 @@
-IO.puts(~S|{"version":"1","tasks":[{"name":"build","command":"exit 1"},{"name":"deploy","command":"echo deploy","depends_on":["build"]}]}|)
+IO.puts(~S|{"version":"1","tasks":[{"name":"build","command":"exit 1"},{"name":"deploy","command":"touch deploy_ran.sentinel","depends_on":["build"]}]}|)

--- a/eval/oracle/run.sh
+++ b/eval/oracle/run.sh
@@ -673,11 +673,13 @@ if begin_case "031" "Semantics: blocked task skipped when dependency fails"; the
   make_pipeline "$dir" "blocked_downstream.exs"
   LAST_OUTPUT=$(run_sykli "$dir" 2>&1) && exit_code=0 || exit_code=$?
   if [[ "$exit_code" -ne 0 ]]; then
-    # "deploy" should NOT have run
-    if ! echo "$LAST_OUTPUT" | grep -q "echo deploy"; then
+    # "deploy" must be reported blocked, not executed. The renderer prints
+    # every task's command in its summary line, so grepping for the command
+    # string can't distinguish "rendered" from "ran" — assert the status.
+    if echo "$LAST_OUTPUT" | grep -E "deploy" | grep -q "blocked"; then
       pass 0
     else
-      fail "blocked task 'deploy' should not have executed"
+      fail "blocked task 'deploy' should be reported as blocked"
     fi
   else
     fail "pipeline should fail when build fails"

--- a/eval/oracle/run.sh
+++ b/eval/oracle/run.sh
@@ -673,10 +673,13 @@ if begin_case "031" "Semantics: blocked task skipped when dependency fails"; the
   make_pipeline "$dir" "blocked_downstream.exs"
   LAST_OUTPUT=$(run_sykli "$dir" 2>&1) && exit_code=0 || exit_code=$?
   if [[ "$exit_code" -ne 0 ]]; then
-    # "deploy" must be reported blocked, not executed. The renderer prints
-    # every task's command in its summary line, so grepping for the command
-    # string can't distinguish "rendered" from "ran" — assert the status.
-    if echo "$LAST_OUTPUT" | grep -E "deploy" | grep -q "blocked"; then
+    # Non-execution is proven by the side effect: deploy's command creates a
+    # sentinel file, which must not exist after the run. The rendered status
+    # is asserted too. (Grepping for the command string can't be used here —
+    # the renderer prints every task's command in its summary line.)
+    if [[ -f "$dir/deploy_ran.sentinel" ]]; then
+      fail "blocked task 'deploy' should not have executed"
+    elif echo "$LAST_OUTPUT" | grep -E "deploy" | grep -q "blocked"; then
       pass 0
     else
       fail "blocked task 'deploy' should be reported as blocked"


### PR DESCRIPTION
## Summary
- Main CI has been red on **Oracle Eval case 031** since the job was introduced (Monster Phase A, May 25) — the job only runs on merge to main, so no PR ever executed it and the failure went unnoticed through every merge since.
- The case asserted `"echo deploy"` never appears in run output, but the visual-reset renderer prints every task's command in its summary line — including blocked tasks (`─  deploy  echo deploy  skipped (blocked)`). The assertion could never pass; the engine behavior is correct (deploy is genuinely blocked, run exits non-zero).
- Fix: assert the deploy task is *reported blocked* — a positive assertion that is mutually exclusive with the task having executed, matching the style of neighboring case 032.

## Verification
- `eval/oracle/run.sh --case 031` passes
- Full `eval/oracle/run.sh` passes 76/76 against a binary built from current main

## Notes
- Worth considering separately: run the Oracle Eval job on PRs touching `core/**` or `eval/**` so merge-to-main-only jobs can't be born red again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)