### PR TITLE
feat(gui): compute evidence audit verdicts through Sykli.Services.Audit

### DIFF
--- a/core/lib/sykli/gui/provider/artifact.ex
+++ b/core/lib/sykli/gui/provider/artifact.ex
@@ -24,9 +24,9 @@ defmodule Sykli.Gui.Provider.Artifact do
   later Team Mode phase.
 
   v5 result fields: task `mandate_outcome` and per-run mandate summaries
-  are read shape-tolerantly from run manifests — they populate once
-  mandate enforcement (PR #276) starts persisting them; `audit_verdict`
-  stays nil until the audit core is a shared service the GUI can call.
+  are read shape-tolerantly from run manifests; `audit_verdict` is
+  computed per evidence row through `Sykli.Services.Audit` — a read-time
+  judgment against the current lock, never persisted.
   """
 
   @behaviour Sykli.Gui.Provider
@@ -60,7 +60,7 @@ defmodule Sykli.Gui.Provider.Artifact do
       members: members(path) ++ actor_members(contract),
       work_items: Enum.map(items, &work_item_row(&1, runs)),
       gates: Enum.map(gates, &gate_row/1),
-      evidence: runs |> Enum.take(@recent_runs) |> Enum.map(&evidence_row/1),
+      evidence: runs |> Enum.take(@recent_runs) |> Enum.map(&evidence_row(&1, path)),
       activity: derive_activity(runs, gates, items),
       agent_calls: []
     }
@@ -414,7 +414,7 @@ defmodule Sykli.Gui.Provider.Artifact do
     }
   end
 
-  defp evidence_row(run) do
+  defp evidence_row(run, path) do
     %Evidence{
       run_id: run.id,
       status: to_string(run.overall),
@@ -422,9 +422,9 @@ defmodule Sykli.Gui.Provider.Artifact do
       failed: Enum.count(run.tasks, &(&1.status == :failed)),
       skipped: Enum.count(run.tasks, &(&1.status == :skipped)),
       complete: run_evidence_status(run) == "complete",
-      # audit_verdict stays nil until the audit core (`sykli audit`,
-      # PR #276) is extractable as a shared service — the GUI must not
-      # re-derive verdict logic.
+      # Read-time judgment against the current lock (see
+      # Sykli.Services.Audit) — the same verdict `sykli audit` prints.
+      audit_verdict: Sykli.Services.Audit.audit_run(path, run).verdict,
       mandates: mandate_summary(run.tasks)
     }
   end

--- a/core/test/sykli/gui/provider/artifact_test.exs
+++ b/core/test/sykli/gui/provider/artifact_test.exs
@@ -249,6 +249,38 @@ defmodule Sykli.Gui.Provider.ArtifactTest do
       assert [%State.Evidence{run_id: "run-m1", mandates: "1 kept · 1 violated"}] =
                state.evidence
     end
+
+    test "evidence rows carry the read-time audit verdict", %{tmp: tmp} do
+      contract = %{"version" => "1", "tasks" => [%{"name" => "test", "command" => "make test"}]}
+      lock = Sykli.ContractLock.build(contract, "sykli.exs")
+      {:ok, _bytes} = Sykli.ContractLock.write(lock, Path.join(tmp, "sykli.lock"))
+
+      :ok =
+        RunHistory.save(
+          %RunHistory.Run{
+            id: "run-a1",
+            timestamp: ~U[2026-07-06 13:00:00Z],
+            git_ref: "abc",
+            git_branch: "main",
+            overall: :passed,
+            contract_hash: lock["contract_hash"],
+            tasks: [task("test", :passed)]
+          },
+          path: tmp
+        )
+
+      assert [%State.Evidence{run_id: "run-a1", audit_verdict: "pass"}] =
+               Artifact.state(repo_path: tmp).evidence
+
+      # Re-locking a different contract flips the verdict at read time —
+      # the GUI shows the same judgment `sykli audit` prints today.
+      changed = %{"version" => "1", "tasks" => [%{"name" => "test", "command" => "make cheat"}]}
+      new_lock = Sykli.ContractLock.build(changed, "sykli.exs")
+      {:ok, _bytes} = Sykli.ContractLock.write(new_lock, Path.join(tmp, "sykli.lock"))
+
+      assert [%State.Evidence{run_id: "run-a1", audit_verdict: "fail"}] =
+               Artifact.state(repo_path: tmp).evidence
+    end
   end
 
   describe "state/1 with work items and gates" do


### PR DESCRIPTION
Closes the loop from #280/#281: evidence rows now carry `auditVerdict`, computed per state read via `Sykli.Services.Audit.audit_run/2` — the identical judgment `sykli audit` prints, evaluated against the *current* lock. A test pins the read-time property end to end through the GUI state: re-locking a different contract flips a recorded run's verdict from pass to fail.

Verified on the live binary: `GET /api/state` returns `auditVerdict` on all evidence rows for this repo.

Full suite 1904 passed, credo clean, escript builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)