### PR TITLE
fix(sdk): reject unknown v5 keys on untyped Python/Elixir entry points

### DIFF
--- a/sdk/elixir/lib/sykli/emitter.ex
+++ b/sdk/elixir/lib/sykli/emitter.ex
@@ -341,7 +341,8 @@ defmodule Sykli.Emitter do
   defp valid_actor?(nil), do: true
 
   defp valid_actor?(%{kind: kind} = actor) do
-    Sykli.Task.valid_actor_kind?(kind) and
+    map_size(Map.drop(actor, [:kind, :id])) == 0 and
+      Sykli.Task.valid_actor_kind?(kind) and
       (not Map.has_key?(actor, :id) or (is_binary(actor.id) and actor.id != ""))
   end
 
@@ -350,7 +351,8 @@ defmodule Sykli.Emitter do
   defp valid_mandate?(nil), do: true
 
   defp valid_mandate?(%{scope: scope} = mandate) when is_list(scope) and scope != [] do
-    Enum.all?(scope, &(is_binary(&1) and &1 != "")) and
+    map_size(Map.drop(mandate, [:scope, :budget, :capabilities])) == 0 and
+      Enum.all?(scope, &(is_binary(&1) and &1 != "")) and
       valid_mandate_budget?(Map.get(mandate, :budget)) and
       valid_mandate_capabilities?(Map.get(mandate, :capabilities))
   end
@@ -370,7 +372,9 @@ defmodule Sykli.Emitter do
 
   defp valid_mandate_capabilities?(nil), do: true
 
-  defp valid_mandate_capabilities?(%{network: value}) when is_boolean(value), do: true
+  defp valid_mandate_capabilities?(%{network: value} = capabilities) when is_boolean(value),
+    do: map_size(capabilities) == 1
+
   defp valid_mandate_capabilities?(capabilities), do: capabilities == %{}
 
   defp agent_missing_field(%{actor: %{kind: :agent}} = task) do

--- a/sdk/elixir/test/sykli_test.exs
+++ b/sdk/elixir/test/sykli_test.exs
@@ -167,6 +167,36 @@ defmodule SykliTest do
       end
     end
 
+    test "emitter rejects unknown actor and mandate keys on hand-built structs" do
+      base = %Sykli.Task{name: "x", command: "true"}
+
+      extra_actor = %Sykli.Pipeline{
+        tasks: [%{base | actor: %{kind: :human, role: "extra"}}]
+      }
+
+      assert_raise RuntimeError, ~r/invalid actor/, fn ->
+        Sykli.Emitter.validate!(extra_actor)
+      end
+
+      extra_mandate_key = %Sykli.Pipeline{
+        tasks: [%{base | mandate: %{scope: ["src/**"], budgets: %{}}}]
+      }
+
+      assert_raise RuntimeError, ~r/invalid mandate/, fn ->
+        Sykli.Emitter.validate!(extra_mandate_key)
+      end
+
+      extra_capability = %Sykli.Pipeline{
+        tasks: [
+          %{base | mandate: %{scope: ["src/**"], capabilities: %{network: false, shell: true}}}
+        ]
+      }
+
+      assert_raise RuntimeError, ~r/invalid mandate/, fn ->
+        Sykli.Emitter.validate!(extra_capability)
+      end
+    end
+
     test "agent actor requires mandate at emit time" do
       use Sykli
 

--- a/sdk/python/src/sykli/__init__.py
+++ b/sdk/python/src/sykli/__init__.py
@@ -290,7 +290,14 @@ def mandate(
     return result
 
 
+def _reject_unknown_keys(task_name: str, label: str, value: dict, known: set[str]) -> None:
+    unknown = sorted(set(value) - known)
+    if unknown:
+        raise ValueError(f"task {task_name!r}: unknown {label} key(s): {', '.join(unknown)}")
+
+
 def _validate_actor(task_name: str, value: Actor) -> None:
+    _reject_unknown_keys(task_name, "actor", value, {"kind", "id"})
     kind = value.get("kind")
     _validate_enum(kind, ACTOR_KINDS, "actor.kind", task_name)
     if "id" in value and (not isinstance(value["id"], str) or not value["id"]):
@@ -298,6 +305,7 @@ def _validate_actor(task_name: str, value: Actor) -> None:
 
 
 def _validate_mandate(task_name: str, value: Mandate) -> None:
+    _reject_unknown_keys(task_name, "mandate", value, {"scope", "budget", "capabilities"})
     scope = value.get("scope")
     if not isinstance(scope, list) or not scope:
         raise ValueError(f"task {task_name!r}: mandate.scope cannot be empty")
@@ -307,6 +315,7 @@ def _validate_mandate(task_name: str, value: Mandate) -> None:
     if budget is not None:
         if not isinstance(budget, dict) or not budget:
             raise ValueError(f"task {task_name!r}: mandate.budget cannot be empty")
+        _reject_unknown_keys(task_name, "mandate.budget", budget, {"diff_lines", "wall_clock_ms"})
         if "diff_lines" in budget and (
             not isinstance(budget["diff_lines"], int) or budget["diff_lines"] <= 0
         ):
@@ -316,11 +325,12 @@ def _validate_mandate(task_name: str, value: Mandate) -> None:
         ):
             raise ValueError(f"task {task_name!r}: mandate.budget.wall_clock_ms must be positive")
     capabilities = value.get("capabilities")
-    if capabilities is not None and (
-        not isinstance(capabilities, dict)
-        or ("network" in capabilities and not isinstance(capabilities["network"], bool))
-    ):
-        raise ValueError(f"task {task_name!r}: mandate.capabilities.network must be boolean")
+    if capabilities is not None:
+        if not isinstance(capabilities, dict):
+            raise ValueError(f"task {task_name!r}: mandate.capabilities.network must be boolean")
+        _reject_unknown_keys(task_name, "mandate.capabilities", capabilities, {"network"})
+        if "network" in capabilities and not isinstance(capabilities["network"], bool):
+            raise ValueError(f"task {task_name!r}: mandate.capabilities.network must be boolean")
 
 
 @dataclass(frozen=True)

--- a/sdk/python/tests/test_validation.py
+++ b/sdk/python/tests/test_validation.py
@@ -196,6 +196,22 @@ class TestDeferredValidation:
         with pytest.raises(ValueError, match="wall_clock_ms must be positive"):
             mandate(["src/**"], wall_clock_ms=0)
 
+    def test_actor_dict_rejects_unknown_keys(self):
+        p = Pipeline()
+        with pytest.raises(ValueError, match="unknown actor key\\(s\\): role"):
+            p.task("x").run("true").actor({"kind": "human", "role": "extra"})
+
+    def test_mandate_dict_rejects_unknown_keys(self):
+        p = Pipeline()
+        with pytest.raises(ValueError, match="unknown mandate key\\(s\\): budgets"):
+            p.task("a").run("true").mandate({"scope": ["src/**"], "budgets": {}})
+        with pytest.raises(ValueError, match="unknown mandate.budget key\\(s\\): diffLines"):
+            p.task("b").run("true").mandate({"scope": ["src/**"], "budget": {"diffLines": 1}})
+        with pytest.raises(ValueError, match="unknown mandate.capabilities key\\(s\\): shell"):
+            p.task("c").run("true").mandate(
+                {"scope": ["src/**"], "capabilities": {"network": False, "shell": True}}
+            )
+
     def test_empty_review_name(self):
         p = Pipeline()
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary

External review of the merged #274 found that the unknown-key rejection added to TypeScript was still missing on the two other untyped entry points:

- **Python**: `Task.actor()`/`Task.mandate()` take raw dicts; `_validate_actor`/`_validate_mandate` checked required fields and value types but not unknown keys, so `{'kind': 'human', 'role': 'extra'}` or `{'scope': [...], 'budgets': {}}` emitted JSON the canonical schema (`additionalProperties: false`) rejects.
- **Elixir**: `Emitter.validate!` is reachable with hand-built `%Sykli.Task{}` structs that bypass the DSL; `valid_actor?` pattern-matched past extra keys (and `actor_to_json` emitted them), `valid_mandate_capabilities?` matched `%{network: false, shell: true}`, and unknown top-level mandate keys were silently dropped by `mandate_to_json`.

Both now reject at validation time. Go and Rust are strict by construction (typed structs, no map-taking APIs); TypeScript already rejects unknown keys since #274.

## Verification

- Reproducers from the review now raise: Python `task 'x': unknown actor key(s): role` / `unknown mandate key(s): budgets`; Elixir `task "x" has invalid actor`
- `sdk/python`: 216 passed
- `sdk/elixir`: `mix compile --warnings-as-errors --force` clean; 58 passed
- `tests/conformance/run.sh` — 160 passed, 0 failed
- `python3 scripts/gen-vocab.py --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)