### PR TITLE
feat(contract): accept v5 actor mandates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pipeline schema v5 parser/validator support.** The engine and canonical
+  schema now accept `version: "5"` payloads with executable-task `actor` and
+  `mandate` declarations. Agent actors require a mandate, non-empty
+  `success_criteria`, and non-empty `evidence_required`; review nodes reject
+  the new executable-task fields. SDK emission remains on the existing v4 path.
 - **`sykli lock`.** Writes `sykli.lock` with the canonical contract and
   enforces matching locked contracts in `sykli validate` and `sykli run`.
 - **`sykli contract`.** Renders the current emitted contract and supports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Most recent first. Older shipped features (Phase 3B `task_type`, Phase 3C `success_criteria`, schema-as-canonical-contract, `target` removed, review nodes) are now load-bearing architecture — see §"SDKs", §"Patterns & Conventions" ("Engine vocabulary modules"), and the `ReviewPrimitive` row in §"Key Modules".
 
+- **Pipeline schema v5 parser/validator support** adds executable-task
+  `actor` and `mandate` declarations to the engine and canonical schema.
+  `Sykli.Actor` and `Sykli.Mandate` mirror the existing vocabulary-module
+  pattern so graph parsing and `sykli validate` render identical errors.
+  `Sykli.ContractSchemaVersion` accepts `"5"` but `current_version/0` remains
+  `"4"` until SDK emitters move in a separate PR.
 - **Monster Phases B/C/E hardening** (audit remediation, `docs/audit-2026-05-22.md`):
   determinism — `ContractHash` now recursively sorts object keys before hashing,
   and the NoWallClock Credo guard covers all pure contract/output-shaping
@@ -36,7 +42,7 @@ Most recent first. Older shipped features (Phase 3B `task_type`, Phase 3C `succe
 - **Team Mode run summary sync** added Phase 7 coordinator projection: joined daemons publish metadata-only run summaries to `POST /v1/runs`, the coordinator stores idempotent run records plus node/criteria/review/gate/evidence refs, and `.sykli/outbox/runs/` replays deferred publishes. No logs, source, artifacts, contract bytes, or tokens cross this boundary.
 - **Evidence requirements are versioned contract fields.** Pipeline `version: "4"` adds executable-task `evidence_required` declarations. V1 evaluates local file evidence refs on the local shell target, persists `evidence_results`, and fails missing required proof with `missing_evidence`; unsupported requirement/target combinations fail explicitly. See `docs/evidence-requirements.md`.
 - **Team Mode foundation** shipped — local work-item and gate-decision stores, `sykli run --work` association with deterministic `contract_hash`, daemon join + heartbeat protocol, self-hosted coordinator skeleton (in-memory store, bearer-token auth), work-item sync via `sykli work ... --team <team>`, deterministic review primitive dispatch (`api_breakage`), and canonical contract hashing. CLI surface: `sykli work`, `sykli gate`, `sykli coordinator`, `sykli daemon join`. The four coordination modes (Local-only / Trusted LAN mesh / Self-hosted coordinator / Hybrid) are normative — see `docs/coordination-modes.md` and the design index under §"Other docs". Phases 0–8 of `docs/team-mode-roadmap.md` are implemented; Phase 9 (Kubernetes deployment) is next.
-- **Engine now enforces `version` strictly.** `Sykli.ContractSchemaVersion` (`core/lib/sykli/contract_schema_version.ex`) is the central policy module — it pins supported versions (`"1"`, `"2"`, `"3"`, `"4"`), the current version (`"4"`), and rejects missing/empty/wrong-type/unsupported versions. `Sykli.Graph.parse/1` and `Sykli.Validate.validate_data/1` both call `ContractSchemaVersion.fetch/1`. The previous silent default-to-`"1"` behavior is gone — payloads without a valid version are rejected. Negative coverage lives in `tests/conformance/schema-invalid/`.
+- **Engine now enforces `version` strictly.** `Sykli.ContractSchemaVersion` (`core/lib/sykli/contract_schema_version.ex`) is the central policy module — it pins supported versions (`"1"`, `"2"`, `"3"`, `"4"`, `"5"`), the current version (`"4"`), and rejects missing/empty/wrong-type/unsupported versions. `Sykli.Graph.parse/1` and `Sykli.Validate.validate_data/1` both call `ContractSchemaVersion.fetch/1`. The previous silent default-to-`"1"` behavior is gone — payloads without a valid version are rejected. Negative coverage lives in `tests/conformance/schema-invalid/`.
 - **GitHub-native foundation** shipped — GitHub App auth, webhook receiver (Plug + Bandit), Checks API client, `Sykli.Mesh.Roles`. See `docs/github-native.md`.
 - **CLI visual reset** shipped — Nordic-minimal renderer (`Sykli.CLI.Renderer/Theme/Live/FixRenderer`). The output rules are testable; banned vocabulary in §"CLI output rules" below.
 
@@ -181,6 +187,7 @@ Local-first is binding: anything new must work in mode 1 with no network. The co
 | `CLI` | `cli.ex` | Command dispatch (see CLI Commands section for the list) |
 | `Graph` | `graph.ex` | JSON → Task DAG, validation, matrix expansion |
 | `Graph.Task` | `graph.ex` + `graph/task/*.ex` | Task struct with semantic/ai_hooks/history fields |
+| `Actor` / `Mandate` | `actor.ex`, `mandate.ex` | V5 executable-task actor/mandate validation. Agent actors require mandate, success criteria, and evidence; review nodes reject these fields. |
 | `Executor` | `executor.ex` | DAG execution with `Executor.Config` struct, AI hooks, concurrency limiting |
 | `Target.Local` | `target/local.ex` | Local execution via Runtime (Docker or Shell) |
 | `Runtime.*` | `runtime/*.ex` | HOW commands execute — Shell, Docker, Podman (distinct from Target = WHERE) |
@@ -355,6 +362,8 @@ Some cases carry `expected_failure: true`, which marks them as known-broken cont
   - `Sykli.TaskType` — the 12-value `task_type` enum (Phase 3B).
   - `Sykli.SuccessCriteria` — `success_criteria` shape, constraints, and target-level result helpers (Phase 3C).
   - `Sykli.EvidenceRequirement` — `evidence_required` shape, constraints, result helpers, and missing/unsupported proof semantics.
+  - `Sykli.Actor` — v5 actor kind enum and actor shape validation.
+  - `Sykli.Mandate` — v5 mandate shape validation and agent-contract checks.
   - `Sykli.ContractSchemaVersion` — supported `version` values + missing/empty/wrong-type/unsupported error policy.
 
   When adding a new closed-enum field or shared-policy concept, follow this pattern. SDKs must carry their own copies (separate Mix projects — engine modules are unreachable from `sdk/<lang>/`).

--- a/core/.credo.exs
+++ b/core/.credo.exs
@@ -18,6 +18,8 @@
           "lib/sykli/graph.ex",
           "lib/sykli/graph/",
           "lib/sykli/validate.ex",
+          "lib/sykli/actor.ex",
+          "lib/sykli/mandate.ex",
           "lib/sykli/task_type.ex",
           "lib/sykli/success_criteria.ex",
           "lib/sykli/evidence_requirement.ex",

--- a/core/lib/sykli/actor.ex
+++ b/core/lib/sykli/actor.ex
@@ -1,0 +1,107 @@
+defmodule Sykli.Actor do
+  @moduledoc """
+  Validation helpers for v5 task `actor` declarations.
+  """
+
+  @kinds ~w(human agent service)
+
+  @spec kinds() :: [String.t()]
+  def kinds, do: @kinds
+
+  @spec valid_kind?(term()) :: boolean()
+  def valid_kind?(kind), do: kind in @kinds
+
+  @spec parse(term(), :task | :review, String.t(), String.t() | nil) ::
+          {:ok, map() | nil} | {:error, term()}
+  def parse(nil, _kind, _version, _task_name), do: {:ok, nil}
+
+  def parse(actor, kind, version, task_name) do
+    case validate(actor, kind, version, task_name) do
+      :ok -> {:ok, normalize(actor)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec validate(term(), :task | :review, String.t(), String.t() | nil) ::
+          :ok | {:error, term()}
+  def validate(nil, _kind, _version, _task_name), do: :ok
+
+  def validate(_actor, :review, _version, task_name) do
+    {:error, {:actor_on_review, task_name}}
+  end
+
+  def validate(_actor, _kind, version, task_name) when version != "5" do
+    {:error, {:actor_requires_version_5, task_name, version}}
+  end
+
+  def validate(%{"kind" => kind} = actor, _kind, "5", task_name) do
+    with :ok <- validate_kind(kind, task_name),
+         :ok <- validate_id(actor, task_name) do
+      validate_no_extra_keys(actor, ["kind", "id"], task_name)
+    end
+  end
+
+  def validate(%{} = _actor, _kind, "5", task_name) do
+    {:error, {:invalid_actor, task_name, "requires kind"}}
+  end
+
+  def validate(_actor, _kind, "5", task_name) do
+    {:error, {:invalid_actor, task_name, "must be an object"}}
+  end
+
+  @spec format_error(term()) :: String.t()
+  def format_error(reason), do: "Error: #{message(reason)}"
+
+  @spec to_error_map(term()) :: map()
+  def to_error_map(reason) do
+    %{
+      type: error_type(reason),
+      task: error_task(reason),
+      message: message(reason)
+    }
+  end
+
+  @spec message(term()) :: String.t()
+  def message({:actor_on_review, task_name}) do
+    "Review node '#{task_name}' cannot declare actor"
+  end
+
+  def message({:actor_requires_version_5, task_name, version}) do
+    "Task '#{task_name}' declares actor but pipeline version is #{inspect(version)}, not \"5\""
+  end
+
+  def message({:invalid_actor, task_name, reason}) do
+    "Task '#{task_name}' declares invalid actor: #{reason}"
+  end
+
+  def message({:unknown_actor_kind, task_name, kind}) do
+    "Task '#{task_name}' declares unknown actor kind #{inspect(kind)}"
+  end
+
+  defp validate_kind(kind, _task_name) when kind in @kinds, do: :ok
+  defp validate_kind(kind, task_name), do: {:error, {:unknown_actor_kind, task_name, kind}}
+
+  defp validate_id(%{"id" => id}, task_name) when not is_binary(id) or id == "" do
+    {:error, {:invalid_actor, task_name, "id must be a non-empty string"}}
+  end
+
+  defp validate_id(_actor, _task_name), do: :ok
+
+  defp validate_no_extra_keys(actor, allowed_keys, task_name) do
+    extra_keys = Map.keys(actor) -- allowed_keys
+
+    if extra_keys == [] do
+      :ok
+    else
+      {:error, {:invalid_actor, task_name, "unknown keys: #{Enum.join(extra_keys, ", ")}"}}
+    end
+  end
+
+  defp normalize(actor), do: Map.take(actor, ["kind", "id"])
+
+  defp error_type({type, _task_name}) when is_atom(type), do: type
+  defp error_type({type, _task_name, _detail}) when is_atom(type), do: type
+
+  defp error_task({_type, task_name}), do: task_name
+  defp error_task({_type, task_name, _detail}), do: task_name
+end

--- a/core/lib/sykli/contract_schema_version.ex
+++ b/core/lib/sykli/contract_schema_version.ex
@@ -7,7 +7,7 @@ defmodule Sykli.ContractSchemaVersion do
   of silently treating them as an older format.
   """
 
-  @supported_versions ~w(1 2 3 4)
+  @supported_versions ~w(1 2 3 4 5)
   @current_version "4"
 
   @type validation_error ::

--- a/core/lib/sykli/contract_slice.ex
+++ b/core/lib/sykli/contract_slice.ex
@@ -29,6 +29,8 @@ defmodule Sykli.ContractSlice do
     |> maybe_put("needs", capability_field(task, "needs"))
     |> maybe_put("success_criteria", non_empty(Task.success_criteria(task)))
     |> maybe_put("evidence_required", non_empty(Task.evidence_required(task)))
+    |> maybe_put("actor", normalized_map(Task.actor(task)))
+    |> maybe_put("mandate", mandate_map(Task.mandate(task)))
     |> maybe_put("target", target_map(task))
     |> maybe_put("review", review_map(task))
     |> maybe_put("gate", gate_map(task))
@@ -54,6 +56,8 @@ defmodule Sykli.ContractSlice do
       "evidence_required",
       normalized_value(non_empty(task[:evidence_required] || task["evidence_required"]))
     )
+    |> maybe_put("actor", normalized_map(task[:actor] || task["actor"]))
+    |> maybe_put("mandate", mandate_map(task[:mandate] || task["mandate"]))
     |> maybe_put("target", map_target(task))
     |> maybe_put("review", normalized_map(task[:review] || task["review"]))
     |> maybe_put("gate", normalized_map(task[:gate] || task["gate"]))
@@ -203,6 +207,26 @@ defmodule Sykli.ContractSlice do
 
   defp gate_map(%Task{gate: %Gate{} = gate}), do: Gate.to_map(gate)
   defp gate_map(_), do: nil
+
+  defp mandate_map(nil), do: nil
+
+  defp mandate_map(%{} = mandate) do
+    mandate
+    |> normalized_map()
+    |> truncate_mandate_scope()
+  end
+
+  defp truncate_mandate_scope(%{"scope" => scope} = mandate) when is_list(scope) do
+    if length(scope) > 20 do
+      mandate
+      |> Map.put("scope", Enum.take(scope, 20))
+      |> Map.put("scope_count", length(scope))
+    else
+      mandate
+    end
+  end
+
+  defp truncate_mandate_scope(mandate), do: mandate
 
   defp parse_status(value) when value in ["passed", "failed", "unsupported"] do
     String.to_existing_atom(value)

--- a/core/lib/sykli/evidence_requirement.ex
+++ b/core/lib/sykli/evidence_requirement.ex
@@ -54,15 +54,16 @@ defmodule Sykli.EvidenceRequirement do
     {:error, {:evidence_required_on_review, task_name}}
   end
 
-  def validate(_requirements, _kind, version, task_name) when version != "4" do
+  def validate(_requirements, _kind, version, task_name) when version not in ["4", "5"] do
     {:error, {:evidence_required_requires_version_4, task_name, version}}
   end
 
-  def validate(requirements, _kind, "4", task_name) when is_list(requirements) do
+  def validate(requirements, _kind, version, task_name)
+      when is_list(requirements) and version in ["4", "5"] do
     validate_items(requirements, task_name)
   end
 
-  def validate(_requirements, _kind, "4", task_name) do
+  def validate(_requirements, _kind, version, task_name) when version in ["4", "5"] do
     {:error, {:invalid_evidence_required, task_name, "must be an array"}}
   end
 
@@ -100,7 +101,7 @@ defmodule Sykli.EvidenceRequirement do
   end
 
   def message({:evidence_required_requires_version_4, task_name, version}) do
-    "Task '#{task_name}' declares evidence_required but pipeline version is #{inspect(version)}, not \"4\""
+    "Task '#{task_name}' declares evidence_required but pipeline version is #{inspect(version)}, not \"4\" or newer"
   end
 
   def message({:invalid_evidence_required, task_name, reason}) do

--- a/core/lib/sykli/graph.ex
+++ b/core/lib/sykli/graph.ex
@@ -75,6 +75,8 @@ defmodule Sykli.Graph do
       :task_type,
       :success_criteria,
       :evidence_required,
+      :actor,
+      :mandate,
       :command,
       :inputs,
       :outputs,
@@ -158,6 +160,14 @@ defmodule Sykli.Graph do
     @doc "Returns declared task evidence requirements."
     @spec evidence_required(t()) :: [map()]
     def evidence_required(%__MODULE__{evidence_required: requirements}), do: requirements || []
+
+    @doc "Returns the task actor declaration."
+    @spec actor(t()) :: map() | nil
+    def actor(%__MODULE__{actor: actor}), do: actor
+
+    @doc "Returns the task mandate declaration."
+    @spec mandate(t()) :: map() | nil
+    def mandate(%__MODULE__{mandate: mandate}), do: mandate
 
     @doc "Returns the task command."
     @spec command(t()) :: String.t()
@@ -442,6 +452,35 @@ defmodule Sykli.Graph do
     Sykli.SuccessCriteria.format_error(reason)
   end
 
+  def format_error({:actor_on_review, _task_name} = reason), do: Sykli.Actor.format_error(reason)
+
+  def format_error({:actor_requires_version_5, _task_name, _version} = reason),
+    do: Sykli.Actor.format_error(reason)
+
+  def format_error({:invalid_actor, _task_name, _reason} = reason),
+    do: Sykli.Actor.format_error(reason)
+
+  def format_error({:unknown_actor_kind, _task_name, _kind} = reason),
+    do: Sykli.Actor.format_error(reason)
+
+  def format_error({:mandate_on_review, _task_name} = reason),
+    do: Sykli.Mandate.format_error(reason)
+
+  def format_error({:mandate_requires_version_5, _task_name, _version} = reason),
+    do: Sykli.Mandate.format_error(reason)
+
+  def format_error({:invalid_mandate, _task_name, _reason} = reason),
+    do: Sykli.Mandate.format_error(reason)
+
+  def format_error({:agent_requires_mandate, _task_name} = reason),
+    do: Sykli.Mandate.format_error(reason)
+
+  def format_error({:agent_requires_success_criteria, _task_name} = reason),
+    do: Sykli.Mandate.format_error(reason)
+
+  def format_error({:agent_requires_evidence_required, _task_name} = reason),
+    do: Sykli.Mandate.format_error(reason)
+
   def format_error(reason), do: inspect(reason)
 
   defp parse_task(map, version) do
@@ -453,6 +492,16 @@ defmodule Sykli.Graph do
            Sykli.SuccessCriteria.parse(map["success_criteria"], kind, version, task_name),
          {:ok, evidence_required} <-
            Sykli.EvidenceRequirement.parse(map["evidence_required"], kind, version, task_name),
+         {:ok, actor} <- Sykli.Actor.parse(map["actor"], kind, version, task_name),
+         {:ok, mandate} <- Sykli.Mandate.parse(map["mandate"], kind, version, task_name),
+         :ok <-
+           Sykli.Mandate.validate_agent_contract(
+             actor,
+             mandate,
+             success_criteria,
+             evidence_required,
+             task_name
+           ),
          {:ok, services} <- parse_services(map["services"], task_name),
          {:ok, mounts} <- parse_mounts(map["mounts"], task_name) do
       {:ok,
@@ -462,6 +511,8 @@ defmodule Sykli.Graph do
          task_type: task_type,
          success_criteria: success_criteria,
          evidence_required: evidence_required,
+         actor: actor,
+         mandate: mandate,
          command: map["command"],
          inputs: map["inputs"] || [],
          outputs: normalize_outputs(map["outputs"], kind),
@@ -510,11 +561,12 @@ defmodule Sykli.Graph do
     {:error, {:task_type_on_review, task_name}}
   end
 
-  defp parse_task_type(task_type, _kind, version, task_name) when version not in ["3", "4"] do
+  defp parse_task_type(task_type, _kind, version, task_name)
+       when version not in ["3", "4", "5"] do
     {:error, {:task_type_requires_v3_or_newer, task_name, version, task_type}}
   end
 
-  defp parse_task_type(task_type, _kind, version, task_name) when version in ["3", "4"] do
+  defp parse_task_type(task_type, _kind, version, task_name) when version in ["3", "4", "5"] do
     if Sykli.TaskType.valid?(task_type) do
       {:ok, task_type}
     else

--- a/core/lib/sykli/mandate.ex
+++ b/core/lib/sykli/mandate.ex
@@ -1,0 +1,201 @@
+defmodule Sykli.Mandate do
+  @moduledoc """
+  Validation helpers for v5 task `mandate` declarations.
+  """
+
+  @spec parse(term(), :task | :review, String.t(), String.t() | nil) ::
+          {:ok, map() | nil} | {:error, term()}
+  def parse(nil, _kind, _version, _task_name), do: {:ok, nil}
+
+  def parse(mandate, kind, version, task_name) do
+    case validate(mandate, kind, version, task_name) do
+      :ok -> {:ok, normalize(mandate)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec validate(term(), :task | :review, String.t(), String.t() | nil) ::
+          :ok | {:error, term()}
+  def validate(nil, _kind, _version, _task_name), do: :ok
+
+  def validate(_mandate, :review, _version, task_name) do
+    {:error, {:mandate_on_review, task_name}}
+  end
+
+  def validate(_mandate, _kind, version, task_name) when version != "5" do
+    {:error, {:mandate_requires_version_5, task_name, version}}
+  end
+
+  def validate(%{"scope" => scope} = mandate, _kind, "5", task_name) do
+    with :ok <- validate_scope(scope, task_name),
+         :ok <- validate_budget(mandate, task_name),
+         :ok <- validate_capabilities(mandate, task_name) do
+      validate_no_extra_keys(mandate, ["scope", "budget", "capabilities"], task_name)
+    end
+  end
+
+  def validate(%{} = _mandate, _kind, "5", task_name) do
+    {:error, {:invalid_mandate, task_name, "requires scope"}}
+  end
+
+  def validate(_mandate, _kind, "5", task_name) do
+    {:error, {:invalid_mandate, task_name, "must be an object"}}
+  end
+
+  @spec validate_agent_contract(map() | nil, map() | nil, [map()], [map()], String.t() | nil) ::
+          :ok | {:error, term()}
+  def validate_agent_contract(%{"kind" => "agent"}, nil, _criteria, _evidence, task_name) do
+    {:error, {:agent_requires_mandate, task_name}}
+  end
+
+  def validate_agent_contract(%{"kind" => "agent"}, _mandate, [], _evidence, task_name) do
+    {:error, {:agent_requires_success_criteria, task_name}}
+  end
+
+  def validate_agent_contract(%{"kind" => "agent"}, _mandate, _criteria, [], task_name) do
+    {:error, {:agent_requires_evidence_required, task_name}}
+  end
+
+  def validate_agent_contract(_actor, _mandate, _criteria, _evidence, _task_name), do: :ok
+
+  @spec format_error(term()) :: String.t()
+  def format_error(reason), do: "Error: #{message(reason)}"
+
+  @spec to_error_map(term()) :: map()
+  def to_error_map(reason) do
+    %{
+      type: error_type(reason),
+      task: error_task(reason),
+      message: message(reason)
+    }
+  end
+
+  @spec message(term()) :: String.t()
+  def message({:mandate_on_review, task_name}) do
+    "Review node '#{task_name}' cannot declare mandate"
+  end
+
+  def message({:mandate_requires_version_5, task_name, version}) do
+    "Task '#{task_name}' declares mandate but pipeline version is #{inspect(version)}, not \"5\""
+  end
+
+  def message({:invalid_mandate, task_name, reason}) do
+    "Task '#{task_name}' declares invalid mandate: #{reason}"
+  end
+
+  def message({:agent_requires_mandate, task_name}) do
+    "Task '#{task_name}' declares actor.kind \"agent\" but does not declare mandate"
+  end
+
+  def message({:agent_requires_success_criteria, task_name}) do
+    "Task '#{task_name}' declares actor.kind \"agent\" but does not declare non-empty success_criteria"
+  end
+
+  def message({:agent_requires_evidence_required, task_name}) do
+    "Task '#{task_name}' declares actor.kind \"agent\" but does not declare non-empty evidence_required"
+  end
+
+  defp validate_scope(scope, task_name) when is_list(scope) and scope != [] do
+    if Enum.all?(scope, &(is_binary(&1) and &1 != "")) do
+      :ok
+    else
+      {:error, {:invalid_mandate, task_name, "scope entries must be non-empty strings"}}
+    end
+  end
+
+  defp validate_scope(_scope, task_name) do
+    {:error, {:invalid_mandate, task_name, "scope must be a non-empty array"}}
+  end
+
+  defp validate_budget(%{"budget" => budget}, task_name) when is_map(budget) do
+    with :ok <- validate_budget_keys(budget, task_name),
+         :ok <- validate_positive_integer(budget, "diff_lines", task_name),
+         :ok <- validate_positive_integer(budget, "wall_clock_ms", task_name) do
+      if map_size(budget) == 0 do
+        {:error, {:invalid_mandate, task_name, "budget must not be empty"}}
+      else
+        :ok
+      end
+    end
+  end
+
+  defp validate_budget(%{"budget" => _budget}, task_name) do
+    {:error, {:invalid_mandate, task_name, "budget must be an object"}}
+  end
+
+  defp validate_budget(_mandate, _task_name), do: :ok
+
+  defp validate_budget_keys(budget, task_name) do
+    validate_no_extra_keys(budget, ["diff_lines", "wall_clock_ms"], task_name, "budget")
+  end
+
+  defp validate_positive_integer(map, key, task_name) do
+    case Map.fetch(map, key) do
+      {:ok, value} when is_integer(value) and value > 0 ->
+        :ok
+
+      {:ok, _value} ->
+        {:error, {:invalid_mandate, task_name, "budget.#{key} must be a positive integer"}}
+
+      :error ->
+        :ok
+    end
+  end
+
+  defp validate_capabilities(%{"capabilities" => capabilities}, task_name)
+       when is_map(capabilities) do
+    with :ok <- validate_no_extra_keys(capabilities, ["network"], task_name, "capabilities") do
+      case Map.fetch(capabilities, "network") do
+        {:ok, value} when is_boolean(value) ->
+          :ok
+
+        {:ok, _value} ->
+          {:error, {:invalid_mandate, task_name, "capabilities.network must be a boolean"}}
+
+        :error ->
+          :ok
+      end
+    end
+  end
+
+  defp validate_capabilities(%{"capabilities" => _capabilities}, task_name) do
+    {:error, {:invalid_mandate, task_name, "capabilities must be an object"}}
+  end
+
+  defp validate_capabilities(_mandate, _task_name), do: :ok
+
+  defp validate_no_extra_keys(map, allowed_keys, task_name) do
+    validate_no_extra_keys(map, allowed_keys, task_name, nil)
+  end
+
+  defp validate_no_extra_keys(map, allowed_keys, task_name, prefix) do
+    extra_keys = Map.keys(map) -- allowed_keys
+
+    if extra_keys == [] do
+      :ok
+    else
+      path = if prefix, do: "#{prefix} has", else: "has"
+
+      {:error,
+       {:invalid_mandate, task_name, "#{path} unknown keys: #{Enum.join(extra_keys, ", ")}"}}
+    end
+  end
+
+  defp normalize(mandate) do
+    mandate
+    |> Map.take(["scope", "budget", "capabilities"])
+    |> reject_empty()
+  end
+
+  defp reject_empty(map) do
+    map
+    |> Enum.reject(fn {_key, value} -> is_nil(value) or value == %{} end)
+    |> Map.new()
+  end
+
+  defp error_type({type, _task_name}) when is_atom(type), do: type
+  defp error_type({type, _task_name, _detail}) when is_atom(type), do: type
+
+  defp error_task({_type, task_name}), do: task_name
+  defp error_task({_type, task_name, _detail}), do: task_name
+end

--- a/core/lib/sykli/success_criteria.ex
+++ b/core/lib/sykli/success_criteria.ex
@@ -50,19 +50,19 @@ defmodule Sykli.SuccessCriteria do
     {:error, {:success_criteria_on_review, task_name}}
   end
 
-  def validate(_criteria, _kind, version, task_name) when version not in ["3", "4"] do
+  def validate(_criteria, _kind, version, task_name) when version not in ["3", "4", "5"] do
     {:error, {:success_criteria_requires_v3_or_newer, task_name, version}}
   end
 
   def validate(criteria, _kind, version, task_name)
-      when is_list(criteria) and version in ["3", "4"] do
+      when is_list(criteria) and version in ["3", "4", "5"] do
     with :ok <- validate_items(criteria, task_name),
          :ok <- validate_single_exit_code(criteria, task_name) do
       :ok
     end
   end
 
-  def validate(_criteria, _kind, version, task_name) when version in ["3", "4"] do
+  def validate(_criteria, _kind, version, task_name) when version in ["3", "4", "5"] do
     {:error, {:invalid_success_criteria, task_name, "must be an array"}}
   end
 

--- a/core/lib/sykli/validate.ex
+++ b/core/lib/sykli/validate.ex
@@ -134,6 +134,9 @@ defmodule Sykli.Validate do
     |> check_task_types(tasks, version)
     |> check_success_criteria(tasks, version)
     |> check_evidence_required(tasks, version)
+    |> check_actors(tasks, version)
+    |> check_mandates(tasks, version)
+    |> check_agent_contracts(tasks, version)
   end
 
   defp check_empty_names(errors, tasks) do
@@ -294,7 +297,7 @@ defmodule Sykli.Validate do
             | acc
           ]
 
-        version not in ["3", "4"] ->
+        version not in ["3", "4", "5"] ->
           [
             %{
               type: :task_type_requires_v3_or_newer,
@@ -380,6 +383,67 @@ defmodule Sykli.Validate do
   defp evidence_required_error_task({_type, task_name}), do: task_name
   defp evidence_required_error_task({_type, task_name, _detail}), do: task_name
 
+  defp check_actors(errors, tasks, version) do
+    tasks
+    |> Enum.filter(fn t -> valid_name?(t["name"]) and Map.has_key?(t, "actor") end)
+    |> Enum.reduce(errors, fn t, acc ->
+      name = t["name"]
+      kind = if t["kind"] == "review", do: :review, else: :task
+
+      case Sykli.Actor.validate(t["actor"], kind, version, name) do
+        :ok -> acc
+        {:error, reason} -> [Sykli.Actor.to_error_map(reason) | acc]
+      end
+    end)
+  end
+
+  defp check_mandates(errors, tasks, version) do
+    tasks
+    |> Enum.filter(fn t -> valid_name?(t["name"]) and Map.has_key?(t, "mandate") end)
+    |> Enum.reduce(errors, fn t, acc ->
+      name = t["name"]
+      kind = if t["kind"] == "review", do: :review, else: :task
+
+      case Sykli.Mandate.validate(t["mandate"], kind, version, name) do
+        :ok -> acc
+        {:error, reason} -> [Sykli.Mandate.to_error_map(reason) | acc]
+      end
+    end)
+  end
+
+  defp check_agent_contracts(errors, _tasks, version) when version != "5", do: errors
+
+  defp check_agent_contracts(errors, tasks, "5") do
+    tasks
+    |> Enum.filter(&valid_name?(&1["name"]))
+    |> Enum.reduce(errors, fn t, acc ->
+      with {:ok, actor} <- Sykli.Actor.parse(t["actor"], :task, "5", t["name"]),
+           {:ok, mandate} <- Sykli.Mandate.parse(t["mandate"], :task, "5", t["name"]),
+           :ok <-
+             Sykli.Mandate.validate_agent_contract(
+               actor,
+               mandate,
+               t["success_criteria"] || [],
+               t["evidence_required"] || [],
+               t["name"]
+             ) do
+        acc
+      else
+        {:error, {:agent_requires_mandate, _} = reason} ->
+          [Sykli.Mandate.to_error_map(reason) | acc]
+
+        {:error, {:agent_requires_success_criteria, _} = reason} ->
+          [Sykli.Mandate.to_error_map(reason) | acc]
+
+        {:error, {:agent_requires_evidence_required, _} = reason} ->
+          [Sykli.Mandate.to_error_map(reason) | acc]
+
+        {:error, _reason} ->
+          acc
+      end
+    end)
+  end
+
   defp format_error(%{type: :missing_command, message: msg}), do: "Error: #{msg}"
   defp format_error(%{type: :task_type_on_review, message: msg}), do: "Error: #{msg}"
   defp format_error(%{type: :task_type_requires_v3_or_newer, message: msg}), do: "Error: #{msg}"
@@ -404,6 +468,17 @@ defmodule Sykli.Validate do
 
   defp format_error(%{type: :unknown_evidence_required_type, message: msg}),
     do: "Error: #{msg}"
+
+  defp format_error(%{type: :actor_on_review, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :actor_requires_version_5, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :invalid_actor, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :unknown_actor_kind, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :mandate_on_review, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :mandate_requires_version_5, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :invalid_mandate, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :agent_requires_mandate, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :agent_requires_success_criteria, message: msg}), do: "Error: #{msg}"
+  defp format_error(%{type: :agent_requires_evidence_required, message: msg}), do: "Error: #{msg}"
 
   defp format_error(%{type: :cycle, message: msg}), do: "Error: #{msg}"
   defp format_error(%{type: :missing_dependency, message: msg}), do: "Error: #{msg}"

--- a/core/test/core_test.exs
+++ b/core/test/core_test.exs
@@ -62,7 +62,7 @@ defmodule SykliTest do
              "Error: empty contract schema version"
 
     assert Sykli.Graph.format_error({:unsupported_contract_schema_version, "0.2"}) ==
-             "Error: unsupported contract schema version: 0.2; supported versions: 1, 2, 3, 4"
+             "Error: unsupported contract schema version: 0.2; supported versions: 1, 2, 3, 4, 5"
   end
 
   test "parses task_type on version 3 executable tasks" do

--- a/core/test/sykli/actor_mandate_test.exs
+++ b/core/test/sykli/actor_mandate_test.exs
@@ -1,0 +1,138 @@
+defmodule Sykli.ActorMandateTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.{Graph, Validate}
+
+  defp pipeline(task, version \\ "5") do
+    Jason.encode!(%{"version" => version, "tasks" => [task]})
+  end
+
+  defp valid_agent_task(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "name" => "implement",
+        "command" => "mix test",
+        "actor" => %{"kind" => "agent", "id" => "codex"},
+        "mandate" => %{
+          "scope" => ["core/lib/**"],
+          "budget" => %{"diff_lines" => 120, "wall_clock_ms" => 60_000},
+          "capabilities" => %{"network" => false}
+        },
+        "success_criteria" => [%{"type" => "exit_code", "equals" => 0}],
+        "evidence_required" => [
+          %{"type" => "file", "name" => "junit", "ref_pattern" => "junit.xml"}
+        ]
+      },
+      overrides
+    )
+  end
+
+  test "parses v5 actor and mandate declarations" do
+    assert {:ok, graph} = Graph.parse(pipeline(valid_agent_task()))
+    task = Map.fetch!(graph, "implement")
+
+    assert Graph.Task.actor(task) == %{"kind" => "agent", "id" => "codex"}
+    assert Graph.Task.mandate(task)["scope"] == ["core/lib/**"]
+  end
+
+  test "accepts task_type success_criteria and evidence_required in v5" do
+    task = valid_agent_task(%{"task_type" => "test"})
+    assert {:ok, _graph} = Graph.parse(pipeline(task))
+
+    result = Validate.validate_json(pipeline(task))
+    assert result.valid
+  end
+
+  test "rejects actor and mandate before v5" do
+    task =
+      valid_agent_task(%{"actor" => %{"kind" => "human"}, "mandate" => %{"scope" => ["lib/**"]}})
+
+    assert {:error, {:actor_requires_version_5, "implement", "4"}} =
+             Graph.parse(pipeline(task, "4"))
+
+    result = Validate.validate_json(pipeline(task, "4"))
+    assert Enum.any?(result.errors, &(&1.type == :actor_requires_version_5))
+    assert Enum.any?(result.errors, &(&1.type == :mandate_requires_version_5))
+  end
+
+  test "rejects invalid actor shapes" do
+    cases = [
+      {%{"kind" => "robot"}, {:unknown_actor_kind, "implement", "robot"}},
+      {%{"kind" => "agent", "id" => ""},
+       {:invalid_actor, "implement", "id must be a non-empty string"}},
+      {%{"id" => "codex"}, {:invalid_actor, "implement", "requires kind"}},
+      {"agent", {:invalid_actor, "implement", "must be an object"}},
+      {%{"kind" => "agent", "role" => "coder"},
+       {:invalid_actor, "implement", "unknown keys: role"}}
+    ]
+
+    for {actor, expected} <- cases do
+      assert {:error, ^expected} = Graph.parse(pipeline(valid_agent_task(%{"actor" => actor})))
+    end
+  end
+
+  test "rejects actor and mandate on review nodes" do
+    review = %{
+      "name" => "review-code",
+      "kind" => "review",
+      "primitive" => "lint",
+      "actor" => %{"kind" => "human"},
+      "mandate" => %{"scope" => ["lib/**"]}
+    }
+
+    assert {:error, {:actor_on_review, "review-code"}} = Graph.parse(pipeline(review))
+
+    result = Validate.validate_json(pipeline(review))
+    assert Enum.any?(result.errors, &(&1.type == :actor_on_review))
+    assert Enum.any?(result.errors, &(&1.type == :mandate_on_review))
+  end
+
+  test "rejects invalid mandate shapes" do
+    cases = [
+      {%{}, {:invalid_mandate, "implement", "requires scope"}},
+      {%{"scope" => []}, {:invalid_mandate, "implement", "scope must be a non-empty array"}},
+      {%{"scope" => [""]},
+       {:invalid_mandate, "implement", "scope entries must be non-empty strings"}},
+      {%{"scope" => ["lib/**"], "budget" => %{}},
+       {:invalid_mandate, "implement", "budget must not be empty"}},
+      {%{"scope" => ["lib/**"], "budget" => %{"diff_lines" => 0}},
+       {:invalid_mandate, "implement", "budget.diff_lines must be a positive integer"}},
+      {%{"scope" => ["lib/**"], "budget" => %{"wall_clock_ms" => "fast"}},
+       {:invalid_mandate, "implement", "budget.wall_clock_ms must be a positive integer"}},
+      {%{"scope" => ["lib/**"], "capabilities" => %{"network" => "yes"}},
+       {:invalid_mandate, "implement", "capabilities.network must be a boolean"}},
+      {%{"scope" => ["lib/**"], "capabilities" => %{"shell" => true}},
+       {:invalid_mandate, "implement", "capabilities has unknown keys: shell"}},
+      {%{"scope" => ["lib/**"], "extra" => true},
+       {:invalid_mandate, "implement", "has unknown keys: extra"}}
+    ]
+
+    for {mandate, expected} <- cases do
+      assert {:error, ^expected} =
+               Graph.parse(pipeline(valid_agent_task(%{"mandate" => mandate})))
+    end
+  end
+
+  test "agent actors require mandate success criteria and evidence" do
+    cases = [
+      {Map.delete(valid_agent_task(), "mandate"), :agent_requires_mandate},
+      {Map.put(valid_agent_task(), "success_criteria", []), :agent_requires_success_criteria},
+      {Map.put(valid_agent_task(), "evidence_required", []), :agent_requires_evidence_required}
+    ]
+
+    for {task, type} <- cases do
+      assert {:error, {^type, "implement"}} = Graph.parse(pipeline(task))
+
+      result = Validate.validate_json(pipeline(task))
+      assert Enum.any?(result.errors, &(&1.type == type))
+    end
+  end
+
+  test "formats actor and mandate errors through graph path" do
+    assert Graph.format_error({:unknown_actor_kind, "implement", "robot"}) ==
+             ~s(Error: Task 'implement' declares unknown actor kind "robot")
+
+    assert Graph.format_error({:agent_requires_mandate, "implement"}) ==
+             ~s(Error: Task 'implement' declares actor.kind "agent" but does not declare mandate)
+  end
+end

--- a/core/test/sykli/contract_slice_test.exs
+++ b/core/test/sykli/contract_slice_test.exs
@@ -75,6 +75,33 @@ defmodule Sykli.ContractSliceTest do
     assert slice["target"]["requires"] == ["linux"]
   end
 
+  test "projects actor and truncated mandate scope" do
+    scope = Enum.map(1..25, &"lib/#{&1}.ex")
+
+    task =
+      parse_task(%{
+        "version" => "5",
+        "tasks" => [
+          %{
+            "name" => "implement",
+            "command" => "mix test",
+            "actor" => %{"kind" => "agent", "id" => "codex"},
+            "mandate" => %{"scope" => scope},
+            "success_criteria" => [%{"type" => "exit_code", "equals" => 0}],
+            "evidence_required" => [
+              %{"type" => "file", "name" => "junit", "ref_pattern" => "junit.xml"}
+            ]
+          }
+        ]
+      })
+
+    slice = ContractSlice.from_task(task)
+
+    assert slice["actor"] == %{"kind" => "agent", "id" => "codex"}
+    assert slice["mandate"]["scope"] == Enum.take(scope, 20)
+    assert slice["mandate"]["scope_count"] == 25
+  end
+
   test "projects review and gate metadata when declared" do
     review =
       parse_task(%{

--- a/core/test/sykli/evidence_requirement_test.exs
+++ b/core/test/sykli/evidence_requirement_test.exs
@@ -33,6 +33,18 @@ defmodule Sykli.EvidenceRequirementTest do
              )
   end
 
+  test "accepts evidence_required in version 5" do
+    assert {:ok, [%{"type" => "file", "name" => "coverage"} = requirement]} =
+             EvidenceRequirement.parse(
+               [%{"type" => "file", "name" => "coverage", "ref_pattern" => "coverage.out"}],
+               :task,
+               "5",
+               "test"
+             )
+
+    assert requirement["ref_pattern"] == "coverage.out"
+  end
+
   test "rejects invalid file evidence shape" do
     assert {:error, {:invalid_evidence_required, "test", "requires ref_pattern"}} =
              EvidenceRequirement.parse(

--- a/core/test/sykli/validate_test.exs
+++ b/core/test/sykli/validate_test.exs
@@ -84,13 +84,13 @@ defmodule Sykli.ValidateTest do
          "invalid contract schema version: expected string, got object"},
         {~s({"version":"0.2","tasks":[{"name":"test","command":"echo test"}]}),
          :unsupported_contract_schema_version,
-         "unsupported contract schema version: 0.2; supported versions: 1, 2, 3, 4"},
+         "unsupported contract schema version: 0.2; supported versions: 1, 2, 3, 4, 5"},
         {~s({"version":"1.0","tasks":[{"name":"test","command":"echo test"}]}),
          :unsupported_contract_schema_version,
-         "unsupported contract schema version: 1.0; supported versions: 1, 2, 3, 4"},
+         "unsupported contract schema version: 1.0; supported versions: 1, 2, 3, 4, 5"},
         {~s({"version":"banana","tasks":[{"name":"test","command":"echo test"}]}),
          :unsupported_contract_schema_version,
-         "unsupported contract schema version: banana; supported versions: 1, 2, 3, 4"}
+         "unsupported contract schema version: banana; supported versions: 1, 2, 3, 4, 5"}
       ]
 
       for {json, type, message} <- cases do

--- a/core/test/sykli/vocabulary_sync_test.exs
+++ b/core/test/sykli/vocabulary_sync_test.exs
@@ -41,8 +41,10 @@ defmodule Sykli.VocabularySyncTest do
   test "success_criteria and evidence_required type sets match schema-owned engine vocabularies" do
     assert MapSet.new(Sykli.SuccessCriteria.types()) == manifest_values("success_criteria")
     assert MapSet.new(Sykli.EvidenceRequirement.types()) == manifest_values("evidence_required")
+    assert MapSet.new(Sykli.Actor.kinds()) == manifest_values("actor_kind")
     assert MapSet.new(Sykli.SuccessCriteria.types()) == schema_success_criteria_types()
     assert MapSet.new(Sykli.EvidenceRequirement.types()) == schema_evidence_required_types()
+    assert MapSet.new(Sykli.Actor.kinds()) == schema_actor_kinds()
   end
 
   test "task_type conformance case exercises every task_type value" do
@@ -86,6 +88,12 @@ defmodule Sykli.VocabularySyncTest do
   defp schema_evidence_required_types do
     schema()
     |> get_in(["$defs", "evidenceRequirement", "properties", "type", "enum"])
+    |> MapSet.new()
+  end
+
+  defp schema_actor_kinds do
+    schema()
+    |> get_in(["$defs", "actor", "properties", "kind", "enum"])
     |> MapSet.new()
   end
 

--- a/docs/sdk-schema.md
+++ b/docs/sdk-schema.md
@@ -35,7 +35,7 @@ parsing.
 
 ```jsonc
 {
-  "version": "1" | "2" | "3" | "4",
+  "version": "1" | "2" | "3" | "4" | "5",
   "tasks":   [ ... task objects ... ],
   "resources": { ... }   // optional
 }
@@ -43,15 +43,17 @@ parsing.
 
 ### `version`
 
-- **Type:** string enum `"1"` | `"2"` | `"3"` | `"4"`.
+- **Type:** string enum `"1"` | `"2"` | `"3"` | `"4"` | `"5"`.
 - **Required by canonical schema.**
 - **Meaning:** pipeline wire-format/schema version. It is not an execution capability selector and not an SDK, engine, runtime, or JSON Schema draft version.
 - `"1"` is the baseline task graph format.
 - `"2"` is the resource-aware format: resources, mounts, caches, containers, and related execution-environment metadata.
 - `"3"` is the semantic contract format, beginning with `task_type` and `success_criteria`.
 - `"4"` is the evidence contract format, adding `evidence_required`.
+- `"5"` is the actor mandate format, adding executable-task `actor` and `mandate`.
 - SDKs auto-detect: `"4"` if any executable task has `evidence_required`; otherwise `"3"` if any executable task has semantic fields such as `task_type` or `success_criteria`; otherwise `"2"` if any task has `container` set, or any task has non-empty `mounts`, or the pipeline has any directory or cache resources; `"1"` otherwise.
-- **Current behavior:** explicit and strict. The schema and engine accept only the supported versions above. Missing, empty, malformed, or unknown future versions are rejected. `task_type` and `success_criteria` require `version == "3"` or newer; `evidence_required` requires `version == "4"`.
+- **Current behavior:** explicit and strict. The schema and engine accept only the supported versions above. Missing, empty, malformed, or unknown future versions are rejected. `task_type` and `success_criteria` require `version == "3"` or newer; `evidence_required` requires `version == "4"` or newer; `actor` and `mandate` require `version == "5"`.
+- **SDK emission status:** SDKs still emit through `"4"` in the current release. Version `"5"` is accepted by the schema and engine parser/validator for forward-compatible engine work.
 - **Future behavior:** new pipeline wire-format versions require explicit schema and engine support. The engine must never silently reinterpret a newer document as an older version.
 
 ### `tasks`
@@ -80,7 +82,9 @@ The full canonical field list, with stability labels:
 | `command` | stable | conditional | required unless `gate` is set or `kind == "review"` |
 | `task_type` | stable, v3-only | no | executable-task semantic class |
 | `success_criteria` | experimental, v3-only | no | declared executable-task success checks; enforced by targets that support them |
-| `evidence_required` | experimental, v4-only | no | declared evidence references required for executable-task success |
+| `evidence_required` | experimental, v4+ | no | declared evidence references required for executable-task success |
+| `actor` | experimental, v5-only | no | executable-task actor declaration |
+| `mandate` | experimental, v5-only | no | bounded work scope for delegated actor execution |
 | `container` | stable | no | triggers v2 |
 | `workdir` | stable | no | |
 | `env` | stable | no | object of string values |
@@ -204,7 +208,7 @@ prompts, or artifact bytes into the contract or coordinator.
 
 Rules:
 
-- Requires top-level `version: "4"`.
+- Requires top-level `version: "4"` or newer.
 - Applies only to executable tasks (`kind` omitted or `kind == "task"`).
 - Rejected on `kind == "review"` nodes.
 - Optional.
@@ -242,6 +246,43 @@ permission to upload evidence bytes.
 
 Non-file evidence entries may include `ref_pattern` as a reserved
 producer-side reference hint. V1 preserves it but does not evaluate it.
+
+### `actor`
+
+Executable-task actor declaration. This is a v5 parser and validation field; it
+does not change runtime behavior until the runtime enforcement PRs land.
+
+Rules:
+
+- Requires top-level `version: "5"`.
+- Applies only to executable tasks (`kind` omitted or `kind == "task"`).
+- Rejected on `kind == "review"` nodes.
+- Optional unless `actor.kind == "agent"` requirements below apply.
+- Shape: `{ "kind": "human" | "agent" | "service", "id"?: string }`.
+- `id`, when present, must be a non-empty string.
+
+When `actor.kind == "agent"`, the task must also declare non-empty
+`success_criteria`, non-empty `evidence_required`, and a `mandate`.
+
+### `mandate`
+
+Executable-task mandate constraining delegated actor work. A mandate may appear
+without an agent actor, but agent actors require one.
+
+Rules:
+
+- Requires top-level `version: "5"`.
+- Applies only to executable tasks (`kind` omitted or `kind == "task"`).
+- Rejected on `kind == "review"` nodes.
+- Required when `actor.kind == "agent"`.
+- `scope` is required and must be a non-empty array of non-empty strings.
+- Optional `budget` may contain positive integer `diff_lines` and
+  `wall_clock_ms`.
+- Optional `capabilities.network` is boolean.
+- Unknown keys are rejected.
+
+`mandate.scope` entries are repo-relative glob-style path patterns. Runtime
+enforcement is not part of this parser/schema PR.
 
 ### `container`, `workdir`, `env`
 
@@ -378,7 +419,7 @@ Review nodes do not have canonical `outputs` behavior yet. SDKs should not emit
 left out of the current experimental contract. The schema rejects task execution
 fields on review nodes: `command`, `outputs`, `gate`, `container`, `services`,
 `k8s`, `mounts`, `retry`, `timeout`, `task_type`, `success_criteria`, and
-`evidence_required`.
+`evidence_required`, `actor`, and `mandate`.
 
 At execution time, review nodes invoke deterministic review primitives rather
 than shell commands. The first primitive boundary is `api_breakage`; it returns
@@ -424,9 +465,10 @@ version of a particular SDK package, engine release, runtime, or JSON Schema
 draft.
 
 Current behavior is version-aware: SDKs emit `version`, the canonical schema and
-engine accept only `"1"`, `"2"`, `"3"`, or `"4"`, and the engine rejects
+engine accept only `"1"`, `"2"`, `"3"`, `"4"`, or `"5"`, and the engine rejects
 `task_type`/`success_criteria` unless the top-level version is `"3"` or newer
-and rejects `evidence_required` unless the top-level version is `"4"`. See the
+and rejects `evidence_required` unless the top-level version is `"4"` or newer.
+It rejects `actor`/`mandate` unless the top-level version is `"5"`. See the
 [`version` field](#version) above for the per-value definitions.
 
 Unknown future versions are rejected by default. If a compatibility mode is ever
@@ -478,7 +520,7 @@ introduce a replacement field.
 
 These are **descriptive, not prescriptive**. The schema documents current behavior; resolving these is Phase 2C / future work.
 
-1. **Version-aware behavior is enforced for supported versions.** SDKs emit `"1"`, `"2"`, `"3"`, or `"4"`; the engine rejects missing, malformed, and unsupported versions, checks `task_type` and `success_criteria` compatibility with `version: "3"` or newer, and checks `evidence_required` compatibility with `version: "4"`.
+1. **Version-aware behavior is enforced for supported versions.** SDKs emit through `"4"` today; the engine rejects missing, malformed, and unsupported versions, checks `task_type` and `success_criteria` compatibility with `version: "3"` or newer, checks `evidence_required` compatibility with `version: "4"` or newer, and checks `actor`/`mandate` compatibility with `version: "5"`.
 2. **Review nodes are experimental.** Engine supports `kind: "review"` and the four review-only fields, and SDKs expose minimal review builders. Review outputs are not canonical.
 3. **`verify` and `oidc` are reserved with no SDK emit.** Engine reads them; SDKs have no API. Either implement SDK support or drop from the schema once a decision lands.
 4. **`history_hint` is engine-internal.** SDKs MUST NOT emit. Schema marks `readOnly` for clarity.

--- a/schemas/sykli-pipeline.schema.json
+++ b/schemas/sykli-pipeline.schema.json
@@ -18,7 +18,8 @@
             "not": {
               "enum": [
                 "3",
-                "4"
+                "4",
+                "5"
               ]
             }
           }
@@ -51,12 +52,15 @@
       }
     },
     {
-      "description": "Evidence requirements require pipeline version 4.",
+      "description": "Evidence requirements require pipeline version 4 or newer.",
       "if": {
         "properties": {
           "version": {
             "not": {
-              "const": "4"
+              "enum": [
+                "4",
+                "5"
+              ]
             }
           }
         },
@@ -77,6 +81,43 @@
           }
         }
       }
+    },
+    {
+      "description": "Actor and mandate declarations require pipeline version 5.",
+      "if": {
+        "properties": {
+          "version": {
+            "not": {
+              "const": "5"
+            }
+          }
+        },
+        "required": [
+          "version"
+        ]
+      },
+      "then": {
+        "properties": {
+          "tasks": {
+            "items": {
+              "not": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "actor"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "mandate"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
     }
   ],
   "properties": {
@@ -86,7 +127,8 @@
         "1",
         "2",
         "3",
-        "4"
+        "4",
+        "5"
       ]
     },
     "tasks": {
@@ -280,6 +322,69 @@
         }
       ]
     },
+    "actor": {
+      "description": "V5 executable task actor declaration.",
+      "type": "object",
+      "required": [
+        "kind"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "enum": [
+            "human",
+            "agent",
+            "service"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "mandate": {
+      "description": "V5 task mandate constraining delegated actor work.",
+      "type": "object",
+      "required": [
+        "scope"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "scope": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "budget": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": false,
+          "properties": {
+            "diff_lines": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "wall_clock_ms": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "capabilities": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "network": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "task": {
       "description": "A pipeline task (or review node when `kind == \"review\"`). The engine validates that non-gate, non-review tasks have a non-empty `command`; that rule is encoded in description rather than schema-level conditionals because gates and reviews compose with several other fields. SDKs validate cycles, duplicate names, and unknown dependencies; the schema does not.",
       "type": "object",
@@ -412,8 +517,53 @@
                   "required": [
                     "evidence_required"
                   ]
+                },
+                {
+                  "required": [
+                    "actor"
+                  ]
+                },
+                {
+                  "required": [
+                    "mandate"
+                  ]
                 }
               ]
+            }
+          }
+        },
+        {
+          "description": "Agent actors must declare a mandate, non-empty success criteria, and non-empty evidence requirements.",
+          "if": {
+            "properties": {
+              "actor": {
+                "properties": {
+                  "kind": {
+                    "const": "agent"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              }
+            },
+            "required": [
+              "actor"
+            ]
+          },
+          "then": {
+            "required": [
+              "mandate",
+              "success_criteria",
+              "evidence_required"
+            ],
+            "properties": {
+              "success_criteria": {
+                "minItems": 1
+              },
+              "evidence_required": {
+                "minItems": 1
+              }
             }
           }
         }
@@ -483,6 +633,14 @@
           "items": {
             "$ref": "#/$defs/evidenceRequirement"
           }
+        },
+        "actor": {
+          "$ref": "#/$defs/actor",
+          "description": "V5 actor declaration for executable tasks. Rejected on review nodes."
+        },
+        "mandate": {
+          "$ref": "#/$defs/mandate",
+          "description": "V5 mandate for delegated actor work. Rejected on review nodes."
         },
         "container": {
           "description": "Container image (e.g., `golang:1.21`). Triggers v2 emission.",

--- a/schemas/vocabulary.json
+++ b/schemas/vocabulary.json
@@ -27,5 +27,10 @@
     "test_report",
     "artifact_ref",
     "custom"
+  ],
+  "actor_kind": [
+    "human",
+    "agent",
+    "service"
   ]
 }

--- a/scripts/gen-vocab.py
+++ b/scripts/gen-vocab.py
@@ -74,6 +74,10 @@ def schema_evidence_required() -> set[str]:
     return set(schema()["$defs"]["evidenceRequirement"]["properties"]["type"]["enum"])
 
 
+def schema_actor_kind() -> set[str]:
+    return set(schema()["$defs"]["actor"]["properties"]["kind"]["enum"])
+
+
 def conformance_task_types() -> set[str]:
     with (ROOT / "tests/conformance/cases/23-task-type.json").open() as handle:
         data = json.load(handle)
@@ -92,6 +96,7 @@ def check() -> int:
     task_types = set(vocab["task_type"])
     success_criteria = set(vocab["success_criteria"])
     evidence_required = set(vocab["evidence_required"])
+    actor_kind = set(vocab["actor_kind"])
     errors: list[str] = []
 
     check_equal("schema task_type", task_types, schema_task_types(), errors)
@@ -248,6 +253,21 @@ def check() -> int:
         errors,
     )
 
+    check_equal("schema actor_kind", actor_kind, schema_actor_kind(), errors)
+    check_equal(
+        "engine actor_kind",
+        actor_kind,
+        set(
+            re.search(
+                r"@kinds\s+~w\(([^)]+)\)",
+                read_text("core/lib/sykli/actor.ex"),
+            )
+            .group(1)
+            .split()
+        ),
+        errors,
+    )
+
     if errors:
         print("Vocabulary drift detected:", file=sys.stderr)
         for error in errors:
@@ -268,6 +288,9 @@ def emit() -> None:
         print(value)
     print("\n# evidence_required")
     for value in vocab["evidence_required"]:
+        print(value)
+    print("\n# actor_kind")
+    for value in vocab["actor_kind"]:
         print(value)
 
 

--- a/tests/conformance/schema-invalid/README.md
+++ b/tests/conformance/schema-invalid/README.md
@@ -12,6 +12,11 @@ while still being schema-valid.
 
 | Fixture | Rule asserted |
 |---------|---------------|
+| `actor-bad-kind.json` | `actor.kind` is a closed enum. |
+| `actor-on-review-node.json` | Review nodes must not carry executable-task `actor`. |
+| `agent-without-criteria.json` | Agent actors must declare non-empty `success_criteria`. |
+| `agent-without-evidence.json` | Agent actors must declare non-empty `evidence_required`. |
+| `agent-without-mandate.json` | Agent actors must declare `mandate`. |
 | `depends-on-wrong-type.json` | `depends_on` must be an array of strings. |
 | `evidence-required-file-missing-ref-pattern.json` | File evidence requirements must declare `ref_pattern`. |
 | `evidence-required-unknown-type.json` | Evidence requirement `type` is a closed enum. |
@@ -19,6 +24,8 @@ while still being schema-valid.
 | `gate-invalid-strategy.json` | `gate.strategy` must be one of the schema enum values (`prompt`, `env`, `file`, `webhook`). |
 | `gate-missing-strategy.json` | `gate.strategy` is required when a gate object is present. |
 | `k8s-extra-field.json` | `k8s` rejects fields outside the canonical `{memory,cpu,gpu,raw}` shape. |
+| `mandate-empty-scope.json` | `mandate.scope` must be a non-empty array. |
+| `mandate-unknown-key.json` | `mandate` rejects unknown fields. |
 | `review-with-command.json` | Review nodes must not carry executable task fields such as `command`. |
 | `review-with-task-type.json` | Review nodes must not carry executable-task `task_type`. |
 | `service-extra-field.json` | Service objects reject unknown fields. |
@@ -34,5 +41,6 @@ while still being schema-valid.
 | `task-type-version-2.json` | `task_type` is rejected under version `"2"`. |
 | `task-type-wrong-type.json` | `task_type` must be a string enum value. |
 | `task-with-review-primitive.json` | Normal executable tasks must not carry review-node `primitive`. |
+| `v4-payload-carrying-actor.json` | `actor` is rejected before version `"5"`. |
 | `version-*.json` | Top-level `version` is required, string-typed, non-empty, and explicitly supported. |
 | `when-and-condition.json` | `when` and `condition` are mutually exclusive aliases. |

--- a/tests/conformance/schema-invalid/actor-bad-kind.json
+++ b/tests/conformance/schema-invalid/actor-bad-kind.json
@@ -1,0 +1,12 @@
+{
+  "version": "5",
+  "tasks": [
+    {
+      "name": "implement",
+      "command": "mix test",
+      "actor": {
+        "kind": "robot"
+      }
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/actor-on-review-node.json
+++ b/tests/conformance/schema-invalid/actor-on-review-node.json
@@ -1,0 +1,13 @@
+{
+  "version": "5",
+  "tasks": [
+    {
+      "name": "review-code",
+      "kind": "review",
+      "primitive": "lint",
+      "actor": {
+        "kind": "human"
+      }
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/agent-without-criteria.json
+++ b/tests/conformance/schema-invalid/agent-without-criteria.json
@@ -1,0 +1,25 @@
+{
+  "version": "5",
+  "tasks": [
+    {
+      "name": "implement",
+      "command": "mix test",
+      "actor": {
+        "kind": "agent"
+      },
+      "mandate": {
+        "scope": [
+          "core/lib/**"
+        ]
+      },
+      "success_criteria": [],
+      "evidence_required": [
+        {
+          "type": "file",
+          "name": "junit",
+          "ref_pattern": "junit.xml"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/agent-without-evidence.json
+++ b/tests/conformance/schema-invalid/agent-without-evidence.json
@@ -1,0 +1,24 @@
+{
+  "version": "5",
+  "tasks": [
+    {
+      "name": "implement",
+      "command": "mix test",
+      "actor": {
+        "kind": "agent"
+      },
+      "mandate": {
+        "scope": [
+          "core/lib/**"
+        ]
+      },
+      "success_criteria": [
+        {
+          "type": "exit_code",
+          "equals": 0
+        }
+      ],
+      "evidence_required": []
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/agent-without-mandate.json
+++ b/tests/conformance/schema-invalid/agent-without-mandate.json
@@ -1,0 +1,25 @@
+{
+  "version": "5",
+  "tasks": [
+    {
+      "name": "implement",
+      "command": "mix test",
+      "actor": {
+        "kind": "agent"
+      },
+      "success_criteria": [
+        {
+          "type": "exit_code",
+          "equals": 0
+        }
+      ],
+      "evidence_required": [
+        {
+          "type": "file",
+          "name": "junit",
+          "ref_pattern": "junit.xml"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/mandate-empty-scope.json
+++ b/tests/conformance/schema-invalid/mandate-empty-scope.json
@@ -1,0 +1,12 @@
+{
+  "version": "5",
+  "tasks": [
+    {
+      "name": "implement",
+      "command": "mix test",
+      "mandate": {
+        "scope": []
+      }
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/mandate-unknown-key.json
+++ b/tests/conformance/schema-invalid/mandate-unknown-key.json
@@ -1,0 +1,15 @@
+{
+  "version": "5",
+  "tasks": [
+    {
+      "name": "implement",
+      "command": "mix test",
+      "mandate": {
+        "scope": [
+          "core/lib/**"
+        ],
+        "instructions": "please do the thing"
+      }
+    }
+  ]
+}

--- a/tests/conformance/schema-invalid/v4-payload-carrying-actor.json
+++ b/tests/conformance/schema-invalid/v4-payload-carrying-actor.json
@@ -1,0 +1,12 @@
+{
+  "version": "4",
+  "tasks": [
+    {
+      "name": "implement",
+      "command": "mix test",
+      "actor": {
+        "kind": "human"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds engine/schema support for pipeline `version: "5"` actor and mandate declarations.
- Enforces D1/D2 in both `Graph.parse/1` and `Validate.validate_json/1` with shared error rendering.
- Extends contract slices, vocabulary checks, schema-invalid conformance fixtures, and v5 docs.

## Verification

- `cd core && mix format --check-formatted`
- `cd core && mix credo --strict`
- `cd core && mix compile --warnings-as-errors --force`
- `cd core && mix test --seed 0` -> `1825 passed (1 property, 1824 tests), 13 excluded`
- `cd core && mix test` -> `1825 passed (1 property, 1824 tests), 13 excluded`
- `cd core && mix test` -> `1825 passed (1 property, 1824 tests), 13 excluded`
- `cd core && mix escript.build`
- `python3 scripts/gen-vocab.py --check` -> `Vocabulary manifest matches schema, engine, SDKs, and conformance.`
- `tests/conformance/run.sh` -> `150 passed, 0 failed, 0 skipped`
- `python3 scripts/validate-conformance-schema.py` -> `Summary: 68 passed, 0 failed`
- `eval/oracle/run.sh` -> `Passed: 76; Failed: 0; Total: 76`

Manual:

- Invalid v5 agent without mandate renders: `Error: Task 'implement' declares actor.kind "agent" but does not declare mandate`
- Temporary v5 fixture: `sykli validate` exits 0 with `Valid` and `Tasks: implement`
- Empty directory smoke: `sykli validate` and `sykli run` both exit 1 with friendly `sdk_not_found` output, no crash
