### PR TITLE
feat(cli): add contract lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`sykli lock`.** Writes `sykli.lock` with the canonical contract and
+  enforces matching locked contracts in `sykli validate` and `sykli run`.
 - **Daemon heartbeat loop (Monster Phase D, PR 1).** New
   `Sykli.Daemon.Heartbeat` GenServer implements the runtime side of
   `docs/daemon-join-protocol.md`: coordinator-owned cadence

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,7 @@ Local-first is binding: anything new must work in mode 1 with no network. The co
 | `Daemon.Join` / `Daemon.SessionStore` | `daemon/join.ex`, `daemon/session_store.ex` | Outbound daemon join + heartbeat protocol (see `docs/daemon-join-protocol.md`). Session token persisted under `.sykli/`. |
 | `ReviewPrimitive` | `review_primitive.ex` | Deterministic dispatch for `kind: "review"` nodes. Canonical names only (e.g. `api_breakage`); hyphenated aliases are rejected. Returns `Result{review_type, status, severity, message, tool, findings, evidence}`. Unsupported primitives fail explicitly — never silently skipped. |
 | `ContractHash` | `contract_hash.ex` | `sha256:` hashes for emitted SDK JSON. Canonicalizes by re-encoding parsed JSON so formatting and SDK-side comments don't perturb the hash. Used as Team Mode contract identity. |
+| `ContractLock` | `contract_lock.ex` | `sykli.lock` build/encode/decode/verify logic. Stores the full canonical contract and enforces locked contract hashes for `validate`/`run`. |
 | `CLI.{Coordinator,Gate,Work}` | `cli/{coordinator,gate,work}.ex` | Subcommand modules for the Team Mode CLI surface. All `--json` output flows through `CLI.JsonResponse`. |
 | `FailureSemantics` | `failure_semantics.ex` | Normalized terminal-result classification (`class`, `retryable`, `source`, `reason`, `message`). Independent of the pipeline contract schema. Produced by the executor; `to_map/1` ↔ `from_map/1` round-trip for history/occurrences. Unknown classes degrade to `:unknown`. |
 | `ContractSlice` | `contract_slice.ex` | Reference-sized post-parse snapshot of a task's declared semantics (`from_task/1`), stored with result evidence to explain *which contract governed* a result. Never carries logs/source/artifacts/raw output. |
@@ -287,7 +288,7 @@ The project dogfoods itself via `sykli.exs` (root-level pipeline) and `.github/w
 
 ## CLI Commands
 
-`run`, `validate`, `init`, `explain`, `fix`, `plan`, `context`, `query`, `graph`, `report`, `history`, `verify`, `delta`, `watch`, `daemon`, `mcp`, `cache`, `work`, `gate`, `coordinator`
+`run`, `validate`, `init`, `lock`, `explain`, `fix`, `plan`, `context`, `query`, `graph`, `report`, `history`, `verify`, `delta`, `watch`, `daemon`, `mcp`, `cache`, `work`, `gate`, `coordinator`
 
 ## Environment Variables
 

--- a/core/.credo.exs
+++ b/core/.credo.exs
@@ -23,6 +23,7 @@
           "lib/sykli/evidence_requirement.ex",
           "lib/sykli/contract_schema_version.ex",
           "lib/sykli/contract_hash.ex",
+          "lib/sykli/contract_lock.ex",
           "lib/sykli/contract_slice.ex",
           "lib/sykli/failure_semantics.ex",
           "lib/sykli/occurrence/serializer.ex",

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -10,7 +10,7 @@ defmodule Sykli.CLI do
   alias Sykli.Work.Store, as: WorkStore
 
   @version Mix.Project.config()[:version]
-  @subcommands ~w(cache graph delta watch report history daemon coordinator work gates gate init validate verify plan explain context fix query mcp run)
+  @subcommands ~w(cache graph delta watch report history daemon coordinator work gates gate init lock validate verify plan explain context fix query mcp run)
 
   def main(args \\ []) do
     args = normalize_global_json(args)
@@ -69,6 +69,11 @@ defmodule Sykli.CLI do
 
       ["init" | init_args] ->
         handle_init(init_args)
+
+      ["lock" | lock_args] ->
+        lock_args
+        |> Sykli.CLI.Lock.run()
+        |> halt()
 
       ["validate" | validate_args] ->
         handle_validate(validate_args)
@@ -150,6 +155,7 @@ defmodule Sykli.CLI do
       sykli [path]     Run pipeline (default: current directory)
       sykli run [path] Run pipeline (explicit form)
       sykli init       Create a new sykli file (auto-detects language)
+      sykli lock       Write sykli.lock for the current contract
       sykli validate   Check sykli file for errors without running
       sykli explain    Show last run occurrence (AI-readable report)
       sykli explain --pipeline  Show pipeline structure (for AI)
@@ -271,6 +277,27 @@ defmodule Sykli.CLI do
         run_opts
       end
 
+    case enforce_contract_lock(path) do
+      :ok ->
+        do_run_after_lock(path, opts, run_opts, start_time, json_output, original_gl)
+
+      {:ok, _meta} ->
+        do_run_after_lock(path, opts, run_opts, start_time, json_output, original_gl)
+
+      {:error, %Error{} = error} ->
+        if original_gl, do: restore_stdout(original_gl)
+
+        if json_output do
+          IO.puts(lock_error_json(error))
+        else
+          display_error(error)
+        end
+
+        halt(1)
+    end
+  end
+
+  defp do_run_after_lock(path, opts, run_opts, start_time, json_output, original_gl) do
     case prepare_work_run_context(path, opts) do
       {:ok, work_meta, work_run_opts} ->
         # return_graph: true lets the --json surface project each task's
@@ -296,6 +323,26 @@ defmodule Sykli.CLI do
         halt(1)
     end
   end
+
+  defp enforce_contract_lock(path), do: Sykli.ContractLock.verify_project(path)
+
+  defp lock_error_json(%Error{code: "contract.lock_mismatch", notes: notes} = error) do
+    hashes =
+      notes
+      |> Enum.map(fn note -> String.split(note, ": ", parts: 2) end)
+      |> Enum.reduce(%{}, fn
+        ["locked", hash], acc -> Map.put(acc, :locked_hash, hash)
+        ["emitted", hash], acc -> Map.put(acc, :emitted_hash, hash)
+        _, acc -> acc
+      end)
+
+    JsonResponse.error_with_data(%{
+      error: %{code: error.code, message: error.message, hints: error.hints},
+      hashes: hashes
+    })
+  end
+
+  defp lock_error_json(error), do: JsonResponse.error(error)
 
   defp output_run_result(result, duration, path, opts, json_output, work_meta) do
     case result do
@@ -1081,6 +1128,20 @@ defmodule Sykli.CLI do
     {opts, path} = parse_validate_args(args)
     path = path || "."
     json_output = Keyword.get(opts, :json, false)
+
+    case enforce_contract_lock(path) do
+      {:error, %Error{} = error} ->
+        if json_output do
+          IO.puts(lock_error_json(error))
+        else
+          display_error(error)
+        end
+
+        halt(1)
+
+      _ ->
+        :ok
+    end
 
     case Sykli.Validate.validate(path) do
       {:ok, result} ->

--- a/core/lib/sykli/cli/lock.ex
+++ b/core/lib/sykli/cli/lock.ex
@@ -1,0 +1,102 @@
+defmodule Sykli.CLI.Lock do
+  @moduledoc """
+  `sykli lock` command.
+  """
+
+  alias Sykli.CLI.JsonResponse
+  alias Sykli.ContractLock
+  alias Sykli.Error
+  alias Sykli.Error.Formatter
+
+  def run(args, runtime_opts \\ []) do
+    {opts, path} = parse(args)
+    path = path || "."
+
+    if Keyword.get(opts, :help, false) do
+      print_help()
+      0
+    else
+      execute(path, opts, runtime_opts)
+    end
+  end
+
+  defp execute(path, opts, runtime_opts) do
+    json? = Keyword.get(opts, :json, false)
+
+    with {:ok, {sdk_file, _runner} = sdk} <- detector(runtime_opts).find(path),
+         {:ok, current} <- ContractLock.double_emit(fn -> emit(runtime_opts, sdk) end),
+         lock <- ContractLock.build(current.contract, sdk_file),
+         lock_path <- ContractLock.lock_path_for_sdk(sdk_file),
+         old_hash <- existing_hash(lock_path),
+         {:ok, _bytes} <- ContractLock.write(lock, lock_path) do
+      data = %{
+        hash: lock["contract_hash"],
+        schema_version: lock["schema_version"],
+        sdk_file: lock["sdk_file"],
+        changed: old_hash != lock["contract_hash"]
+      }
+
+      if json? do
+        IO.puts(JsonResponse.ok(data))
+      else
+        IO.puts("Locked contract #{lock["contract_hash"]}")
+      end
+
+      0
+    else
+      {:error, reason} ->
+        output_error(reason, json?)
+    end
+  end
+
+  defp existing_hash(path) do
+    case ContractLock.read(path) do
+      {:ok, lock} -> lock["contract_hash"]
+      {:error, _} -> nil
+    end
+  end
+
+  defp emit(opts, sdk) do
+    case Keyword.get(opts, :emit_fun) do
+      fun when is_function(fun, 1) -> fun.(sdk)
+      _ -> detector(opts).emit(sdk)
+    end
+  end
+
+  defp detector(opts), do: Keyword.get(opts, :detector, Sykli.Detector)
+
+  defp output_error(reason, json?) do
+    error = Error.wrap(reason)
+
+    if json? do
+      IO.puts(JsonResponse.error(error))
+    else
+      IO.puts(Formatter.format(error))
+    end
+
+    1
+  end
+
+  defp parse(args) do
+    Enum.reduce(args, {[], []}, fn
+      "--json", {opts, rest} -> {[json: true] ++ opts, rest}
+      "--help", {opts, rest} -> {[help: true] ++ opts, rest}
+      "-h", {opts, rest} -> {[help: true] ++ opts, rest}
+      <<"--", _::binary>>, {opts, rest} -> {opts, rest}
+      arg, {opts, rest} -> {opts, rest ++ [arg]}
+    end)
+    |> then(fn {opts, rest} -> {opts, List.first(rest)} end)
+  end
+
+  defp print_help do
+    IO.puts("""
+    Usage: sykli lock [options] [path]
+
+    Write sykli.lock for the detected pipeline contract.
+
+    Options:
+      --json       Output as JSON (for tooling)
+      --help       Show this help
+    """)
+  end
+end

--- a/core/lib/sykli/contract_hash.ex
+++ b/core/lib/sykli/contract_hash.ex
@@ -10,10 +10,24 @@ defmodule Sykli.ContractHash do
   @doc "Computes a sha256-prefixed hash for emitted contract JSON."
   def from_json(json) when is_binary(json) do
     with {:ok, decoded} <- Jason.decode(json) do
-      {:ok, from_bytes(Jason.encode!(canonicalize(decoded)))}
+      {:ok, from_contract(decoded)}
     else
       {:error, reason} -> {:error, {:contract_hash_failed, :emitted_json, reason}}
     end
+  end
+
+  @doc "Computes a sha256-prefixed hash for a parsed contract."
+  def from_contract(contract) when is_map(contract) do
+    contract
+    |> canonical_json()
+    |> from_bytes()
+  end
+
+  @doc "Encodes a parsed contract in Sykli's canonical key order."
+  def canonical_json(contract) when is_map(contract) do
+    contract
+    |> canonicalize()
+    |> Jason.encode!()
   end
 
   # Canonicalize by recursively sorting object keys so the hash is independent of

--- a/core/lib/sykli/contract_lock.ex
+++ b/core/lib/sykli/contract_lock.ex
@@ -113,22 +113,22 @@ defmodule Sykli.ContractLock do
   end
 
   def verify_project(path, opts \\ []) do
-    with {:ok, {sdk_file, _runner} = sdk} <- detector(opts).find(path) do
-      lock_path = lock_path_for_sdk(sdk_file)
+    case detector(opts).find(path) do
+      {:ok, {sdk_file, _runner} = sdk} ->
+        lock_path = lock_path_for_sdk(sdk_file)
 
-      if File.exists?(lock_path) do
-        with {:ok, lock} <- read(lock_path),
-             {:ok, current} <- double_emit(fn -> emit(opts, sdk) end),
-             :ok <- verify_contract(current.contract, lock) do
-          {:ok, %{hash: current.hash, lock_path: lock_path}}
+        if File.exists?(lock_path) do
+          with {:ok, lock} <- read(lock_path),
+               {:ok, current} <- double_emit(fn -> emit(opts, sdk) end),
+               :ok <- verify_contract(current.contract, lock) do
+            {:ok, %{hash: current.hash, lock_path: lock_path}}
+          end
         else
-          {:error, %Error{} = error} -> {:error, error}
+          :ok
         end
-      else
+
+      {:error, _reason} ->
         :ok
-      end
-    else
-      {:error, reason} -> {:error, Error.wrap(reason)}
     end
   end
 

--- a/core/lib/sykli/contract_lock.ex
+++ b/core/lib/sykli/contract_lock.ex
@@ -1,0 +1,166 @@
+defmodule Sykli.ContractLock do
+  @moduledoc """
+  `sykli.lock` encoding and verification.
+  """
+
+  alias Sykli.ContractHash
+  alias Sykli.Error
+
+  @version "1"
+  @filename "sykli.lock"
+
+  def filename, do: @filename
+
+  def build(contract, sdk_file) when is_map(contract) and is_binary(sdk_file) do
+    %{
+      "version" => @version,
+      "contract_hash" => ContractHash.from_contract(contract),
+      "schema_version" => to_string(contract["version"] || ""),
+      "sdk_file" => Path.basename(sdk_file),
+      "contract" => contract
+    }
+  end
+
+  def encode(lock) when is_map(lock) do
+    case verify_integrity(lock) do
+      :ok -> {:ok, Jason.encode!(canonicalize(lock)) <> "\n"}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  def decode(bytes, path \\ @filename) when is_binary(bytes) do
+    with {:ok, lock} <- Jason.decode(bytes),
+         true <- is_map(lock) || {:error, :not_object},
+         :ok <- verify_integrity(lock) do
+      {:ok, lock}
+    else
+      {:error, %Error{} = error} -> {:error, error}
+      {:error, reason} -> {:error, Error.contract_lock_corrupt(path, reason)}
+      false -> {:error, Error.contract_lock_corrupt(path, :not_object)}
+    end
+  end
+
+  def read(path) do
+    case File.read(path) do
+      {:ok, bytes} -> decode(bytes, path)
+      {:error, reason} -> {:error, Error.contract_lock_corrupt(path, reason)}
+    end
+  end
+
+  def write(lock, path) do
+    with {:ok, bytes} <- encode(lock),
+         :ok <- File.write(path, bytes) do
+      {:ok, bytes}
+    else
+      {:error, %Error{} = error} -> {:error, error}
+      {:error, reason} -> {:error, Error.contract_lock_corrupt(path, reason)}
+    end
+  end
+
+  def lock_path_for_sdk(sdk_file), do: Path.join(Path.dirname(sdk_file), @filename)
+
+  def verify_integrity(lock) when is_map(lock) do
+    case integrity_reason(lock) do
+      :ok -> :ok
+      {:error, reason} -> {:error, Error.contract_lock_corrupt(@filename, reason)}
+    end
+  end
+
+  defp integrity_reason(lock) do
+    with :ok <- require_keys(lock),
+         true <- lock["version"] == @version || {:error, :unsupported_lock_version},
+         true <- is_map(lock["contract"]) || {:error, :missing_contract},
+         hash <- ContractHash.from_contract(lock["contract"]),
+         true <- lock["contract_hash"] == hash || {:error, :internal_hash_mismatch} do
+      :ok
+    end
+  end
+
+  def verify_contract(contract, lock) when is_map(contract) and is_map(lock) do
+    with :ok <- verify_integrity(lock),
+         hash <- ContractHash.from_contract(contract),
+         true <- hash == lock["contract_hash"] || {:error, hash} do
+      :ok
+    else
+      {:error, %Error{} = error} ->
+        {:error, error}
+
+      {:error, actual_hash} when is_binary(actual_hash) ->
+        {:error, Error.contract_lock_mismatch(lock["contract_hash"], actual_hash)}
+    end
+  end
+
+  def double_emit(emit_fun) when is_function(emit_fun, 0) do
+    with {:ok, first_json} <- emit_fun.(),
+         {:ok, first} <- decode_contract(first_json),
+         {:ok, second_json} <- emit_fun.(),
+         {:ok, second} <- decode_contract(second_json),
+         first_hash <- ContractHash.from_contract(first),
+         second_hash <- ContractHash.from_contract(second),
+         true <- first_hash == second_hash || {:error, {first_hash, second_hash}} do
+      {:ok, %{contract: first, hash: first_hash}}
+    else
+      {:error, {first_hash, second_hash}} ->
+        {:error, Error.contract_nondeterministic(first_hash, second_hash)}
+
+      {:error, %Error{} = error} ->
+        {:error, error}
+
+      {:error, reason} ->
+        {:error, Error.wrap(reason)}
+    end
+  end
+
+  def verify_project(path, opts \\ []) do
+    with {:ok, {sdk_file, _runner} = sdk} <- detector(opts).find(path) do
+      lock_path = lock_path_for_sdk(sdk_file)
+
+      if File.exists?(lock_path) do
+        with {:ok, lock} <- read(lock_path),
+             {:ok, current} <- double_emit(fn -> emit(opts, sdk) end),
+             :ok <- verify_contract(current.contract, lock) do
+          {:ok, %{hash: current.hash, lock_path: lock_path}}
+        else
+          {:error, %Error{} = error} -> {:error, error}
+        end
+      else
+        :ok
+      end
+    end
+  end
+
+  defp emit(opts, sdk) do
+    case Keyword.get(opts, :emit_fun) do
+      fun when is_function(fun, 1) -> fun.(sdk)
+      _ -> detector(opts).emit(sdk)
+    end
+  end
+
+  defp detector(opts), do: Keyword.get(opts, :detector, Sykli.Detector)
+
+  defp decode_contract(json) do
+    case Jason.decode(json) do
+      {:ok, contract} when is_map(contract) -> {:ok, contract}
+      {:ok, _} -> {:error, :invalid_format}
+      {:error, reason} -> {:error, {:json_parse_error, reason}}
+    end
+  end
+
+  defp require_keys(lock) do
+    missing =
+      ["version", "contract_hash", "schema_version", "sdk_file", "contract"]
+      |> Enum.reject(&Map.has_key?(lock, &1))
+
+    if missing == [], do: :ok, else: {:error, {:missing_keys, missing}}
+  end
+
+  defp canonicalize(map) when is_map(map) do
+    map
+    |> Enum.sort_by(fn {key, _value} -> key end)
+    |> Enum.map(fn {key, value} -> {key, canonicalize(value)} end)
+    |> Jason.OrderedObject.new()
+  end
+
+  defp canonicalize(list) when is_list(list), do: Enum.map(list, &canonicalize/1)
+  defp canonicalize(value), do: value
+end

--- a/core/lib/sykli/contract_lock.ex
+++ b/core/lib/sykli/contract_lock.ex
@@ -97,10 +97,11 @@ defmodule Sykli.ContractLock do
          {:ok, second} <- decode_contract(second_json),
          first_hash <- ContractHash.from_contract(first),
          second_hash <- ContractHash.from_contract(second),
-         true <- first_hash == second_hash || {:error, {first_hash, second_hash}} do
+         true <-
+           first_hash == second_hash || {:error, {:nondeterministic, first_hash, second_hash}} do
       {:ok, %{contract: first, hash: first_hash}}
     else
-      {:error, {first_hash, second_hash}} ->
+      {:error, {:nondeterministic, first_hash, second_hash}} ->
         {:error, Error.contract_nondeterministic(first_hash, second_hash)}
 
       {:error, %Error{} = error} ->
@@ -126,6 +127,8 @@ defmodule Sykli.ContractLock do
       else
         :ok
       end
+    else
+      {:error, reason} -> {:error, Error.wrap(reason)}
     end
   end
 

--- a/core/lib/sykli/error.ex
+++ b/core/lib/sykli/error.ex
@@ -715,6 +715,39 @@ defmodule Sykli.Error do
     }
   end
 
+  def contract_lock_mismatch(locked_hash, actual_hash) do
+    %__MODULE__{
+      code: "contract.lock_mismatch",
+      type: :validation,
+      message: "emitted contract hash does not match sykli.lock",
+      step: :validate,
+      hints: ["run `sykli lock` to accept the new contract edition"],
+      notes: ["locked: #{locked_hash}", "emitted: #{actual_hash}"]
+    }
+  end
+
+  def contract_lock_corrupt(path, reason) do
+    %__MODULE__{
+      code: "contract.lock_corrupt",
+      type: :validation,
+      message: "sykli.lock is unreadable or internally inconsistent",
+      step: :validate,
+      hints: ["inspect #{path} or regenerate it with `sykli lock`"],
+      notes: ["reason: #{inspect(reason)}"]
+    }
+  end
+
+  def contract_nondeterministic(first_hash, second_hash) do
+    %__MODULE__{
+      code: "contract.nondeterministic",
+      type: :validation,
+      message: "pipeline emission is not deterministic",
+      step: :validate,
+      hints: ["remove random, clock, or ambient inputs from the sykli file before retrying"],
+      notes: ["first: #{first_hash}", "second: #{second_hash}"]
+    }
+  end
+
   # ─────────────────────────────────────────────────────────────────────────────
   # GATE DECISION ERRORS
   # ─────────────────────────────────────────────────────────────────────────────
@@ -1030,6 +1063,7 @@ defmodule Sykli.Error do
   def wrap({:invalid_note, reason}), do: invalid_work_item({:invalid_note, reason})
   def wrap({:invalid_note_author, reason}), do: invalid_work_item({:invalid_note_author, reason})
   def wrap({:contract_hash_failed, path, reason}), do: contract_hash_failed(path, reason)
+  def wrap({:contract_lock_corrupt, path, reason}), do: contract_lock_corrupt(path, reason)
 
   # Gate decision errors
   def wrap({:gate_not_found, id}), do: gate_not_found(id)

--- a/core/test/sykli/contract_lock_test.exs
+++ b/core/test/sykli/contract_lock_test.exs
@@ -72,11 +72,8 @@ defmodule Sykli.ContractLockTest do
     assert error.code == "sdk_failed"
   end
 
-  test "verify_project preserves detector failures" do
-    assert {:error, error} =
-             ContractLock.verify_project(".", detector: __MODULE__.MissingDetector)
-
-    assert error.code == "sdk_not_found"
+  test "verify_project ignores detector failures" do
+    assert :ok = ContractLock.verify_project(".", detector: __MODULE__.MissingDetector)
   end
 
   test "verify_project uses injected detector and emit source" do

--- a/core/test/sykli/contract_lock_test.exs
+++ b/core/test/sykli/contract_lock_test.exs
@@ -1,0 +1,91 @@
+defmodule Sykli.ContractLockTest do
+  use ExUnit.Case, async: false
+
+  alias Sykli.ContractLock
+
+  @contract %{
+    "version" => "4",
+    "tasks" => [
+      %{
+        "name" => "test",
+        "command" => "mix test",
+        "success_criteria" => [%{"type" => "exit_code", "value" => 0}]
+      }
+    ]
+  }
+
+  @changed_contract put_in(@contract, ["tasks", Access.at(0), "name"], "test-2")
+
+  test "build encode decode verify round-trips" do
+    lock = ContractLock.build(@contract, "/tmp/project/sykli.exs")
+
+    assert {:ok, bytes} = ContractLock.encode(lock)
+    assert {:ok, decoded} = ContractLock.decode(bytes)
+    assert :ok = ContractLock.verify_contract(@contract, decoded)
+    assert decoded["sdk_file"] == "sykli.exs"
+    assert decoded["schema_version"] == "4"
+  end
+
+  test "lock encoding is deterministic" do
+    lock = ContractLock.build(@contract, "sykli.exs")
+
+    assert ContractLock.encode(lock) == ContractLock.encode(lock)
+  end
+
+  test "decode rejects bad json, missing keys, and wrong internal hash" do
+    assert {:error, %{code: "contract.lock_corrupt"}} = ContractLock.decode("{")
+
+    assert {:error, %{code: "contract.lock_corrupt"}} =
+             ContractLock.decode(~s({"version":"1"}))
+
+    lock = ContractLock.build(@contract, "sykli.exs") |> Map.put("contract_hash", "sha256:bad")
+
+    assert {:error, %{code: "contract.lock_corrupt"}} =
+             lock |> Jason.encode!() |> ContractLock.decode()
+  end
+
+  test "verify_contract detects mismatch" do
+    lock = ContractLock.build(@contract, "sykli.exs")
+    changed = put_in(@contract, ["tasks", Access.at(0), "command"], "mix test --failed")
+
+    assert {:error, error} = ContractLock.verify_contract(changed, lock)
+    assert error.code == "contract.lock_mismatch"
+    assert Enum.any?(error.hints, &String.contains?(&1, "sykli lock"))
+  end
+
+  test "double_emit rejects nondeterministic contracts" do
+    {:ok, agent} =
+      Agent.start_link(fn -> [Jason.encode!(@contract), Jason.encode!(@changed_contract)] end)
+
+    {:error, error} =
+      ContractLock.double_emit(fn ->
+        {:ok, Agent.get_and_update(agent, fn [head | tail] -> {head, tail} end)}
+      end)
+
+    assert error.code == "contract.nondeterministic"
+  end
+
+  test "verify_project uses injected detector and emit source" do
+    tmp = Path.join(System.tmp_dir!(), "sykli-lock-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    sdk = Path.join(tmp, "sykli.exs")
+    File.write!(sdk, "")
+
+    lock = ContractLock.build(@contract, sdk)
+    assert {:ok, _} = ContractLock.write(lock, Path.join(tmp, "sykli.lock"))
+
+    emit_fun = fn {^sdk, _runner} -> {:ok, Jason.encode!(@contract)} end
+
+    assert {:ok, %{hash: hash}} =
+             ContractLock.verify_project(tmp,
+               detector: __MODULE__.FakeDetector,
+               emit_fun: emit_fun
+             )
+
+    assert hash == lock["contract_hash"]
+  end
+
+  defmodule FakeDetector do
+    def find(path), do: {:ok, {Path.join(path, "sykli.exs"), fn _ -> :unused end}}
+  end
+end

--- a/core/test/sykli/contract_lock_test.exs
+++ b/core/test/sykli/contract_lock_test.exs
@@ -65,6 +65,20 @@ defmodule Sykli.ContractLockTest do
     assert error.code == "contract.nondeterministic"
   end
 
+  test "double_emit preserves sdk emission failures" do
+    assert {:error, error} =
+             ContractLock.double_emit(fn -> {:error, {:elixir_failed, "compile error"}} end)
+
+    assert error.code == "sdk_failed"
+  end
+
+  test "verify_project preserves detector failures" do
+    assert {:error, error} =
+             ContractLock.verify_project(".", detector: __MODULE__.MissingDetector)
+
+    assert error.code == "sdk_not_found"
+  end
+
   test "verify_project uses injected detector and emit source" do
     tmp = Path.join(System.tmp_dir!(), "sykli-lock-#{System.unique_integer([:positive])}")
     File.mkdir_p!(tmp)
@@ -87,5 +101,9 @@ defmodule Sykli.ContractLockTest do
 
   defmodule FakeDetector do
     def find(path), do: {:ok, {Path.join(path, "sykli.exs"), fn _ -> :unused end}}
+  end
+
+  defmodule MissingDetector do
+    def find(_path), do: {:error, :no_sdk_file}
   end
 end

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -20,6 +20,17 @@ To rename or deprecate a public code, add the replacement first, keep the old co
 
 No cache-prefixed `Sykli.Error` codes are emitted today. Cache failures currently surface through execution/runtime errors or internal wrapping.
 
+### contract
+
+Contract codes are public-stable because they are emitted by `sykli lock`,
+`sykli validate`, and `sykli run` JSON surfaces.
+
+| Code | Description | Tier | Emitted from |
+|------|-------------|------|--------------|
+| `contract.lock_mismatch` | The emitted contract hash does not match `sykli.lock`. | public-stable | `core/lib/sykli/contract_lock.ex` |
+| `contract.lock_corrupt` | `sykli.lock` is unreadable, malformed, missing required fields, or has an invalid internal hash. | public-stable | `core/lib/sykli/contract_lock.ex` |
+| `contract.nondeterministic` | Two emissions of the same pipeline produced different canonical hashes. | public-stable | `core/lib/sykli/contract_lock.ex` |
+
 ### coordinator
 
 Coordinator codes are public-unstable while the self-hosted Team Mode API

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -1159,6 +1159,21 @@
       "validated_by": "Injected bug: ignore corrupt lockfile; validate exits 0."
     },
     {
+      "id": "NEG-024",
+      "name": "run without SDK file returns JSON error",
+      "fixture": "empty_dir",
+      "command": "sykli run --json",
+      "expect_exit": 1,
+      "expect_json_contains": {
+        "ok": false
+      },
+      "expect_stdout_contains": [
+        "sdk_not_found"
+      ],
+      "source": "docs/codex-brief-notation-core.md PR 1 follow-up",
+      "validated_by": "Regression: lock enforcement returned {:error, :no_sdk_file}; run crashed with CaseClauseError."
+    },
+    {
       "id": "ABN-015",
       "name": "Task timeout is errored, not failed",
       "fixture": "task_timeout",

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -1134,6 +1134,31 @@
       "validated_by": "Injected bug: generic validation message; offending task assertion fails."
     },
     {
+      "id": "NEG-022",
+      "name": "run rejects stale sykli.lock",
+      "fixture": "locked_contract",
+      "command": "sykli lock >/dev/null && perl -0pi -e 's/echo hi/echo bye/' sykli.exs && sykli run",
+      "shell": true,
+      "expect_exit": 1,
+      "expect_stdout_contains": [
+        "contract.lock_mismatch",
+        "sykli lock"
+      ],
+      "source": "docs/codex-brief-notation-core.md PR 1",
+      "validated_by": "Injected bug: skip lock enforcement before run; command exits 0."
+    },
+    {
+      "id": "NEG-023",
+      "name": "validate rejects corrupt sykli.lock",
+      "fixture": "locked_contract",
+      "command": "printf '{' > sykli.lock && sykli validate",
+      "shell": true,
+      "expect_exit": 1,
+      "expect_stdout": "contract.lock_corrupt",
+      "source": "docs/codex-brief-notation-core.md PR 1",
+      "validated_by": "Injected bug: ignore corrupt lockfile; validate exits 0."
+    },
+    {
       "id": "ABN-015",
       "name": "Task timeout is errored, not failed",
       "fixture": "task_timeout",
@@ -1281,6 +1306,39 @@
       "validated_by": "Injected bug: drop contract_slice from cli run --json; jq assertion fails."
     },
     {
+      "id": "JSON-010",
+      "name": "lock --json returns shared envelope",
+      "fixture": "locked_contract",
+      "command": "sykli lock --json",
+      "expect_exit": 0,
+      "expect_json_jq": [
+        ".ok == true",
+        ".data.hash | startswith(\"sha256:\")",
+        ".data.schema_version == \"4\"",
+        ".data.sdk_file == \"sykli.exs\"",
+        ".data.changed == true"
+      ],
+      "source": "docs/codex-brief-notation-core.md PR 1",
+      "validated_by": "Injected bug: bypass JsonResponse or omit lock metadata; jq assertions fail."
+    },
+    {
+      "id": "JSON-011",
+      "name": "validate --json lock mismatch returns hashes",
+      "fixture": "locked_contract",
+      "command": "sykli lock >/dev/null && perl -0pi -e 's/echo hi/echo bye/' sykli.exs && sykli validate --json",
+      "shell": true,
+      "expect_exit": 1,
+      "expect_json_jq": [
+        ".ok == false",
+        ".error == null",
+        ".data.error.code == \"contract.lock_mismatch\"",
+        ".data.hashes.locked_hash | startswith(\"sha256:\")",
+        ".data.hashes.emitted_hash | startswith(\"sha256:\")"
+      ],
+      "source": "docs/codex-brief-notation-core.md PR 1",
+      "validated_by": "Injected bug: return a plain JsonResponse.error for mismatch; .data hash assertions fail."
+    },
+    {
       "id": "DET-001",
       "name": "Two identical validate JSON outputs are byte-identical",
       "fixture": "dependency_chain",
@@ -1342,6 +1400,26 @@
       "source": "CLAUDE.md \u00a7No wall-clock or global RNG",
       "validated_by": "Injected bug: remove NoWallClock check; credo would pass and status assertion fails.",
       "findings": "NoWallClock now covers pure contract & output-shaping transforms (graph/, validate, vocab, contract hashing, occurrence serialization); a planted violation under lib/sykli/graph/ is rejected."
+    },
+    {
+      "id": "DET-007",
+      "name": "lock is byte-identical across repeated writes",
+      "fixture": "locked_contract",
+      "command": "sykli lock >/dev/null && cp sykli.lock first.lock && sykli lock >/dev/null && cmp -s first.lock sykli.lock && sykli validate >/dev/null",
+      "shell": true,
+      "expect_exit": 0,
+      "source": "docs/codex-brief-notation-core.md PR 1",
+      "validated_by": "Injected bug: add timestamp or unsorted encoding to sykli.lock; cmp assertion fails."
+    },
+    {
+      "id": "DET-008",
+      "name": "lock rejects nondeterministic emission",
+      "fixture": "nondeterministic_contract",
+      "command": "sykli lock",
+      "expect_exit": 1,
+      "expect_stdout": "contract.nondeterministic",
+      "source": "docs/codex-brief-notation-core.md PR 1",
+      "validated_by": "Injected bug: emit only once during lock; nondeterministic fixture locks successfully."
     },
     {
       "id": "SDK-001",

--- a/test/blackbox/fixtures/locked_contract/sykli.exs
+++ b/test/blackbox/fixtures/locked_contract/sykli.exs
@@ -1,0 +1,1 @@
+IO.puts(~s|{"version":"4","tasks":[{"name":"hello","command":"echo hi","task_type":"test","success_criteria":[{"type":"exit_code","equals":0}],"evidence_required":[{"type":"file","name":"pipeline","ref_pattern":"sykli.exs"}]}]}|)

--- a/test/blackbox/fixtures/nondeterministic_contract/sykli.exs
+++ b/test/blackbox/fixtures/nondeterministic_contract/sykli.exs
@@ -1,0 +1,1 @@
+IO.puts("{\"version\":\"4\",\"tasks\":[{\"name\":\"task-#{:rand.uniform(1000)}\",\"command\":\"echo hi\",\"task_type\":\"test\"}]}")


### PR DESCRIPTION
## Summary

- Adds `sykli lock` and the `sykli.lock` format with the full canonical contract.
- Adds double-emit determinism checks for lock creation and lock enforcement.
- Enforces an existing `sykli.lock` before `sykli validate` and `sykli run`.
- Adds structured contract error codes and black-box coverage for DET/NEG/JSON paths.

## Design decisions honored

- Lockfile stores the full canonical contract, not only the hash.
- Lock enforcement is presence-based: no lockfile means current behavior remains unchanged.
- Double-emit compares canonical hashes via `Sykli.ContractHash`.
- Lock pins the emitted contract before graph expansion.
- No SDK, schema, runtime, team coordinator, GitHub, or workflow changes.

## Verification

```text
$ cd core && mix format --check-formatted
# exit 0
```

```text
$ cd core && mix credo --strict
Checking 33 source files ...
787 mods/funs, found no issues.
```

```text
$ cd core && mix compile --warnings-as-errors --force
Compiling 218 files (.ex)
Generated sykli app
```

```text
$ cd core && mix test --seed 0
Result: 1804 passed (1 property, 1803 tests), 13 excluded
```

```text
$ cd core && mix test
Result: 1804 passed (1 property, 1803 tests), 13 excluded
```

```text
$ cd core && mix escript.build
Generated escript sykli with MIX_ENV=dev
```

```text
$ test/blackbox/run.sh --filter=DET
Passed: 8
Failed: 0
Skipped: 168
Total: 176
```

```text
$ test/blackbox/run.sh --filter=NEG
Passed: 23
Failed: 0
Skipped: 153
Total: 176
```

```text
$ test/blackbox/run.sh --filter=JSON
Passed: 11
Failed: 0
Skipped: 165
Total: 176
```

```text
$ eval/oracle/run.sh
Passed: 76
Failed: 0
Total: 76
```

## Manual demo

```text
$ sykli lock
Locked contract sha256:b5c01969762b8f04829853700729f4c139f8aa3a2a84536cfe992328a6e48636

$ sykli validate
Valid

$ perl -0pi -e 's/echo hi/echo bye/' sykli.exs
$ sykli run
error[contract.lock_mismatch]: emitted contract hash does not match sykli.lock
help: run `sykli lock` to accept the new contract edition
```

`sykli contract --diff` is intentionally not demonstrated in this PR because that command is PR 2 in the mandate.

## Out of scope

- SDK canonicalization.
- Schema v5, `actor`, `mandate`, or audit work.
- CI gating and workflow changes.
- `sykli contract` / `sykli contract --diff` surface, which is the next PR.
