### PR TITLE
feat(gui): surface v5 actors, mandates, and mandate outcomes

### DIFF
--- a/core/lib/sykli/gui/provider/artifact.ex
+++ b/core/lib/sykli/gui/provider/artifact.ex
@@ -17,10 +17,16 @@ defmodule Sykli.Gui.Provider.Artifact do
       produces
     * activity — derived from the artifacts above
 
-  Local-only for now: the member list is the local git identity, `team` is
-  the local pseudo-team, and `agent_calls` is empty (no local artifact
-  records MCP tool calls yet). Coordinator-backed team state is a later
-  Team Mode phase.
+  Local-only for now: the member list is the local git identity plus any
+  v5 agent/service actors declared in the contract (with their mandates),
+  `team` is the local pseudo-team, and `agent_calls` is empty (no local
+  artifact records MCP tool calls yet). Coordinator-backed team state is a
+  later Team Mode phase.
+
+  v5 result fields: task `mandate_outcome` and per-run mandate summaries
+  are read shape-tolerantly from run manifests — they populate once
+  mandate enforcement (PR #276) starts persisting them; `audit_verdict`
+  stays nil until the audit core is a shared service the GUI can call.
   """
 
   @behaviour Sykli.Gui.Provider
@@ -51,7 +57,7 @@ defmodule Sykli.Gui.Provider.Artifact do
       current_actor: local_actor(path),
       latest_run: latest && run_row(latest),
       graph: graph(contract, latest),
-      members: members(path),
+      members: members(path) ++ actor_members(contract),
       work_items: Enum.map(items, &work_item_row(&1, runs)),
       gates: Enum.map(gates, &gate_row/1),
       evidence: runs |> Enum.take(@recent_runs) |> Enum.map(&evidence_row/1),
@@ -175,6 +181,33 @@ defmodule Sykli.Gui.Provider.Artifact do
     }
   end
 
+  # v5 actors declared in the contract are execution participants the
+  # Workbench must show — with their mandate — even before any run. They
+  # are declarations, not live presence, so status is "declared".
+  defp actor_members({:ok, %{"tasks" => tasks}, _version}) do
+    tasks
+    |> Enum.filter(&(get_in(&1, ["actor", "kind"]) in ["agent", "service"]))
+    |> Enum.group_by(&get_in(&1, ["actor", "id"]))
+    |> Enum.sort()
+    |> Enum.map(fn {actor_id, actor_tasks} ->
+      first = List.first(actor_tasks)
+      kind = get_in(first, ["actor", "kind"])
+
+      %Member{
+        id: actor_id || kind,
+        name: actor_id || kind,
+        identity_type: kind,
+        role: "executor",
+        status: "declared",
+        current_work: Enum.map_join(actor_tasks, " · ", & &1["name"]),
+        mandate: first["mandate"],
+        trust: "declared in contract"
+      }
+    end)
+  end
+
+  defp actor_members(_contract), do: []
+
   defp git(path, args) do
     case System.cmd("git", args, cd: path, stderr_to_stdout: true) do
       {out, 0} -> String.trim(out)
@@ -282,8 +315,39 @@ defmodule Sykli.Gui.Provider.Artifact do
       retry_hint: semantics && if(semantics.retryable, do: "yes", else: "no"),
       reason: result_reason(result),
       duration: format_duration(result),
-      evidence: task_evidence_label(result)
+      evidence: task_evidence_label(result),
+      mandate_outcome: mandate_outcome_label(result)
     }
+  end
+
+  # `mandate_outcome` is persisted by mandate enforcement (PR #276) as
+  # %{"status" => "kept" | "violated" | "unverified" | "unsupported", ...}.
+  # Read it shape-tolerantly: manifests written before enforcement (or by
+  # engines without it) simply have no outcome. Exposed for tests until
+  # the TaskResult struct carries the field on main.
+  @doc false
+  def mandate_outcome_label(result) do
+    case Map.get(result, :mandate_outcome) do
+      %{"status" => status} when is_binary(status) -> status
+      _ -> nil
+    end
+  end
+
+  @doc false
+  def mandate_summary(tasks) do
+    counts =
+      tasks
+      |> Enum.map(&mandate_outcome_label/1)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.frequencies()
+
+    if counts == %{} do
+      nil
+    else
+      counts
+      |> Enum.sort()
+      |> Enum.map_join(" · ", fn {status, n} -> "#{n} #{status}" end)
+    end
   end
 
   defp result_status(%{cached: true}), do: "cached"
@@ -357,7 +421,11 @@ defmodule Sykli.Gui.Provider.Artifact do
       tasks: length(run.tasks),
       failed: Enum.count(run.tasks, &(&1.status == :failed)),
       skipped: Enum.count(run.tasks, &(&1.status == :skipped)),
-      complete: run_evidence_status(run) == "complete"
+      complete: run_evidence_status(run) == "complete",
+      # audit_verdict stays nil until the audit core (`sykli audit`,
+      # PR #276) is extractable as a shared service — the GUI must not
+      # re-derive verdict logic.
+      mandates: mandate_summary(run.tasks)
     }
   end
 

--- a/core/lib/sykli/gui/provider/demo.ex
+++ b/core/lib/sykli/gui/provider/demo.ex
@@ -176,7 +176,7 @@ defmodule Sykli.Gui.Provider.Demo do
         mandate: %{
           scope: ["core/test/**"],
           budget: %{diff_lines: 200, wall_clock_ms: 900_000},
-          network: false
+          capabilities: %{network: false}
         },
         trust: "team platform · executor"
       },

--- a/core/lib/sykli/run_history.ex
+++ b/core/lib/sykli/run_history.ex
@@ -30,6 +30,7 @@ defmodule Sykli.RunHistory do
       :kind,
       :review_result,
       :failure_semantics,
+      :mandate_outcome,
       :contract_slice,
       :inputs,
       :likely_cause,
@@ -49,6 +50,7 @@ defmodule Sykli.RunHistory do
             kind: String.t() | nil,
             review_result: map() | nil,
             failure_semantics: Sykli.FailureSemantics.t() | nil,
+            mandate_outcome: map() | nil,
             contract_slice: map() | nil,
             success_criteria_results: [Sykli.SuccessCriteria.Result.t() | map()] | nil,
             evidence_results: [Sykli.EvidenceRequirement.Result.t()],
@@ -325,6 +327,7 @@ defmodule Sykli.RunHistory do
     |> maybe_add(:kind, tr.kind)
     |> maybe_add(:review_result, tr.review_result)
     |> maybe_add(:failure_semantics, Sykli.FailureSemantics.to_map(tr.failure_semantics))
+    |> maybe_add(:mandate_outcome, tr.mandate_outcome)
     |> maybe_add(:contract_slice, tr.contract_slice)
     |> maybe_add(
       :success_criteria_results,
@@ -378,6 +381,7 @@ defmodule Sykli.RunHistory do
       kind: data["kind"],
       review_result: data["review_result"],
       failure_semantics: Sykli.FailureSemantics.from_map(data["failure_semantics"]),
+      mandate_outcome: data["mandate_outcome"],
       contract_slice: data["contract_slice"],
       success_criteria_results:
         Sykli.ContractSlice.success_criteria_results_from_maps(data["success_criteria_results"]),

--- a/core/priv/gui/app.js
+++ b/core/priv/gui/app.js
@@ -730,9 +730,12 @@ function mandateHTML(m) {
   Object.keys(b).forEach(function (k) {
     if (k !== 'diffLines' && k !== 'wallClockMs') lines.push('budget ' + k + ' ≤ ' + b[k]);
   });
-  var net = m.network === false
+  /* canonical v5 contract shape: capabilities.network */
+  var caps = m.capabilities || {};
+  var netFlag = caps.network;
+  var net = netFlag === false
     ? '<div class="mline" style="color:' + COLORS.red + '">network denied</div>'
-    : m.network === true
+    : netFlag === true
       ? '<div class="mline" style="color:' + COLORS.green + '">network allowed</div>'
       : '';
   return '<div class="mandate-block">' +

--- a/core/test/sykli/gui/provider/artifact_test.exs
+++ b/core/test/sykli/gui/provider/artifact_test.exs
@@ -39,7 +39,8 @@ defmodule Sykli.Gui.Provider.ArtifactTest do
       status: status,
       duration_ms: Keyword.get(opts, :duration_ms, 100),
       error: Keyword.get(opts, :error),
-      cached: Keyword.get(opts, :cached, false)
+      cached: Keyword.get(opts, :cached, false),
+      mandate_outcome: Keyword.get(opts, :mandate_outcome)
     }
   end
 
@@ -210,14 +211,14 @@ defmodule Sykli.Gui.Provider.ArtifactTest do
 
     test "mandate outcome mapping tolerates pre-enforcement manifests" do
       # Manifests written before mandate enforcement (PR #276) carry no
-      # mandate_outcome — including every TaskResult main can produce today.
+      # mandate_outcome.
       assert Artifact.mandate_outcome_label(%RunHistory.TaskResult{
                name: "t",
                status: :passed,
                duration_ms: 1
              }) == nil
 
-      # Post-enforcement shape: %{"status" => ...} on the task result.
+      # Enforcement persists %{"status" => ...} on the task result.
       kept = %{name: "t", status: :passed, mandate_outcome: %{"status" => "kept"}}
       violated = %{name: "u", status: :failed, mandate_outcome: %{"status" => "violated"}}
       bare = %{name: "v", status: :passed}
@@ -229,6 +230,24 @@ defmodule Sykli.Gui.Provider.ArtifactTest do
       assert Artifact.mandate_summary([kept, violated, bare]) == "1 kept · 1 violated"
       assert Artifact.mandate_summary([bare]) == nil
       assert Artifact.mandate_summary([]) == nil
+    end
+
+    test "mandate outcomes round-trip from saved manifests into the state", %{tmp: tmp} do
+      save_run(tmp, "run-m1", ~U[2026-07-06 12:00:00Z], :failed, [
+        task("fix:flaky", :passed, mandate_outcome: %{"status" => "kept"}),
+        task("fix:docs", :failed,
+          mandate_outcome: %{"status" => "violated", "reason" => "scope_violation"}
+        ),
+        task("test", :passed)
+      ])
+
+      state = Artifact.state(repo_path: tmp)
+
+      outcomes = Map.new(state.graph.nodes, &{&1.id, &1.mandate_outcome})
+      assert outcomes == %{"fix:flaky" => "kept", "fix:docs" => "violated", "test" => nil}
+
+      assert [%State.Evidence{run_id: "run-m1", mandates: "1 kept · 1 violated"}] =
+               state.evidence
     end
   end
 

--- a/core/test/sykli/gui/provider/artifact_test.exs
+++ b/core/test/sykli/gui/provider/artifact_test.exs
@@ -168,6 +168,70 @@ defmodule Sykli.Gui.Provider.ArtifactTest do
     end
   end
 
+  describe "state/1 v5 actors and mandates" do
+    test "contract agent actors appear as declared members with their mandate", %{tmp: tmp} do
+      contract = %{
+        "version" => "5",
+        "tasks" => [
+          %{"name" => "test", "command" => "make test"},
+          %{
+            "name" => "fix:flaky",
+            "command" => "claude fix",
+            "actor" => %{"kind" => "agent", "id" => "codex"},
+            "mandate" => %{
+              "scope" => ["core/test/**"],
+              "budget" => %{"diff_lines" => 200, "wall_clock_ms" => 900_000},
+              "capabilities" => %{"network" => false}
+            }
+          },
+          %{
+            "name" => "fix:docs",
+            "command" => "claude docs",
+            "actor" => %{"kind" => "agent", "id" => "codex"},
+            "mandate" => %{"scope" => ["docs/**"]}
+          }
+        ]
+      }
+
+      lock = Sykli.ContractLock.build(contract, "sykli.exs")
+      {:ok, _bytes} = Sykli.ContractLock.write(lock, Path.join(tmp, "sykli.lock"))
+
+      state = Artifact.state(repo_path: tmp)
+
+      assert [%State.Member{identity_type: "human"}, agent] = state.members
+      assert agent.id == "codex"
+      assert agent.identity_type == "agent"
+      assert agent.status == "declared"
+      assert agent.role == "executor"
+      assert agent.current_work == "fix:flaky · fix:docs"
+      assert agent.mandate["scope"] == ["core/test/**"]
+      assert agent.mandate["capabilities"] == %{"network" => false}
+    end
+
+    test "mandate outcome mapping tolerates pre-enforcement manifests" do
+      # Manifests written before mandate enforcement (PR #276) carry no
+      # mandate_outcome — including every TaskResult main can produce today.
+      assert Artifact.mandate_outcome_label(%RunHistory.TaskResult{
+               name: "t",
+               status: :passed,
+               duration_ms: 1
+             }) == nil
+
+      # Post-enforcement shape: %{"status" => ...} on the task result.
+      kept = %{name: "t", status: :passed, mandate_outcome: %{"status" => "kept"}}
+      violated = %{name: "u", status: :failed, mandate_outcome: %{"status" => "violated"}}
+      bare = %{name: "v", status: :passed}
+
+      assert Artifact.mandate_outcome_label(kept) == "kept"
+      assert Artifact.mandate_outcome_label(violated) == "violated"
+      assert Artifact.mandate_outcome_label(%{mandate_outcome: %{"reason" => "x"}}) == nil
+
+      assert Artifact.mandate_summary([kept, violated, bare]) == "1 kept · 1 violated"
+      assert Artifact.mandate_summary([bare]) == nil
+      assert Artifact.mandate_summary([]) == nil
+    end
+  end
+
   describe "state/1 with work items and gates" do
     test "work items list with associated run counts", %{tmp: tmp} do
       {:ok, item} =

--- a/core/test/sykli/gui/state_test.exs
+++ b/core/test/sykli/gui/state_test.exs
@@ -26,7 +26,8 @@ defmodule Sykli.Gui.StateTest do
 
     codex = Enum.find(wire["members"], &(&1["id"] == "codex"))
     assert codex["mandate"]["budget"]["diffLines"] == 200
-    assert codex["mandate"]["network"] == false
+    # canonical v5 contract shape: capabilities.network
+    assert codex["mandate"]["capabilities"]["network"] == false
 
     run42 = Enum.find(wire["evidence"], &(&1["runId"] == "run-42"))
     assert run42["auditVerdict"] == "pass"


### PR DESCRIPTION
## Summary

- Workbench members now include v5 **agent/service actors declared in the contract**, grouped by actor id, with their declared **mandate** (scope / budget / capabilities) and the tasks they're declared on. They render as `status: declared` — contract declarations, not live presence.
- Graph nodes gain **`mandateOutcome`** and evidence rows gain a **mandate summary** (`"1 kept · 1 violated"`). Both are read shape-tolerantly from run manifests: nil for every manifest main can produce today, populated automatically once mandate enforcement (#276) persists `mandate_outcome` on task results — no GUI change needed when it merges.
- `auditVerdict` deliberately stays nil: the audit logic in #276 lives as private functions inside `Sykli.CLI.Audit`, and the GUI must not re-derive verdict semantics. Follow-up: extract the audit core into a shared service (`services/` pattern) that CLI, MCP, and GUI all call.

## Verification

- New tests: agent members from a v5 `sykli.lock` (exercisable today), and outcome-mapping tests using post-#276-shaped task results.
- Full suite 1855 passed, credo clean, escript builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)