### PR TITLE
docs(readme): tell the shipped v5 + Workbench story in the present tense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ docs/*
 !docs/team-mode-roadmap.md
 !docs/team-mode-security.md
 !docs/vartio-integration.md
+!docs/workbench.md
 
 # Sykli runtime data (AI context, run history, logs)
 .codex/

--- a/README.md
+++ b/README.md
@@ -276,7 +276,15 @@ Violations are typed like everything else: work outside `scope` or beyond
 a mandate the target cannot enforce fails explicitly with
 `unsupported_target` rather than pretending. An agent's own claim of success
 is never the record — the engine classifies the outcome against the declared
-contract.
+contract, and every mandated task records a `mandate_outcome`
+(`kept` / `violated` / `unverified` / `unsupported`) in run history.
+
+After the fact, `sykli audit <run-id>` judges any recorded run: does its
+contract hash match the current `sykli.lock`, were declared success
+criteria and evidence actually recorded, does every agent task have a
+mandate outcome? The verdict is computed at read time — re-pinning a
+different contract flips old runs to fail, because an audit is a judgment
+over evidence, not a frozen fact.
 
 This is deliberately *not* a behavioral policy engine: a mandate is a
 per-run, deterministic contract field. Cross-run behavioral judgment about
@@ -305,6 +313,25 @@ the terminal.
 
 The detailed on-disk schema is documented in
 [`docs/false-protocol-schema.md`](docs/false-protocol-schema.md).
+
+## The Workbench: One Screen For One Repo
+
+```bash
+sykli gui
+```
+
+A local-first control room served on `127.0.0.1` — no auth, no cloud, no
+analytics, embedded in the binary. One screen answers: what was declared
+(the contract), what ran (the graph), who moved the work forward (humans,
+agents, daemons), what failed and why (typed failure classes), what
+evidence exists, and who may unblock the next step (gates).
+
+It is a *view over the evidence*, not a second system: the contract comes
+from `sykli.lock`, runs from `.sykli/runs/`, and approving a gate in the
+browser writes the same artifact `sykli gate approve` does. The Workbench
+never executes repo code, and evidence rows show the same read-time audit
+verdict `sykli audit` prints. Details in
+[`docs/workbench.md`](docs/workbench.md).
 
 ## Product Pillars
 
@@ -509,7 +536,10 @@ curl -fsSL https://raw.githubusercontent.com/false-systems/sykli/main/install.sh
 ```
 
 Or [download a binary](https://github.com/false-systems/sykli/releases/latest) for
-macOS or Linux.
+macOS or Linux. Release candidates (e.g. `v0.9.0-rc.1`) are published as
+GitHub prereleases — they appear on the
+[releases page](https://github.com/false-systems/sykli/releases) but never
+as `latest`, and are not pushed to package registries.
 
 <details>
 <summary>Build from source</summary>
@@ -597,6 +627,8 @@ sykli delta               # run tasks affected by git changes
 sykli watch               # re-run on file changes
 sykli explain             # show last run as an AI-readable report
 sykli fix                 # failure analysis with source context
+sykli audit <run-id>      # judge a recorded run against the current lock
+sykli gui                 # local Workbench (127.0.0.1); --demo for fake data
 sykli context             # write .sykli/context.json
 sykli query               # query pipeline, history, and health data
 sykli graph               # Mermaid or DOT graph
@@ -648,18 +680,20 @@ Selection priority and runtime extension notes are in
 | Core engine, all 5 SDKs, local execution, Docker/Podman/Shell/Fake runtimes, FALSE Protocol output, canonical schema, opt-in GitHub-native receiver | **Stable** |
 | Contract lock (`sykli lock`, drift refusal, nondeterminism rejection), contract surface (`sykli contract`, `--diff` weakening classifier) | **Beta** |
 | Mesh distribution, Kubernetes target, gates, SLSA attestations, remote cache via S3, review-node graph support, `task_type` / `success_criteria` v3 fields, `evidence_required` v4 fields, `actor` / `mandate` v5 fields | **Beta** |
+| Mandate enforcement in the executor (scope, budget, capabilities; recorded `mandate_outcome`), `sykli audit` run verification, Sykli Workbench (`sykli gui`) | **Beta** |
 | Team Mode: self-hosted coordinator, daemon join/heartbeat/leave, work-item sync, metadata-only run summaries, remote gate approvals (round-trip CI-proven) | **Beta** |
-| Mandate enforcement in the executor (scope, budget, capabilities), `sykli audit` run verification, review primitive adapters, multi-agent execution, LLM/provider review runners | **In development** |
+| Review primitive adapters, multi-agent execution, LLM/provider review runners | **In development** |
 
 The status table is part of the contract: beta and in-development features are
 usable surfaces, not production-readiness claims.
 
 ## Roadmap
 
-- **0.9.0-rc.1 — the mandate release.** Executor enforcement for `mandate`
-  scope, budget, and capabilities; `sykli audit <run-id>` to verify a
-  recorded run against its contract, evidence, and mandate outcomes;
-  registry packages for all five SDKs.
+- **0.9.0 stable — the mandate release.** The rc is cut
+  (`v0.9.0-rc.1`, GitHub-only prerelease): executor enforcement for
+  `mandate` scope, budget, and capabilities; `sykli audit <run-id>`;
+  the Sykli Workbench. Stabilization plus registry packages for all five
+  SDKs land with the stable tag.
 - **Agent Contract Release.** Tighten MCP response envelopes, coded tool
   errors, stable agent-readable failure output, `.sykli/` evidence docs, and a
   focused Codex/Claude repair demo.

--- a/docs/workbench.md
+++ b/docs/workbench.md
@@ -1,0 +1,81 @@
+# Sykli Workbench (`sykli gui`)
+
+A local-first execution control room for one repo. One screen answers: what
+was declared (the contract), what ran (the graph), who or what moved the
+work forward (humans, agents, daemons, CI), what failed and why, what
+evidence exists, and who is allowed to unblock the next step (gates).
+
+```
+sykli gui [--port N] [--no-open] [--demo] [--json]   # shipped binary
+mix sykli.gui                                         # development convenience
+```
+
+Binds `127.0.0.1` only. No auth, no cloud, no billing, no org admin, no
+analytics. This is not the commercial fleet-dashboard surface reserved in
+`docs/strategy-2026.md` — it is the free, single-repo, single-user tool.
+
+## Architecture
+
+Bandit + Plug (`Sykli.Gui.Router`), the same stack as the webhook receiver
+and coordinator — deliberately not Phoenix. The SPA (hand-written HTML/CSS/
+JS in `core/priv/gui/`) is **embedded at compile time** via
+`Sykli.Gui.Assets`, because `priv/` paths are not readable from inside an
+escript archive; the same bytes serve from `mix`, the escript, and Burrito
+releases. `@external_resource` keeps embedded copies in sync — editing an
+SPA file recompiles the module.
+
+### The provider seam
+
+All data flows through one behaviour, so demo and real providers are
+interchangeable and the web layer never scrapes CLI text:
+
+```elixir
+Sykli.Gui.Provider          # behaviour: state/1, run/1, approve_gate/2, reject_gate/3
+Sykli.Gui.Provider.Artifact # real local data (default for `sykli gui`)
+Sykli.Gui.Provider.Demo     # hardcoded realistic state (`sykli gui --demo`)
+```
+
+`sykli gui` selects the artifact provider unless `--demo` is passed; tests
+and embedders can override with `config :sykli, :gui_provider, <module>`.
+
+The artifact provider reads **artifacts only** — it never executes repo
+code. Sources: repo identity from git; the contract from `sykli.lock`
+(preferred; carries schema version, gate and review counts) or
+`.sykli/context.json` (structure only); runs and evidence from
+`.sykli/runs/` manifests; work items from `Sykli.Work.Store`; gates from
+`Sykli.Gate.Store`. Gate approve/reject **write through** `Gate.Store`
+with a `member:`-qualified `decided_by`, so a Workbench decision is the
+same artifact `sykli gate approve` produces. A repo that has never run
+`sykli lock` or `sykli context` shows no contract until one of those
+runs — `GET /api/state` must not trigger an SDK emit. Team-mode members
+and agent tool-call history stay empty until their local artifacts exist
+(the member list is the local git identity for now).
+
+### API
+
+`GET /api/state` returns the full state document (camelCase) inside the
+shared JSON envelope (`Sykli.CLI.JsonResponse` — same shape agents parse
+everywhere else). `POST /api/gates/:id/approve` / `.../reject` take
+`{"actor": ...}` (+ `"reason"`). `GET /api/runs/:id` returns one run.
+
+### v5 fields
+
+The state model carries the actor/mandate/audit story end to end: graph
+nodes have `mandateOutcome` (`kept` / `violated` / `unverified` /
+`unsupported`), agent/daemon members carry their declared `mandate`
+(scope, budgets, network — canonical shape `capabilities.network`) beside
+the ALLOWED / NOT ALLOWED permission chips, and evidence entries carry
+`auditVerdict` and a mandate summary. The artifact provider populates all
+of these from real sources: mandate outcomes from run manifests (persisted
+by mandate enforcement), declared actors/mandates from the contract, and
+`auditVerdict` computed per state read through `Sykli.Services.Audit` —
+the same read-time judgment `sykli audit` prints, never persisted.
+
+## Design
+
+Nordic Bauhaus control room, per the design handoff: strict grid, calm,
+static; color is state only (green/red/amber/cyan/grey), geometry is
+identity (task=square, gate=diamond, human=open circle, agent=filled
+circle, daemon=filled rect, CI=outlined rect); no border-radius, no
+shadows, no chat UI. Team members are execution participants, not SaaS
+users — an agent must never look like it can approve a human gate.


### PR DESCRIPTION
## Summary

- **Status table**: mandate enforcement (with recorded `mandate_outcome`), `sykli audit`, and the Workbench move from *In development* to *Beta*; the in-development row keeps what's genuinely unshipped (review primitive adapters, multi-agent execution, LLM review runners).
- **Roadmap**: `0.9.0-rc.1` is no longer future tense — the stable `0.9.0` bullet carries stabilization + registry packages (deferred from the rc by design).
- **CLI list** gains `sykli audit <run-id>` and `sykli gui`.
- **Mandates section** now documents the recorded `mandate_outcome` and the read-time `sykli audit` judgment (re-locking flips old runs — judgment over evidence, not frozen fact).
- **New Workbench section** — one screen for one repo, a view over the evidence, never executes repo code.
- **Install** notes that rc's are GitHub prereleases: on the releases page, never `latest`, never in registries.
- `docs/workbench.md` is now **tracked** (gitignore allowlist) so the README and CLAUDE.md links resolve; its v5 paragraph updated to shipped reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)