### PR TITLE
refactor(audit): extract the audit core into Sykli.Services.Audit

### DIFF
--- a/core/lib/sykli/cli/audit.ex
+++ b/core/lib/sykli/cli/audit.ex
@@ -2,7 +2,7 @@ defmodule Sykli.CLI.Audit do
   @moduledoc false
 
   alias Sykli.CLI.JsonResponse
-  alias Sykli.RunHistory
+  alias Sykli.Services.Audit
 
   def run(args, opts \\ []) do
     {json?, rest} = parse_args(args)
@@ -29,9 +29,8 @@ defmodule Sykli.CLI.Audit do
   end
 
   defp run_audit(path, run_id, json?) do
-    case RunHistory.get(run_id, path: path) do
-      {:ok, run} ->
-        result = audit_run(path, run)
+    case Audit.audit(path, run_id) do
+      {:ok, result} ->
         emit_result(json?, result)
         if result.verdict == "pass", do: 0, else: 1
 
@@ -51,118 +50,6 @@ defmodule Sykli.CLI.Audit do
         1
     end
   end
-
-  defp audit_run(path, %RunHistory.Run{} = run) do
-    findings =
-      []
-      |> maybe_lock_finding(path, run)
-      |> success_criteria_findings(run)
-      |> evidence_findings(run)
-      |> mandate_findings(run)
-      |> Enum.reverse()
-
-    verdict = if Enum.any?(findings, &(&1["status"] == "fail")), do: "fail", else: "pass"
-
-    %{
-      run_id: run.id,
-      verdict: verdict,
-      findings: findings
-    }
-  end
-
-  defp maybe_lock_finding(findings, path, run) do
-    lock_path = Path.join(path, "sykli.lock")
-
-    if File.exists?(lock_path) do
-      case Sykli.ContractLock.read(lock_path) do
-        {:ok, %{"contract_hash" => hash}} ->
-          [lock_hash_finding(hash, run.contract_hash) | findings]
-
-        {:error, error} ->
-          [finding("lock_contract_hash", "fail", Exception.message(error)) | findings]
-      end
-    else
-      findings
-    end
-  end
-
-  # Runs not started via `sykli run --work <id>` never record a contract
-  # hash, so there is nothing to compare against the lock — that is not a
-  # mismatch, and must not fail the audit.
-  defp lock_hash_finding(_lock_hash, nil) do
-    finding(
-      "lock_contract_hash",
-      "skip",
-      "run has no recorded contract hash; lock comparison skipped"
-    )
-  end
-
-  defp lock_hash_finding(lock_hash, run_hash) when lock_hash == run_hash do
-    finding("lock_contract_hash", "pass", "lock hash matches run")
-  end
-
-  defp lock_hash_finding(lock_hash, run_hash) do
-    finding("lock_contract_hash", "fail", "lock hash does not match run", nil,
-      expected: lock_hash,
-      observed: run_hash
-    )
-  end
-
-  defp success_criteria_findings(findings, run) do
-    Enum.reduce(run.tasks, findings, fn task, acc ->
-      declared = get_in(task.contract_slice || %{}, ["success_criteria"]) || []
-
-      if declared != [] and task.success_criteria_results == [] do
-        [
-          finding("success_criteria_recorded", "fail", "success criteria result missing", task)
-          | acc
-        ]
-      else
-        acc
-      end
-    end)
-  end
-
-  defp evidence_findings(findings, run) do
-    Enum.reduce(run.tasks, findings, fn task, acc ->
-      declared = get_in(task.contract_slice || %{}, ["evidence_required"]) || []
-
-      if declared != [] and task.evidence_results == [] do
-        [finding("evidence_recorded", "fail", "evidence result missing", task) | acc]
-      else
-        acc
-      end
-    end)
-  end
-
-  defp mandate_findings(findings, run) do
-    Enum.reduce(run.tasks, findings, fn task, acc ->
-      actor = get_in(task.contract_slice || %{}, ["actor"]) || %{}
-      mandate = get_in(task.contract_slice || %{}, ["mandate"])
-
-      if actor["kind"] == "agent" and mandate != nil and task.mandate_outcome == nil do
-        [finding("mandate_outcome_recorded", "fail", "mandate outcome missing", task) | acc]
-      else
-        acc
-      end
-    end)
-  end
-
-  defp finding(check, status, message, task \\ nil, details \\ []) do
-    %{
-      "check" => check,
-      "status" => status,
-      "message" => message
-    }
-    |> maybe_put("task", task_name(task))
-    |> maybe_put("details", if(details == [], do: nil, else: Map.new(details)))
-  end
-
-  defp task_name(%RunHistory.TaskResult{name: name}), do: name
-  defp task_name(_), do: nil
-
-  defp maybe_put(map, _key, nil), do: map
-  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp emit_result(true, result), do: IO.puts(JsonResponse.ok(result))
 

--- a/core/lib/sykli/services/audit.ex
+++ b/core/lib/sykli/services/audit.ex
@@ -1,0 +1,153 @@
+defmodule Sykli.Services.Audit do
+  @moduledoc """
+  Read-time contract audit over recorded run manifests.
+
+  The audit is a judgment over evidence — a pure function of the run
+  manifest and the current `sykli.lock` — computed at read time, never
+  persisted. That is deliberate: the lock comparison is inherently a
+  read-time question (re-locking after a run *should* flip that run's
+  verdict to fail), and `.sykli/` stores evidence, not judgments.
+  Persisting verdicts would freeze the weaker claim "matched the lock at
+  the time" and invite dual-write drift.
+
+  Shared by every audit surface — CLI (`sykli audit`), MCP, and the
+  Workbench — so verdict semantics exist in exactly one place.
+  """
+
+  alias Sykli.RunHistory
+
+  @type result :: %{run_id: String.t(), verdict: String.t(), findings: [map()]}
+
+  @doc """
+  Audits a recorded run by id.
+
+  Loads the manifest through `RunHistory.get/2` and returns
+  `{:error, :not_found | :corrupt}` on load failure.
+  """
+  @spec audit(String.t(), String.t()) :: {:ok, result()} | {:error, :not_found | :corrupt}
+  def audit(path, run_id) do
+    with {:ok, run} <- RunHistory.get(run_id, path: path) do
+      {:ok, audit_run(path, run)}
+    end
+  end
+
+  @doc """
+  Audits an already-loaded run manifest against the project at `path`.
+
+  Verdict is `"fail"` when any finding fails, `"pass"` otherwise.
+  Findings are `%{"check", "status", "message"}` maps with optional
+  `"task"` and `"details"`.
+  """
+  @spec audit_run(String.t(), RunHistory.Run.t()) :: result()
+  def audit_run(path, %RunHistory.Run{} = run) do
+    findings =
+      []
+      |> maybe_lock_finding(path, run)
+      |> success_criteria_findings(run)
+      |> evidence_findings(run)
+      |> mandate_findings(run)
+      |> Enum.reverse()
+
+    verdict = if Enum.any?(findings, &(&1["status"] == "fail")), do: "fail", else: "pass"
+
+    %{
+      run_id: run.id,
+      verdict: verdict,
+      findings: findings
+    }
+  end
+
+  defp maybe_lock_finding(findings, path, run) do
+    lock_path = Path.join(path, "sykli.lock")
+
+    if File.exists?(lock_path) do
+      case Sykli.ContractLock.read(lock_path) do
+        {:ok, %{"contract_hash" => hash}} ->
+          [lock_hash_finding(hash, run.contract_hash) | findings]
+
+        {:error, error} ->
+          [finding("lock_contract_hash", "fail", Exception.message(error)) | findings]
+      end
+    else
+      findings
+    end
+  end
+
+  # Runs not started via `sykli run --work <id>` never record a contract
+  # hash, so there is nothing to compare against the lock — that is not a
+  # mismatch, and must not fail the audit.
+  defp lock_hash_finding(_lock_hash, nil) do
+    finding(
+      "lock_contract_hash",
+      "skip",
+      "run has no recorded contract hash; lock comparison skipped"
+    )
+  end
+
+  defp lock_hash_finding(lock_hash, run_hash) when lock_hash == run_hash do
+    finding("lock_contract_hash", "pass", "lock hash matches run")
+  end
+
+  defp lock_hash_finding(lock_hash, run_hash) do
+    finding("lock_contract_hash", "fail", "lock hash does not match run", nil,
+      expected: lock_hash,
+      observed: run_hash
+    )
+  end
+
+  defp success_criteria_findings(findings, run) do
+    Enum.reduce(run.tasks, findings, fn task, acc ->
+      declared = get_in(task.contract_slice || %{}, ["success_criteria"]) || []
+
+      if declared != [] and task.success_criteria_results == [] do
+        [
+          finding("success_criteria_recorded", "fail", "success criteria result missing", task)
+          | acc
+        ]
+      else
+        acc
+      end
+    end)
+  end
+
+  defp evidence_findings(findings, run) do
+    Enum.reduce(run.tasks, findings, fn task, acc ->
+      declared = get_in(task.contract_slice || %{}, ["evidence_required"]) || []
+
+      if declared != [] and task.evidence_results == [] do
+        [finding("evidence_recorded", "fail", "evidence result missing", task) | acc]
+      else
+        acc
+      end
+    end)
+  end
+
+  defp mandate_findings(findings, run) do
+    Enum.reduce(run.tasks, findings, fn task, acc ->
+      actor = get_in(task.contract_slice || %{}, ["actor"]) || %{}
+      mandate = get_in(task.contract_slice || %{}, ["mandate"])
+
+      if actor["kind"] == "agent" and mandate != nil and task.mandate_outcome == nil do
+        [finding("mandate_outcome_recorded", "fail", "mandate outcome missing", task) | acc]
+      else
+        acc
+      end
+    end)
+  end
+
+  defp finding(check, status, message, task \\ nil, details \\ []) do
+    %{
+      "check" => check,
+      "status" => status,
+      "message" => message
+    }
+    |> maybe_put("task", task_name(task))
+    |> maybe_put("details", if(details == [], do: nil, else: Map.new(details)))
+  end
+
+  defp task_name(%RunHistory.TaskResult{name: name}), do: name
+  defp task_name(_), do: nil
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/core/test/sykli/services/audit_test.exs
+++ b/core/test/sykli/services/audit_test.exs
@@ -1,0 +1,81 @@
+defmodule Sykli.Services.AuditTest do
+  use ExUnit.Case, async: true
+
+  alias Sykli.RunHistory
+  alias Sykli.Services.Audit
+
+  setup do
+    tmp =
+      Path.join(
+        System.tmp_dir!(),
+        "sykli-audit-service-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp)
+    on_exit(fn -> File.rm_rf!(tmp) end)
+    {:ok, tmp: tmp}
+  end
+
+  defp save_run(tmp, id, contract_hash) do
+    :ok =
+      RunHistory.save(
+        %RunHistory.Run{
+          id: id,
+          timestamp: ~U[2026-07-06 10:00:00Z],
+          git_ref: "abc123",
+          git_branch: "main",
+          overall: :passed,
+          contract_hash: contract_hash,
+          tasks: [
+            %RunHistory.TaskResult{name: "test", status: :passed, duration_ms: 10}
+          ]
+        },
+        path: tmp
+      )
+  end
+
+  defp write_lock(tmp, contract) do
+    lock = Sykli.ContractLock.build(contract, "sykli.exs")
+    {:ok, _bytes} = Sykli.ContractLock.write(lock, Path.join(tmp, "sykli.lock"))
+    lock["contract_hash"]
+  end
+
+  test "audit/2 loads the manifest by id", %{tmp: tmp} do
+    save_run(tmp, "run-1", nil)
+
+    assert {:ok, %{run_id: "run-1", verdict: "pass"}} = Audit.audit(tmp, "run-1")
+    assert {:error, :not_found} = Audit.audit(tmp, "run-missing")
+  end
+
+  test "verdict is a read-time judgment against the current lock", %{tmp: tmp} do
+    contract_a = %{"version" => "1", "tasks" => [%{"name" => "test", "command" => "make test"}]}
+    contract_b = %{"version" => "1", "tasks" => [%{"name" => "test", "command" => "make cheat"}]}
+
+    hash_a = write_lock(tmp, contract_a)
+    save_run(tmp, "run-1", hash_a)
+
+    # The run matches the lock it was recorded under.
+    assert {:ok, %{verdict: "pass", findings: findings}} = Audit.audit(tmp, "run-1")
+    assert %{"check" => "lock_contract_hash", "status" => "pass"} = hd(findings)
+
+    # Re-locking a different contract flips this run's verdict at read
+    # time — the audit is a judgment over evidence, never a frozen fact.
+    write_lock(tmp, contract_b)
+
+    assert {:ok, %{verdict: "fail", findings: findings}} = Audit.audit(tmp, "run-1")
+
+    assert %{
+             "check" => "lock_contract_hash",
+             "status" => "fail",
+             "details" => %{observed: ^hash_a}
+           } = hd(findings)
+  end
+
+  test "runs without a recorded contract hash skip the lock check", %{tmp: tmp} do
+    write_lock(tmp, %{"version" => "1", "tasks" => [%{"name" => "t", "command" => "x"}]})
+    save_run(tmp, "run-1", nil)
+
+    assert {:ok, %{verdict: "pass", findings: findings}} = Audit.audit(tmp, "run-1")
+    assert %{"check" => "lock_contract_hash", "status" => "skip"} = hd(findings)
+  end
+end


### PR DESCRIPTION
Stacked on #276.

## Summary

- Move the `sykli audit` verdict logic from private functions in `Sykli.CLI.Audit` into a stateless `Sykli.Services.Audit` (the `services/` convention): `audit(path, run_id)` and `audit_run(path, run)`. The CLI keeps arg parsing, exit codes, and rendering; behavior and output are unchanged (all existing CLI audit tests pass untouched).
- This makes the verdict callable from MCP and the Workbench, so audit semantics exist in exactly one place. The GUI's `auditVerdict` (see #280) becomes a one-line call once this lands on main.

## Design note (pinned in the moduledoc and a test)

The audit is a **read-time judgment over evidence** — a pure function of the run manifest and the *current* `sykli.lock` — never a persisted fact. Re-locking a different contract after a run must flip that run's verdict to fail; persisting verdicts at run time would freeze the weaker claim "matched the lock at the time" and invite dual-write drift. A service test asserts the verdict flip.

## Verification

- Full suite on this branch: 1877 passed, credo clean, escript builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)