### PR TITLE
fix(daemon): heartbeat terminate/2 crashes when the transport is gone

### DIFF
--- a/core/lib/sykli/daemon/heartbeat.ex
+++ b/core/lib/sykli/daemon/heartbeat.ex
@@ -157,7 +157,16 @@ defmodule Sykli.Daemon.Heartbeat do
   def terminate(_reason, state) do
     if state.synced_once do
       payload = Join.heartbeat_payload(state.session, %{"status" => "offline"})
-      post_heartbeat(state, payload)
+
+      # The goodbye is a courtesy, and the transport may already be gone
+      # while we shut down (:inets stopped during VM drain, injected test
+      # transports torn down first) — a failed offline heartbeat must not
+      # turn a clean stop into a crash.
+      try do
+        post_heartbeat(state, payload)
+      catch
+        _kind, _reason -> :ok
+      end
     end
 
     :ok

--- a/core/test/sykli/daemon/heartbeat_test.exs
+++ b/core/test/sykli/daemon/heartbeat_test.exs
@@ -114,7 +114,7 @@ defmodule Sykli.Daemon.HeartbeatTest do
 
   test "drains the outbox on the first successful heartbeat and after failures" do
     test_pid = self()
-    {:ok, agent} = Agent.start_link(fn -> [:fail, :ok, :ok, :fail, :ok] end)
+    agent = start_supervised!({Agent, fn -> [:fail, :ok, :ok, :fail, :ok] end})
 
     pid =
       start_loop(
@@ -161,7 +161,7 @@ defmodule Sykli.Daemon.HeartbeatTest do
       "reason" => "test"
     }
 
-    {:ok, agent} = Agent.start_link(fn -> [{:ok_with, [decision]}, :plain_ok] end)
+    agent = start_supervised!({Agent, fn -> [{:ok_with, [decision]}, :plain_ok] end})
 
     pid =
       start_loop(
@@ -186,7 +186,7 @@ defmodule Sykli.Daemon.HeartbeatTest do
   end
 
   test "backs off exponentially with a cap of interval * 4" do
-    {:ok, agent} = Agent.start_link(fn -> 0 end)
+    agent = start_supervised!({Agent, fn -> 0 end})
 
     pid =
       start_loop(
@@ -235,7 +235,7 @@ defmodule Sykli.Daemon.HeartbeatTest do
 
   test "persists liveness fields on success and failure" do
     RecordingStore.record_to(self())
-    {:ok, agent} = Agent.start_link(fn -> [:ok, :fail] end)
+    agent = start_supervised!({Agent, fn -> [:ok, :fail] end})
 
     pid =
       start_loop(
@@ -262,14 +262,17 @@ defmodule Sykli.Daemon.HeartbeatTest do
   test "rejoins automatically when the coordinator forgot the session" do
     test_pid = self()
 
-    {:ok, agent} =
-      Agent.start_link(fn ->
-        [
-          {:error,
-           {:coordinator_error, 404, %{"code" => "coordinator.daemon_session_not_found"}}},
-          :plain_ok
-        ]
-      end)
+    agent =
+      start_supervised!(
+        {Agent,
+         fn ->
+           [
+             {:error,
+              {:coordinator_error, 404, %{"code" => "coordinator.daemon_session_not_found"}}},
+             :plain_ok
+           ]
+         end}
+      )
 
     pid =
       start_loop(
@@ -318,6 +321,33 @@ defmodule Sykli.Daemon.HeartbeatTest do
 
     GenServer.stop(pid)
     assert_receive {:posted, %{"status" => "offline"}}
+  end
+
+  test "shutdown stays clean when the transport is already gone" do
+    # Regression: terminate/2's best-effort offline heartbeat used to crash
+    # with :noproc when the transport died first (test teardown ordering,
+    # or :inets stopping during VM drain), turning a clean stop into an
+    # abnormal exit.
+    {:ok, agent} = Agent.start(fn -> :ok end)
+
+    pid =
+      start_loop(
+        post_fun: fn _session, _payload ->
+          Agent.get_and_update(agent, fn s -> {s, s} end)
+          ok_response()
+        end
+      )
+
+    assert_receive {:scheduled, 0}
+    send(pid, :heartbeat)
+    # the post-success reschedule confirms the loop synced (synced_once: true)
+    assert_receive {:scheduled, 15_000}
+
+    Process.exit(agent, :kill)
+
+    ref = Process.monitor(pid)
+    assert :ok = GenServer.stop(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
   end
 
   test "does not send an offline heartbeat if it never synced" do


### PR DESCRIPTION
## Summary

- `Sykli.Daemon.Heartbeat.terminate/2` sends a best-effort final offline heartbeat on shutdown. When the transport is already dead — `:inets` stopped during VM drain in production, or an injected test transport torn down first in tests — the `GenServer.call` inside it exited with `:noproc` **from terminate/2**, turning a clean stop into an abnormal exit.
- This was the root cause of the flaky `daemon/heartbeat_test.exs` failures under full-suite load: bare `Agent.start_link` transports (linked to the test process) died before the supervised loop shut down, and the loop's goodbye crashed into the dead Agent.

## Fix

- Wrap the goodbye in `try/catch` — a failed courtesy must never crash termination (the process is already dying; a crash there only corrupts the shutdown protocol).
- Supervise the test transports with `start_supervised!` so ExUnit's reverse-order teardown stops the loop before its transport, making the offline-goodbye path deterministic.
- Add a regression test ("shutdown stays clean when the transport is already gone") that reproduces the exact production crash signature when the catch is removed.

## Verification

- Repro script confirmed the crash deterministically before the fix and a clean `:shutdown` after.
- Regression test verified to fail without the fix (stash/pop) and pass with it.
- Full suite: 1854 passed, 0 failures (previously flaked ~2 tests under load). `mix credo` clean, escript builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)