### PR TITLE
ci(release): prerelease-safe pipeline for 0.9.0-rc.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,10 @@ jobs:
         with:
           files: release/*
           body_path: docs/releases/${{ github.ref_name }}.md
-          make_latest: true
+          # A tag containing '-' (v0.9.0-rc.1) is a prerelease: marked as such
+          # on GitHub and never promoted to "latest".
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}
 
   # ── Registry publishing ──────────────────────────────────────────────
   # Tokenless where the registry supports OIDC trusted publishing.
@@ -209,4 +212,9 @@ jobs:
   #       working-directory: sdk/typescript
   #       run: |
   #         npm install -g npm@latest
-  #         npm publish
+  #         version="${GITHUB_REF_NAME#v}"
+  #         if [[ "$version" == *-* ]]; then
+  #           npm publish --tag rc   # prerelease must never become npm "latest"
+  #         else
+  #           npm publish
+  #         fi

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -92,6 +92,32 @@ The publish jobs run after the GitHub release is created, so a registry
 failure never blocks the binary release — fix the registry side and re-run
 the failed job from the Actions UI.
 
+## Release candidates
+
+A version containing a `-` (e.g. `0.9.0-rc.1`) is a prerelease end to end.
+Use the `X.Y.Z-rc.N` form everywhere — `bump-version.sh` and
+`check-version.sh` accept it, and each ecosystem maps it safely:
+
+| Registry | Version as published | Default-install safety |
+|---|---|---|
+| GitHub release | tag `v0.9.0-rc.1` | marked prerelease, never "latest" (workflow derives both from the `-` in the tag) |
+| Go | tag `sdk/go/v0.9.0-rc.1` | Go tooling never selects prerelease tags for `@latest` |
+| PyPI | normalized to `0.9.0rc1` (PEP 440) | `pip install sykli` skips pre-releases by default |
+| crates.io | `0.9.0-rc.1` | `sykli = "0.9"` never resolves to a prerelease |
+| npm | `0.9.0-rc.1` under dist-tag `rc` | `npm install sykli` keeps serving stable; RCs install via `sykli@rc` (`publish-ts.sh` and the workflow job apply the tag automatically) |
+| Hex | `0.9.0-rc.1` | `~>` requirements never match prereleases |
+
+Before tagging an RC:
+
+1. `docs/releases/v<version>.md` must exist — the release job reads it via
+   `body_path` and fails without it.
+2. `scripts/bump-version.sh <version> --dry-run`, then without `--dry-run`.
+3. Registry versions are immutable: an abandoned RC is left in place
+   (superseded by `-rc.2`), never deleted.
+
+Promoting an RC to final is a fresh release of `X.Y.Z` through the same
+pipeline — never a re-tag of the RC artifacts.
+
 ## Publish Credentials (manual script path)
 
 `make publish` / `scripts/publish-all.sh` remain available as the manual

--- a/scripts/publish-ts.sh
+++ b/scripts/publish-ts.sh
@@ -35,4 +35,10 @@ trap 'rm -f "$npmrc"' EXIT
 # shellcheck disable=SC2016
 echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > "$npmrc"
 
-NPM_CONFIG_USERCONFIG="$npmrc" npm publish
+# Prerelease versions (anything with a '-', e.g. 0.9.0-rc.1) go to the "rc"
+# dist-tag so `npm install sykli` keeps serving the latest stable.
+if [[ "$VERSION" == *-* ]]; then
+  NPM_CONFIG_USERCONFIG="$npmrc" npm publish --tag rc
+else
+  NPM_CONFIG_USERCONFIG="$npmrc" npm publish
+fi


### PR DESCRIPTION
## Summary
Prepares the release pipeline for the 0.9.0-rc.1 plan (mandate/v5 lands first, then RC, dogfood, then final):

- **GitHub release**: `prerelease` and `make_latest` are now derived from the tag — `v0.9.0-rc.1` is marked prerelease and never becomes "latest". Previously `make_latest: true` was hardcoded, so an RC tag would have displaced v0.7.0 as the latest release.
- **npm dist-tag**: `publish-ts.sh` (and the commented trusted-publishing job, for when it's enabled) publish `-`-versions under `--tag rc`, so `npm install sykli` keeps resolving stable. This was the one registry where an RC would have been served by default.
- **RELEASE.md**: new "Release candidates" section with the per-registry version mapping (`0.9.0rc1` on PyPI per PEP 440, `sdk/go/v0.9.0-rc.1` module tag, hex/cargo prerelease resolution semantics), the pre-tag checklist (release-notes file must exist for `body_path`), and the promotion rule (RC→final is a fresh release, never a re-tag).

## Verification
- `release.yml` parses (YAML), `publish-ts.sh` passes `bash -n`
- `scripts/bump-version.sh 0.9.0-rc.1 --dry-run` accepted the version format (regex already supports prerelease suffixes)
- No behavior change for stable tags: `contains('v0.8.0', '-')` is false → `prerelease: false`, `make_latest: true`, plain `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)