### PR TITLE
fix(action): run sykli in the caller's workspace, not the build dir

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,5 +44,8 @@ runs:
         mix deps.get
         mix escript.build
 
-        # Run sykli on the project
+        # Run sykli on the project. The build left cwd in /tmp/sykli/core, so
+        # return to the caller's checkout first — inputs.path is relative to
+        # the workspace, not to sykli's own build directory.
+        cd "${GITHUB_WORKSPACE}"
         /tmp/sykli/core/sykli ${{ inputs.path }}


### PR DESCRIPTION
The composite action clones and builds sykli under `/tmp/sykli/core` and never leaves that directory, so the final `sykli ${{ inputs.path }}` resolves `path` against sykli's own build tree. Every consumer using the default `path: .` gets:

```
error[sdk_not_found]: no sykli configuration file found
  note: searched in: /tmp/sykli/core
```

Observed live on false-systems/toimija#148, whose Sykli check runs this action from `@main` (its workflow comment already notes the rc tag has the same defect).

Fix: `cd "${GITHUB_WORKSPACE}"` before invoking, so `inputs.path` resolves against the caller's checkout as the input's description promises.

Once merged, re-running toimija#148's Sykli job should pick this up directly (it pins `@main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)