### PR TITLE
feat(cli): add contract surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`sykli lock`.** Writes `sykli.lock` with the canonical contract and
   enforces matching locked contracts in `sykli validate` and `sykli run`.
+- **`sykli contract`.** Renders the current emitted contract and supports
+  `--diff` against `sykli.lock` or another lockfile with weakening
+  classification.
 - **Daemon heartbeat loop (Monster Phase D, PR 1).** New
   `Sykli.Daemon.Heartbeat` GenServer implements the runtime side of
   `docs/daemon-join-protocol.md`: coordinator-owned cadence

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,9 @@ Local-first is binding: anything new must work in mode 1 with no network. The co
 | `ReviewPrimitive` | `review_primitive.ex` | Deterministic dispatch for `kind: "review"` nodes. Canonical names only (e.g. `api_breakage`); hyphenated aliases are rejected. Returns `Result{review_type, status, severity, message, tool, findings, evidence}`. Unsupported primitives fail explicitly — never silently skipped. |
 | `ContractHash` | `contract_hash.ex` | `sha256:` hashes for emitted SDK JSON. Canonicalizes by re-encoding parsed JSON so formatting and SDK-side comments don't perturb the hash. Used as Team Mode contract identity. |
 | `ContractLock` | `contract_lock.ex` | `sykli.lock` build/encode/decode/verify logic. Stores the full canonical contract and enforces locked contract hashes for `validate`/`run`. |
+| `ContractDiff` | `contract_diff.ex` | Pure classifier for `sykli contract --diff`; reports neutral, strengthening, and weakening contract changes. |
 | `CLI.{Coordinator,Gate,Work}` | `cli/{coordinator,gate,work}.ex` | Subcommand modules for the Team Mode CLI surface. All `--json` output flows through `CLI.JsonResponse`. |
+| `CLI.{Contract,Lock}` | `cli/{contract,lock}.ex` | Contract CLI surfaces. `lock` pins the emitted canonical contract; `contract` renders and diffs it through the shared JSON envelope. |
 | `FailureSemantics` | `failure_semantics.ex` | Normalized terminal-result classification (`class`, `retryable`, `source`, `reason`, `message`). Independent of the pipeline contract schema. Produced by the executor; `to_map/1` ↔ `from_map/1` round-trip for history/occurrences. Unknown classes degrade to `:unknown`. |
 | `ContractSlice` | `contract_slice.ex` | Reference-sized post-parse snapshot of a task's declared semantics (`from_task/1`), stored with result evidence to explain *which contract governed* a result. Never carries logs/source/artifacts/raw output. |
 | `AgentHints` | `agent_hints.ex` | Derives agent next-step hints from a `FailureSemantics`. Surfaced in CLI `--json` and MCP alongside the semantics. |
@@ -288,7 +290,7 @@ The project dogfoods itself via `sykli.exs` (root-level pipeline) and `.github/w
 
 ## CLI Commands
 
-`run`, `validate`, `init`, `lock`, `explain`, `fix`, `plan`, `context`, `query`, `graph`, `report`, `history`, `verify`, `delta`, `watch`, `daemon`, `mcp`, `cache`, `work`, `gate`, `coordinator`
+`run`, `validate`, `init`, `lock`, `contract`, `explain`, `fix`, `plan`, `context`, `query`, `graph`, `report`, `history`, `verify`, `delta`, `watch`, `daemon`, `mcp`, `cache`, `work`, `gate`, `coordinator`
 
 ## Environment Variables
 

--- a/core/.credo.exs
+++ b/core/.credo.exs
@@ -24,6 +24,7 @@
           "lib/sykli/contract_schema_version.ex",
           "lib/sykli/contract_hash.ex",
           "lib/sykli/contract_lock.ex",
+          "lib/sykli/contract_diff.ex",
           "lib/sykli/contract_slice.ex",
           "lib/sykli/failure_semantics.ex",
           "lib/sykli/occurrence/serializer.ex",

--- a/core/lib/sykli/cli.ex
+++ b/core/lib/sykli/cli.ex
@@ -10,7 +10,7 @@ defmodule Sykli.CLI do
   alias Sykli.Work.Store, as: WorkStore
 
   @version Mix.Project.config()[:version]
-  @subcommands ~w(cache graph delta watch report history daemon coordinator work gates gate init lock validate verify plan explain context fix query mcp run)
+  @subcommands ~w(cache graph delta watch report history daemon coordinator work gates gate init lock contract validate verify plan explain context fix query mcp run)
 
   def main(args \\ []) do
     args = normalize_global_json(args)
@@ -73,6 +73,11 @@ defmodule Sykli.CLI do
       ["lock" | lock_args] ->
         lock_args
         |> Sykli.CLI.Lock.run()
+        |> halt()
+
+      ["contract" | contract_args] ->
+        contract_args
+        |> Sykli.CLI.Contract.run()
         |> halt()
 
       ["validate" | validate_args] ->
@@ -156,6 +161,7 @@ defmodule Sykli.CLI do
       sykli run [path] Run pipeline (explicit form)
       sykli init       Create a new sykli file (auto-detects language)
       sykli lock       Write sykli.lock for the current contract
+      sykli contract   Render or diff the current contract
       sykli validate   Check sykli file for errors without running
       sykli explain    Show last run occurrence (AI-readable report)
       sykli explain --pipeline  Show pipeline structure (for AI)

--- a/core/lib/sykli/cli/contract.ex
+++ b/core/lib/sykli/cli/contract.ex
@@ -1,0 +1,247 @@
+defmodule Sykli.CLI.Contract do
+  @moduledoc """
+  `sykli contract` command.
+  """
+
+  alias Sykli.CLI.JsonResponse
+  alias Sykli.ContractDiff
+  alias Sykli.ContractLock
+  alias Sykli.Error
+  alias Sykli.Error.Formatter
+
+  def run(args, runtime_opts \\ []) do
+    case parse(args) do
+      {:help, _opts} ->
+        print_help()
+        0
+
+      {:render, path, opts} ->
+        render(path || ".", opts, runtime_opts)
+
+      {:diff, path, lock_path, opts} ->
+        diff(path || ".", lock_path, opts, runtime_opts)
+    end
+  end
+
+  defp render(path, opts, runtime_opts) do
+    json? = Keyword.get(opts, :json, false)
+
+    case current(path, runtime_opts) do
+      {:ok, current} ->
+        if json? do
+          IO.puts(JsonResponse.ok(current.contract))
+        else
+          IO.puts(render_contract(current.contract, current.hash))
+        end
+
+        0
+
+      {:error, reason} ->
+        output_error(reason, json?)
+    end
+  end
+
+  defp diff(path, lock_arg, opts, runtime_opts) do
+    json? = Keyword.get(opts, :json, false)
+
+    with {:ok, current} <- current(path, runtime_opts),
+         {:ok, lock_path} <- diff_lock_path(path, lock_arg, runtime_opts),
+         {:ok, lock} <- ContractLock.read(lock_path) do
+      changes = ContractDiff.classify(lock["contract"], current.contract)
+      weakening? = Enum.any?(changes, &(&1.direction == :weakening))
+
+      if json? do
+        IO.puts(
+          JsonResponse.ok(%{
+            changes: Enum.map(changes, &stringify_direction/1),
+            weakening: weakening?,
+            from_hash: lock["contract_hash"],
+            to_hash: current.hash
+          })
+        )
+      else
+        IO.puts(render_changes(changes, lock["contract_hash"], current.hash, weakening?))
+      end
+
+      if weakening?, do: 1, else: 0
+    else
+      {:error, reason} -> output_error(reason, json?)
+    end
+  end
+
+  defp current(path, runtime_opts) do
+    with {:ok, sdk} <- detector(runtime_opts).find(path) do
+      ContractLock.double_emit(fn -> emit(runtime_opts, sdk) end)
+    end
+  end
+
+  defp diff_lock_path(path, nil, runtime_opts) do
+    with {:ok, {sdk_file, _runner}} <- detector(runtime_opts).find(path) do
+      lock_path = ContractLock.lock_path_for_sdk(sdk_file)
+
+      if File.exists?(lock_path) do
+        {:ok, lock_path}
+      else
+        {:error,
+         %Error{
+           code: "contract.lock_corrupt",
+           type: :validation,
+           message: "sykli.lock was not found",
+           step: :validate,
+           hints: ["run `sykli lock` before diffing the contract"]
+         }}
+      end
+    end
+  end
+
+  defp diff_lock_path(_path, lock_path, _runtime_opts), do: {:ok, lock_path}
+
+  defp emit(opts, sdk) do
+    case Keyword.get(opts, :emit_fun) do
+      fun when is_function(fun, 1) -> fun.(sdk)
+      _ -> detector(opts).emit(sdk)
+    end
+  end
+
+  defp detector(opts), do: Keyword.get(opts, :detector, Sykli.Detector)
+
+  defp output_error(reason, json?) do
+    error = Error.wrap(reason)
+
+    if json? do
+      IO.puts(JsonResponse.error(error))
+    else
+      IO.puts(Formatter.format(error))
+    end
+
+    1
+  end
+
+  defp render_contract(contract, hash) do
+    tasks = contract["tasks"] || []
+
+    [
+      "Contract #{hash}\n",
+      "schema #{contract["version"] || "-"}\n",
+      Enum.map(tasks, &render_task/1)
+    ]
+    |> IO.iodata_to_binary()
+  end
+
+  defp render_task(task) do
+    [
+      "\n",
+      task["name"] || "-",
+      "  ",
+      task["task_type"] || task["kind"] || "task",
+      "\n",
+      render_line("deps", Enum.join(task["depends_on"] || [], ", ")),
+      render_line("command", task["command"]),
+      render_line("condition", task["when"] || task["condition"]),
+      render_list("criteria", task["success_criteria"]),
+      render_list("evidence", task["evidence_required"]),
+      render_list("capabilities", task["requires"]),
+      render_gate(task)
+    ]
+  end
+
+  defp render_line(_label, nil), do: []
+  defp render_line(_label, ""), do: []
+  defp render_line(label, value), do: ["  ", label, ": ", to_string(value), "\n"]
+
+  defp render_list(_label, nil), do: []
+  defp render_list(_label, []), do: []
+
+  defp render_list(label, values) do
+    ["  ", label, ":\n", Enum.map(values, fn value -> ["    - ", inspect(value), "\n"] end)]
+  end
+
+  defp render_gate(%{"gate" => gate}) when not is_nil(gate),
+    do: render_line("gate", inspect(gate))
+
+  defp render_gate(%{"kind" => "review"}), do: "  gate: review\n"
+  defp render_gate(_task), do: []
+
+  defp render_changes([], from_hash, to_hash, _weakening?) do
+    "Contract diff #{from_hash} -> #{to_hash}\nNo contract changes\nVerdict: no weakening\n"
+  end
+
+  defp render_changes(changes, from_hash, to_hash, weakening?) do
+    groups = [:weakening, :strengthening, :neutral]
+
+    body =
+      groups
+      |> Enum.flat_map(fn direction ->
+        selected = Enum.filter(changes, &(&1.direction == direction))
+
+        if selected == [] do
+          []
+        else
+          [
+            "\n",
+            String.capitalize(Atom.to_string(direction)),
+            "\n",
+            Enum.map(selected, fn change ->
+              ["  - ", change.task || "-", ": ", change.detail, field_suffix(change.field), "\n"]
+            end)
+          ]
+        end
+      end)
+
+    verdict = if weakening?, do: "weakening present", else: "no weakening"
+
+    IO.iodata_to_binary([
+      "Contract diff #{from_hash} -> #{to_hash}\n",
+      body,
+      "Verdict: ",
+      verdict,
+      "\n"
+    ])
+  end
+
+  defp field_suffix(nil), do: ""
+  defp field_suffix(field), do: " (#{field})"
+
+  defp stringify_direction(change), do: %{change | direction: Atom.to_string(change.direction)}
+
+  defp parse(args) do
+    {opts, rest} =
+      Enum.reduce(args, {[], []}, fn
+        "--json", {opts, rest} -> {[json: true] ++ opts, rest}
+        "--help", {opts, rest} -> {[help: true] ++ opts, rest}
+        "-h", {opts, rest} -> {[help: true] ++ opts, rest}
+        "--diff", {opts, rest} -> {[diff: true] ++ opts, rest}
+        arg, {opts, rest} -> {opts, rest ++ [arg]}
+      end)
+
+    cond do
+      Keyword.get(opts, :help, false) ->
+        {:help, opts}
+
+      Keyword.get(opts, :diff, false) ->
+        {path, lock_path} = diff_args(rest)
+        {:diff, path, lock_path, opts}
+
+      true ->
+        {:render, List.first(rest), opts}
+    end
+  end
+
+  defp diff_args([]), do: {".", nil}
+  defp diff_args([one]), do: {".", one}
+  defp diff_args([path, lock_path | _]), do: {path, lock_path}
+
+  defp print_help do
+    IO.puts("""
+    Usage: sykli contract [options] [path]
+           sykli contract --diff [lockfile]
+
+    Render or diff the emitted contract.
+
+    Options:
+      --diff       Compare current emission against sykli.lock or a lockfile
+      --json       Output as JSON (for tooling)
+      --help       Show this help
+    """)
+  end
+end

--- a/core/lib/sykli/contract_diff.ex
+++ b/core/lib/sykli/contract_diff.ex
@@ -1,0 +1,162 @@
+defmodule Sykli.ContractDiff do
+  @moduledoc """
+  Pure contract change classifier for `sykli contract --diff`.
+  """
+
+  @criticality %{"low" => 1, "medium" => 2, "high" => 3, "critical" => 4}
+
+  def classify(from, to) when is_map(from) and is_map(to) do
+    from_tasks = tasks_by_name(from)
+    to_tasks = tasks_by_name(to)
+
+    removed_tasks(from_tasks, to_tasks) ++
+      added_tasks(from_tasks, to_tasks) ++
+      changed_tasks(from_tasks, to_tasks)
+  end
+
+  defp removed_tasks(from_tasks, to_tasks) do
+    from_tasks
+    |> Map.drop(Map.keys(to_tasks))
+    |> Enum.map(fn {name, _task} ->
+      change(:task_removed, name, nil, "task removed", :weakening)
+    end)
+  end
+
+  defp added_tasks(from_tasks, to_tasks) do
+    to_tasks
+    |> Map.drop(Map.keys(from_tasks))
+    |> Enum.map(fn {name, task} ->
+      direction = if gate_or_review?(task), do: :strengthening, else: :neutral
+      change(:task_added, name, nil, "task added", direction)
+    end)
+  end
+
+  defp changed_tasks(from_tasks, to_tasks) do
+    common = Enum.filter(Map.keys(from_tasks), &Map.has_key?(to_tasks, &1))
+
+    Enum.flat_map(common, fn name ->
+      before = from_tasks[name]
+      after_ = to_tasks[name]
+
+      criteria_changes(name, before, after_) ++
+        evidence_changes(name, before, after_) ++
+        criticality_changes(name, before, after_) ++
+        condition_changes(name, before, after_) ++
+        neutral_changes(name, before, after_)
+    end)
+  end
+
+  defp criteria_changes(name, before, after_) do
+    list_entry_changes(
+      name,
+      "success_criteria",
+      before["success_criteria"],
+      after_["success_criteria"]
+    )
+  end
+
+  defp evidence_changes(name, before, after_) do
+    list_entry_changes(
+      name,
+      "evidence_required",
+      before["evidence_required"],
+      after_["evidence_required"]
+    )
+  end
+
+  defp list_entry_changes(name, field, before, after_) do
+    before_set = MapSet.new(before || [], &canonical/1)
+    after_set = MapSet.new(after_ || [], &canonical/1)
+
+    removed =
+      before_set
+      |> MapSet.difference(after_set)
+      |> Enum.map(fn _ ->
+        change(:entry_removed, name, field, "#{field} entry removed", :weakening)
+      end)
+
+    added =
+      after_set
+      |> MapSet.difference(before_set)
+      |> Enum.map(fn _ ->
+        change(:entry_added, name, field, "#{field} entry added", :strengthening)
+      end)
+
+    removed ++ added
+  end
+
+  defp criticality_changes(name, before, after_) do
+    before_rank = criticality(before)
+    after_rank = criticality(after_)
+
+    cond do
+      is_nil(before_rank) or is_nil(after_rank) or before_rank == after_rank ->
+        []
+
+      after_rank < before_rank ->
+        [change(:criticality_lowered, name, "criticality", "criticality lowered", :weakening)]
+
+      true ->
+        [change(:criticality_changed, name, "criticality", "criticality changed", :neutral)]
+    end
+  end
+
+  defp condition_changes(name, before, after_) do
+    before_condition = before["when"] || before["condition"]
+    after_condition = after_["when"] || after_["condition"]
+
+    if blank?(before_condition) and not blank?(after_condition) do
+      [
+        change(
+          :condition_added,
+          name,
+          "condition",
+          "condition added to unconditional task",
+          :weakening
+        )
+      ]
+    else
+      []
+    end
+  end
+
+  defp neutral_changes(name, before, after_) do
+    [
+      neutral_if_changed(name, "command", before["command"], after_["command"]),
+      neutral_if_changed(name, "depends_on", before["depends_on"], after_["depends_on"]),
+      neutral_if_changed(name, "env", before["env"], after_["env"])
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp neutral_if_changed(_name, _field, value, value), do: nil
+
+  defp neutral_if_changed(name, field, _before, _after) do
+    change(:field_changed, name, field, "#{field} changed", :neutral)
+  end
+
+  defp tasks_by_name(contract) do
+    contract
+    |> Map.get("tasks", [])
+    |> Enum.filter(&is_map/1)
+    |> Map.new(fn task -> {task["name"], task} end)
+  end
+
+  defp gate_or_review?(task), do: task["gate"] != nil or task["kind"] == "review"
+
+  defp criticality(task) do
+    task
+    |> Map.get("criticality")
+    |> then(&Map.get(@criticality, &1))
+  end
+
+  defp canonical(value), do: Jason.encode!(value)
+
+  defp blank?(nil), do: true
+  defp blank?(""), do: true
+  defp blank?(_), do: false
+
+  defp change(kind, task, field, detail, direction) do
+    %{kind: kind, task: task, field: field, detail: detail, direction: direction}
+  end
+end

--- a/core/test/sykli/contract_diff_test.exs
+++ b/core/test/sykli/contract_diff_test.exs
@@ -1,0 +1,126 @@
+defmodule Sykli.ContractDiffTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.ContractDiff
+
+  @base %{
+    "version" => "4",
+    "tasks" => [
+      %{
+        "name" => "test",
+        "command" => "mix test",
+        "task_type" => "test",
+        "criticality" => "high",
+        "success_criteria" => [%{"type" => "exit_code", "equals" => 0}],
+        "evidence_required" => [
+          %{"type" => "file", "name" => "coverage", "ref_pattern" => "coverage.out"}
+        ]
+      },
+      %{"name" => "gate", "gate" => %{"strategy" => "manual"}}
+    ]
+  }
+
+  test "unchanged contract has no changes" do
+    assert ContractDiff.classify(@base, @base) == []
+  end
+
+  test "success_criteria removed is weakening and added is strengthening" do
+    without = update_task(@base, "test", &Map.put(&1, "success_criteria", []))
+
+    assert [%{direction: :weakening, field: "success_criteria"}] =
+             only(ContractDiff.classify(@base, without), "success_criteria")
+
+    assert [%{direction: :strengthening, field: "success_criteria"}] =
+             only(ContractDiff.classify(without, @base), "success_criteria")
+  end
+
+  test "evidence_required removed is weakening and added is strengthening" do
+    without = update_task(@base, "test", &Map.put(&1, "evidence_required", []))
+
+    assert [%{direction: :weakening, field: "evidence_required"}] =
+             only(ContractDiff.classify(@base, without), "evidence_required")
+
+    assert [%{direction: :strengthening, field: "evidence_required"}] =
+             only(ContractDiff.classify(without, @base), "evidence_required")
+  end
+
+  test "criticality lowered is weakening" do
+    changed = update_task(@base, "test", &Map.put(&1, "criticality", "medium"))
+
+    assert Enum.any?(
+             ContractDiff.classify(@base, changed),
+             &match?(%{direction: :weakening, field: "criticality"}, &1)
+           )
+  end
+
+  test "gate removed is weakening and gate added is strengthening" do
+    without_gate = Map.put(@base, "tasks", [List.first(@base["tasks"])])
+
+    assert Enum.any?(
+             ContractDiff.classify(@base, without_gate),
+             &match?(%{direction: :weakening, kind: :task_removed}, &1)
+           )
+
+    assert Enum.any?(
+             ContractDiff.classify(without_gate, @base),
+             &match?(%{direction: :strengthening, kind: :task_added}, &1)
+           )
+  end
+
+  test "condition added to unconditional task is weakening" do
+    changed = update_task(@base, "test", &Map.put(&1, "condition", "branch == main"))
+
+    assert Enum.any?(
+             ContractDiff.classify(@base, changed),
+             &match?(%{direction: :weakening, field: "condition"}, &1)
+           )
+  end
+
+  test "task removed is weakening and task added is neutral" do
+    without = %{"version" => "4", "tasks" => []}
+
+    assert Enum.any?(
+             ContractDiff.classify(@base, without),
+             &match?(%{direction: :weakening, kind: :task_removed}, &1)
+           )
+
+    assert Enum.any?(
+             ContractDiff.classify(without, @base),
+             &match?(%{direction: :neutral, task: "test", kind: :task_added}, &1)
+           )
+  end
+
+  test "command deps and env changes are neutral" do
+    changed =
+      @base
+      |> update_task("test", fn task ->
+        task
+        |> Map.put("command", "mix test --failed")
+        |> Map.put("depends_on", ["build"])
+        |> Map.put("env", %{"MIX_ENV" => "test"})
+      end)
+
+    changes = ContractDiff.classify(@base, changed)
+    assert Enum.any?(changes, &match?(%{direction: :neutral, field: "command"}, &1))
+    assert Enum.any?(changes, &match?(%{direction: :neutral, field: "depends_on"}, &1))
+    assert Enum.any?(changes, &match?(%{direction: :neutral, field: "env"}, &1))
+  end
+
+  test "classify fixture against itself is empty" do
+    for path <- Path.wildcard("../tests/conformance/cases/*.json") do
+      assert {:ok, contract} = path |> File.read!() |> Jason.decode()
+      assert ContractDiff.classify(contract, contract) == []
+    end
+  end
+
+  defp update_task(contract, name, fun) do
+    Map.update!(contract, "tasks", fn tasks ->
+      Enum.map(tasks, fn
+        %{"name" => ^name} = task -> fun.(task)
+        task -> task
+      end)
+    end)
+  end
+
+  defp only(changes, field), do: Enum.filter(changes, &(&1.field == field))
+end

--- a/docs/guardrails-conformance.md
+++ b/docs/guardrails-conformance.md
@@ -40,7 +40,7 @@ Gate alias commands: `deps.get --check-locked`, `deps.unlock --check-unused`,
 | B-G.6 | n-a | No deterministic performance gate declared. |
 | B-C.1 | gap | Coverage ratchet against main not implemented. Issue: pending guardrails rollout ticket. |
 | B-E.1 | met | `.github/CODEOWNERS` protects guardrail-sensitive paths. |
-| B-E.2 | gap | Test-weakening diff checks not implemented. Issue: pending guardrails rollout ticket. |
+| B-E.2 | partial | sykli contract --diff classifies weakening changes; CI gating pending. |
 | B-E.3 | gap | Scope conformance check not implemented. Issue: pending guardrails rollout ticket. |
 | B-E.4 | gap | Diff budget check not implemented. Issue: pending guardrails rollout ticket. |
 | B-R.1 | met | `mix gate` is committed in `core/mix.exs`. |

--- a/test/blackbox/dataset.json
+++ b/test/blackbox/dataset.json
@@ -1174,6 +1174,20 @@
       "validated_by": "Regression: lock enforcement returned {:error, :no_sdk_file}; run crashed with CaseClauseError."
     },
     {
+      "id": "NEG-025",
+      "name": "contract diff exits one on weakening",
+      "fixture": "locked_contract",
+      "command": "sykli lock >/dev/null && perl -0pi -e 's/\"success_criteria\":\\[\\{\"type\":\"exit_code\",\"equals\":0\\}\\],//' sykli.exs && sykli contract --diff",
+      "shell": true,
+      "expect_exit": 1,
+      "expect_stdout_contains": [
+        "Weakening",
+        "Verdict: weakening present"
+      ],
+      "source": "docs/codex-brief-notation-core.md PR 2",
+      "validated_by": "Injected bug: weakening diff exits 0; exit assertion fails."
+    },
+    {
       "id": "ABN-015",
       "name": "Task timeout is errored, not failed",
       "fixture": "task_timeout",
@@ -1352,6 +1366,37 @@
       ],
       "source": "docs/codex-brief-notation-core.md PR 1",
       "validated_by": "Injected bug: return a plain JsonResponse.error for mismatch; .data hash assertions fail."
+    },
+    {
+      "id": "JSON-012",
+      "name": "contract --json returns canonical contract envelope",
+      "fixture": "locked_contract",
+      "command": "sykli contract --json",
+      "expect_exit": 0,
+      "expect_json_jq": [
+        ".ok == true",
+        ".data.version == \"4\"",
+        ".data.tasks[0].success_criteria | type == \"array\""
+      ],
+      "source": "docs/codex-brief-notation-core.md PR 2",
+      "validated_by": "Injected bug: render human text for contract --json; jq assertions fail."
+    },
+    {
+      "id": "JSON-013",
+      "name": "contract --diff --json reports weakening",
+      "fixture": "locked_contract",
+      "command": "sykli lock >/dev/null && perl -0pi -e 's/\"success_criteria\":\\[\\{\"type\":\"exit_code\",\"equals\":0\\}\\],//' sykli.exs && sykli contract --diff --json",
+      "shell": true,
+      "expect_exit": 1,
+      "expect_json_jq": [
+        ".ok == true",
+        ".data.weakening == true",
+        ".data.from_hash | startswith(\"sha256:\")",
+        ".data.to_hash | startswith(\"sha256:\")",
+        ".data.changes[] | select(.direction == \"weakening\")"
+      ],
+      "source": "docs/codex-brief-notation-core.md PR 2",
+      "validated_by": "Injected bug: classify removed success_criteria as neutral; weakening assertion fails."
     },
     {
       "id": "DET-001",


### PR DESCRIPTION
## Summary

- add `sykli contract` and `sykli contract --diff` with shared JSON envelopes
- add pure contract change classification for weakening/strengthening/neutral deltas
- add focused ExUnit and black-box coverage for render, JSON, and weakening diff exit behavior

## Stack note

This PR is based on PR #269 (`feature/contract-lock`), which is currently unmerged. The branch targets `main` per the brief, so the GitHub diff includes the PR #269 base work until that lands.

## Verification

- `cd core && mix format --check-formatted`
- `cd core && mix credo --strict`
- `cd core && mix compile --warnings-as-errors --force`
- `cd core && mix test test/sykli/contract_diff_test.exs`
- `cd core && mix test --seed 0`
- `cd core && mix test`
- `cd core && mix escript.build`
- `jq empty test/blackbox/dataset.json`
- `test/blackbox/run.sh --filter=DET`
- `test/blackbox/run.sh --filter=NEG`
- `test/blackbox/run.sh --filter=JSON`
- `eval/oracle/run.sh`
- `git diff --check`
