### PR TITLE
ci: move to org self-hosted runners (arch-aware)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   changes:
     name: Detect changes
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     outputs:
       core: ${{ steps.filter.outputs.core }}
       blackbox: ${{ steps.filter.outputs.blackbox }}
@@ -95,7 +95,7 @@ jobs:
 
   core:
     name: Core Tests
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.core == 'true'
     steps:
@@ -126,7 +126,7 @@ jobs:
 
   blackbox:
     name: Black-box Tests
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.blackbox == 'true'
     steps:
@@ -174,7 +174,7 @@ jobs:
 
   conformance:
     name: SDK Conformance
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.conformance == 'true'
     steps:
@@ -220,7 +220,7 @@ jobs:
 
   oracle:
     name: Oracle Eval
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     needs: changes
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
@@ -245,7 +245,7 @@ jobs:
 
   sdk-go:
     name: Go SDK Tests
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.sdk_go == 'true'
     steps:
@@ -266,7 +266,7 @@ jobs:
 
   sdk-rust:
     name: Rust SDK Tests
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.sdk_rust == 'true'
     steps:
@@ -285,7 +285,7 @@ jobs:
 
   sdk-elixir:
     name: Elixir SDK Tests
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.sdk_elixir == 'true'
     steps:
@@ -317,7 +317,7 @@ jobs:
 
   sdk-typescript:
     name: TypeScript SDK Tests
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.sdk_typescript == 'true'
     steps:
@@ -342,7 +342,7 @@ jobs:
 
   sdk-python:
     name: Python SDK Tests
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.sdk_python == 'true'
     steps:
@@ -363,7 +363,7 @@ jobs:
 
   integration:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     needs: changes
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         include:
           - target: linux-x86_64
-            os: ubuntu-latest
+            os: arc-amd64
             burrito_target: linux_x86_64
           - target: linux-aarch64
-            os: ubuntu-latest
+            os: arc-amd64
             burrito_target: linux_aarch64
           - target: macos-x86_64
             os: macos-15-intel
@@ -83,7 +83,7 @@ jobs:
   release:
     name: Create Release
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -130,7 +130,7 @@ jobs:
     name: Publish Go SDK (module tag)
     needs: release
     if: ${{ !contains(github.ref_name, '-') }}
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     permissions:
       contents: write
     steps:
@@ -151,7 +151,7 @@ jobs:
     name: Publish Python SDK (PyPI trusted publishing)
     needs: release
     if: ${{ !contains(github.ref_name, '-') }}
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     environment: pypi
     permissions:
       id-token: write
@@ -177,7 +177,7 @@ jobs:
     name: Publish Rust SDK (crates.io trusted publishing)
     needs: release
     if: ${{ !contains(github.ref_name, '-') }}
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     permissions:
       id-token: write
     steps:
@@ -205,7 +205,7 @@ jobs:
   # publish-npm:
   #   name: Publish TypeScript SDK (npm trusted publishing)
   #   needs: release
-  #   runs-on: ubuntu-latest
+  #   runs-on: arc-arm64
   #   permissions:
   #     id-token: write
   #   steps:

--- a/.github/workflows/seed-soak.yml
+++ b/.github/workflows/seed-soak.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   seed-soak:
     name: Seed Soak
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/sykli-ci.yml
+++ b/.github/workflows/sykli-ci.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   sykli:
     name: Run with Sykli
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Org-wide move off GitHub-hosted runners (context: false-systems/false-infra#5).

- ci.yml / seed-soak.yml / sykli-ci.yml: `ubuntu-latest` → `arc-arm64`.
- release.yml: the two **linux matrix legs → `arc-amd64`** — they cross-compile with an x86_64 Zig toolchain, so the host must stay x86_64 (the new cx33 pool). Plain jobs (release-create, Go SDK tag, PyPI publish) → `arc-arm64`. **macOS legs untouched** — no self-hosted Mac hardware, and hosted macOS is free on public repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)