### PR TITLE
docs(release): tell SDK consumers how to depend on the rc tag

### DIFF
--- a/docs/releases/v0.9.0-rc.1.md
+++ b/docs/releases/v0.9.0-rc.1.md
@@ -61,6 +61,42 @@ work items, gates, evidence, activity — one screen. Bandit + Plug bound to
 - **Run lookup by id.** `Sykli.RunHistory.get/2` finds a run without
   loading every manifest; corrupt manifests cannot hide valid runs.
 
+## Using the SDKs with this rc
+
+This is a GitHub-only prerelease: **no SDK package was pushed to any
+registry** (crates.io, PyPI, Hex, npm, Go module tag). Registry versions
+resolve again at the stable `0.9.0` tag. Until then, depend on the tag
+directly:
+
+**Rust** (verified against this tag):
+
+```toml
+[dependencies]
+sykli = { git = "https://github.com/false-systems/sykli", tag = "v0.9.0-rc.1" }
+```
+
+**Python**:
+
+```bash
+pip install "git+https://github.com/false-systems/sykli@v0.9.0-rc.1#subdirectory=sdk/python"
+```
+
+**Elixir**:
+
+```elixir
+{:sykli, git: "https://github.com/false-systems/sykli.git", tag: "v0.9.0-rc.1", sparse: "sdk/elixir"}
+```
+
+**Go** (the module-aware `sdk/go/v…` tag ships with stable releases only;
+pin the release commit):
+
+```bash
+go get github.com/false-systems/sykli/sdk/go@5e0130e
+```
+
+**TypeScript**: npm cannot install a subdirectory of a git repo — clone the
+tag and use a local `file:` dependency on `sdk/typescript` for now.
+
 ## Compatibility
 
 - Pipelines emitting versions `"1"`–`"4"` are unchanged. `"5"` is emitted


### PR DESCRIPTION
The v0.9.0-rc.1 GitHub release body is already updated (`gh release edit`); this PR keeps the tracked notes file in sync.

Context: the rc deliberately skips all registry publishes, but the notes never said how to consume the SDKs during the rc window — which already produced one false bug report downstream ("sykli 0.9.0-rc.1 is not on crates.io"). Adds per-SDK instructions: Rust git-tag dependency (verified: resolves `sykli 0.9.0-rc.1` from the tag), pip `git+…#subdirectory`, mix `sparse:`, Go commit pin (module tag is stable-only), and the honest npm limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)