### PR TITLE
ci: run Oracle Eval on PRs that touch the paths it checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       sdk_typescript: ${{ steps.filter.outputs.sdk_typescript }}
       sdk_python: ${{ steps.filter.outputs.sdk_python }}
       integration: ${{ steps.filter.outputs.integration }}
+      oracle: ${{ steps.filter.outputs.oracle }}
     steps:
       - uses: actions/checkout@v4
 
@@ -86,6 +87,11 @@ jobs:
               - 'core/**'
               - 'sdk/go/**'
               - 'examples/**'
+            oracle:
+              - '.github/workflows/ci.yml'
+              - 'core/**'
+              - 'schemas/**'
+              - 'eval/oracle/**'
 
   core:
     name: Core Tests
@@ -215,7 +221,10 @@ jobs:
   oracle:
     name: Oracle Eval
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: changes
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      needs.changes.outputs.oracle == 'true'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Oracle Eval was gated `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` — no PR ever ran it, which is how oracle case 031 shipped born-red and kept main red for six weeks with no PR-time signal (context: #267).
- This gives the job the same condition shape as Integration Tests: always on main pushes, **plus** on PRs whose diff touches `core/**`, `schemas/**`, or `eval/oracle/**` (new `oracle` entry in the `changes` paths filter).
- Job cost is ~3 minutes, so the PR-time overhead is small.

## Verification
- YAML parses cleanly.
- This PR touches `.github/workflows/ci.yml`, which is in the new filter — so **Oracle Eval runs on this very PR**, proving the wiring end-to-end before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)